### PR TITLE
refactor(dispatch): replace direct OrderService calls with EventEmitt…

### DIFF
--- a/backend/src/dispatch/dispatch-orders.e2e.spec.ts
+++ b/backend/src/dispatch/dispatch-orders.e2e.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { DispatchService } from './dispatch.service';
+import { OrdersService } from '../orders/orders.service';
+
+describe('Dispatch-Orders Event Integration (E2E)', () => {
+  let dispatchService: DispatchService;
+  let ordersService: OrdersService;
+  let eventEmitter: EventEmitter2;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot()],
+      providers: [DispatchService, OrdersService],
+    }).compile();
+
+    dispatchService = module.get<DispatchService>(DispatchService);
+    ordersService = module.get<OrdersService>(OrdersService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create dispatch when order is created', async () => {
+    const dispatchSpy = jest.spyOn(dispatchService, 'handleOrderConfirmed');
+
+    const createOrderDto = {
+      hospitalId: 'hospital-123',
+      bloodType: 'O-',
+      quantity: 3,
+      deliveryAddress: '456 Hospital Ave',
+    };
+
+    await ordersService.create(createOrderDto);
+
+    // Wait for event propagation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(dispatchSpy).toHaveBeenCalled();
+    const callArgs = dispatchSpy.mock.calls[0][0];
+    expect(callArgs.hospitalId).toBe('hospital-123');
+    expect(callArgs.bloodType).toBe('O-');
+    expect(callArgs.quantity).toBe(3);
+  });
+
+  it('should cancel dispatch when order is cancelled', async () => {
+    const dispatchSpy = jest.spyOn(dispatchService, 'handleOrderCancelled');
+
+    await ordersService.remove('order-123');
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(dispatchSpy).toHaveBeenCalled();
+    const callArgs = dispatchSpy.mock.calls[0][0];
+    expect(callArgs.orderId).toBe('order-123');
+  });
+
+  it('should update dispatch when order status changes', async () => {
+    const dispatchSpy = jest.spyOn(dispatchService, 'handleOrderStatusUpdated');
+
+    await ordersService.updateStatus('order-123', 'in-transit');
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(dispatchSpy).toHaveBeenCalled();
+    const callArgs = dispatchSpy.mock.calls[0][0];
+    expect(callArgs.orderId).toBe('order-123');
+    expect(callArgs.newStatus).toBe('in-transit');
+  });
+
+  it('should assign rider to dispatch when rider is assigned to order', async () => {
+    const dispatchSpy = jest.spyOn(dispatchService, 'handleOrderRiderAssigned');
+
+    await ordersService.assignRider('order-123', 'rider-456');
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(dispatchSpy).toHaveBeenCalled();
+    const callArgs = dispatchSpy.mock.calls[0][0];
+    expect(callArgs.orderId).toBe('order-123');
+    expect(callArgs.riderId).toBe('rider-456');
+  });
+
+  it('should handle complete order lifecycle', async () => {
+    const confirmedSpy = jest.spyOn(dispatchService, 'handleOrderConfirmed');
+    const statusSpy = jest.spyOn(dispatchService, 'handleOrderStatusUpdated');
+    const riderSpy = jest.spyOn(dispatchService, 'handleOrderRiderAssigned');
+
+    // Create order
+    const result = await ordersService.create({
+      hospitalId: 'hospital-789',
+      bloodType: 'AB+',
+      quantity: 1,
+      deliveryAddress: '789 Medical Center',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const orderId = result.data.id;
+
+    // Assign rider
+    await ordersService.assignRider(orderId, 'rider-999');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Update status
+    await ordersService.updateStatus(orderId, 'delivered');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(confirmedSpy).toHaveBeenCalledTimes(1);
+    expect(riderSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should verify DispatchModule has no imports from OrdersModule', () => {
+    // Verify that DispatchService constructor doesn't inject OrdersService
+    const constructorParams = Reflect.getMetadata(
+      'design:paramtypes',
+      DispatchService,
+    ) || [];
+
+    const hasOrdersServiceDependency = constructorParams.some(
+      (param: any) => param?.name === 'OrdersService',
+    );
+
+    expect(hasOrdersServiceDependency).toBe(false);
+  });
+});

--- a/backend/src/dispatch/dispatch.integration.spec.ts
+++ b/backend/src/dispatch/dispatch.integration.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { DispatchService } from './dispatch.service';
+import {
+  OrderConfirmedEvent,
+  OrderCancelledEvent,
+  OrderStatusUpdatedEvent,
+  OrderRiderAssignedEvent,
+} from '../events';
+
+describe('DispatchService Integration Tests', () => {
+  let dispatchService: DispatchService;
+  let eventEmitter: EventEmitter2;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot()],
+      providers: [DispatchService],
+    }).compile();
+
+    dispatchService = module.get<DispatchService>(DispatchService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Event-Driven Dispatch Creation', () => {
+    it('should create dispatch when order.confirmed event is emitted', async () => {
+      const event = new OrderConfirmedEvent(
+        'order-123',
+        'hospital-456',
+        'A+',
+        2,
+        '123 Main St',
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderConfirmed');
+
+      eventEmitter.emit('order.confirmed', event);
+
+      // Wait for async event handler
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledWith(event);
+      expect(handleSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle order.cancelled event', async () => {
+      const event = new OrderCancelledEvent(
+        'order-123',
+        'hospital-456',
+        'Patient recovered',
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderCancelled');
+
+      eventEmitter.emit('order.cancelled', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledWith(event);
+      expect(handleSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle order.status.updated event', async () => {
+      const event = new OrderStatusUpdatedEvent(
+        'order-123',
+        'pending',
+        'confirmed',
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderStatusUpdated');
+
+      eventEmitter.emit('order.status.updated', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledWith(event);
+      expect(handleSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle order.rider.assigned event', async () => {
+      const event = new OrderRiderAssignedEvent('order-123', 'rider-789');
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderRiderAssigned');
+
+      eventEmitter.emit('order.rider.assigned', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledWith(event);
+      expect(handleSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Idempotency', () => {
+    it('should not process duplicate order.confirmed events', async () => {
+      const timestamp = new Date();
+      const event = new OrderConfirmedEvent(
+        'order-123',
+        'hospital-456',
+        'A+',
+        2,
+        '123 Main St',
+        timestamp,
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderConfirmed');
+
+      // Emit the same event twice
+      eventEmitter.emit('order.confirmed', event);
+      eventEmitter.emit('order.confirmed', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Handler should be called twice but only process once
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not process duplicate order.cancelled events', async () => {
+      const timestamp = new Date();
+      const event = new OrderCancelledEvent(
+        'order-123',
+        'hospital-456',
+        'Patient recovered',
+        timestamp,
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderCancelled');
+
+      eventEmitter.emit('order.cancelled', event);
+      eventEmitter.emit('order.cancelled', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not process duplicate order.status.updated events', async () => {
+      const timestamp = new Date();
+      const event = new OrderStatusUpdatedEvent(
+        'order-123',
+        'pending',
+        'confirmed',
+        timestamp,
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderStatusUpdated');
+
+      eventEmitter.emit('order.status.updated', event);
+      eventEmitter.emit('order.status.updated', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not process duplicate order.rider.assigned events', async () => {
+      const timestamp = new Date();
+      const event = new OrderRiderAssignedEvent('order-123', 'rider-789', timestamp);
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderRiderAssigned');
+
+      eventEmitter.emit('order.rider.assigned', event);
+      eventEmitter.emit('order.rider.assigned', event);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should process events with different timestamps', async () => {
+      const event1 = new OrderConfirmedEvent(
+        'order-123',
+        'hospital-456',
+        'A+',
+        2,
+        '123 Main St',
+        new Date('2024-01-01'),
+      );
+
+      const event2 = new OrderConfirmedEvent(
+        'order-123',
+        'hospital-456',
+        'A+',
+        2,
+        '123 Main St',
+        new Date('2024-01-02'),
+      );
+
+      const handleSpy = jest.spyOn(dispatchService, 'handleOrderConfirmed');
+
+      eventEmitter.emit('order.confirmed', event1);
+      eventEmitter.emit('order.confirmed', event2);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Both should be processed as they have different timestamps
+      expect(handleSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Module Independence', () => {
+    it('should not have direct dependency on OrdersModule', () => {
+      // This test verifies that DispatchService doesn't import OrdersService
+      const dispatchServiceString = dispatchService.constructor.toString();
+      expect(dispatchServiceString).not.toContain('OrdersService');
+    });
+  });
+});

--- a/backend/src/dispatch/dispatch.module.ts
+++ b/backend/src/dispatch/dispatch.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { DispatchService } from './dispatch.service';
 import { DispatchController } from './dispatch.controller';
 
 @Module({
+  imports: [EventEmitterModule.forRoot()],
   controllers: [DispatchController],
   providers: [DispatchService],
   exports: [DispatchService],

--- a/backend/src/dispatch/dispatch.service.ts
+++ b/backend/src/dispatch/dispatch.service.ts
@@ -1,8 +1,147 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+  OrderConfirmedEvent,
+  OrderCancelledEvent,
+  OrderStatusUpdatedEvent,
+  OrderRiderAssignedEvent,
+} from '../events';
 
 @Injectable()
 export class DispatchService {
+  private readonly logger = new Logger(DispatchService.name);
+  private readonly processedEvents = new Set<string>(); // For idempotency
+
   constructor() {}
+
+  /**
+   * Generate a unique key for event idempotency
+   */
+  private getEventKey(eventName: string, orderId: string, timestamp: Date): string {
+    return `${eventName}:${orderId}:${timestamp.getTime()}`;
+  }
+
+  /**
+   * Check if event has already been processed (idempotency check)
+   */
+  private isEventProcessed(eventKey: string): boolean {
+    return this.processedEvents.has(eventKey);
+  }
+
+  /**
+   * Mark event as processed
+   */
+  private markEventProcessed(eventKey: string): void {
+    this.processedEvents.add(eventKey);
+    // Clean up old entries after 1 hour to prevent memory leak
+    setTimeout(() => this.processedEvents.delete(eventKey), 3600000);
+  }
+
+  @OnEvent('order.confirmed')
+  async handleOrderConfirmed(event: OrderConfirmedEvent) {
+    const eventKey = this.getEventKey('order.confirmed', event.orderId, event.timestamp);
+
+    if (this.isEventProcessed(eventKey)) {
+      this.logger.warn(`Duplicate event detected: ${eventKey}`);
+      return;
+    }
+
+    this.logger.log(`Handling order confirmed: ${event.orderId}`);
+
+    // TODO: Implement dispatch creation logic
+    const dispatch = {
+      id: `dispatch-${Date.now()}`,
+      orderId: event.orderId,
+      hospitalId: event.hospitalId,
+      bloodType: event.bloodType,
+      quantity: event.quantity,
+      deliveryAddress: event.deliveryAddress,
+      status: 'pending',
+      createdAt: new Date(),
+    };
+
+    this.markEventProcessed(eventKey);
+
+    this.logger.log(`Dispatch created: ${dispatch.id} for order ${event.orderId}`);
+    return dispatch;
+  }
+
+  @OnEvent('order.cancelled')
+  async handleOrderCancelled(event: OrderCancelledEvent) {
+    const eventKey = this.getEventKey('order.cancelled', event.orderId, event.timestamp);
+
+    if (this.isEventProcessed(eventKey)) {
+      this.logger.warn(`Duplicate event detected: ${eventKey}`);
+      return;
+    }
+
+    this.logger.log(`Handling order cancelled: ${event.orderId}`);
+
+    // TODO: Implement dispatch cancellation logic
+    const result = {
+      orderId: event.orderId,
+      status: 'cancelled',
+      reason: event.reason,
+      cancelledAt: new Date(),
+    };
+
+    this.markEventProcessed(eventKey);
+
+    this.logger.log(`Dispatch cancelled for order ${event.orderId}`);
+    return result;
+  }
+
+  @OnEvent('order.status.updated')
+  async handleOrderStatusUpdated(event: OrderStatusUpdatedEvent) {
+    const eventKey = this.getEventKey('order.status.updated', event.orderId, event.timestamp);
+
+    if (this.isEventProcessed(eventKey)) {
+      this.logger.warn(`Duplicate event detected: ${eventKey}`);
+      return;
+    }
+
+    this.logger.log(
+      `Handling order status update: ${event.orderId} from ${event.previousStatus} to ${event.newStatus}`,
+    );
+
+    // TODO: Implement dispatch status update logic based on order status
+    const result = {
+      orderId: event.orderId,
+      previousStatus: event.previousStatus,
+      newStatus: event.newStatus,
+      updatedAt: new Date(),
+    };
+
+    this.markEventProcessed(eventKey);
+
+    this.logger.log(`Dispatch status updated for order ${event.orderId}`);
+    return result;
+  }
+
+  @OnEvent('order.rider.assigned')
+  async handleOrderRiderAssigned(event: OrderRiderAssignedEvent) {
+    const eventKey = this.getEventKey('order.rider.assigned', event.orderId, event.timestamp);
+
+    if (this.isEventProcessed(eventKey)) {
+      this.logger.warn(`Duplicate event detected: ${eventKey}`);
+      return;
+    }
+
+    this.logger.log(`Handling rider assignment: ${event.riderId} to order ${event.orderId}`);
+
+    // TODO: Implement dispatch rider assignment logic
+    const result = {
+      orderId: event.orderId,
+      riderId: event.riderId,
+      status: 'assigned',
+      assignedAt: new Date(),
+    };
+
+    this.markEventProcessed(eventKey);
+
+    this.logger.log(`Rider ${event.riderId} assigned to dispatch for order ${event.orderId}`);
+    return result;
+  }
 
   async findAll() {
     // TODO: Implement find all dispatches logic

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -1,0 +1,4 @@
+export * from './order-confirmed.event';
+export * from './order-cancelled.event';
+export * from './order-status-updated.event';
+export * from './order-rider-assigned.event';

--- a/backend/src/events/order-cancelled.event.ts
+++ b/backend/src/events/order-cancelled.event.ts
@@ -1,0 +1,8 @@
+export class OrderCancelledEvent {
+  constructor(
+    public readonly orderId: string,
+    public readonly hospitalId: string,
+    public readonly reason: string,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/order-confirmed.event.ts
+++ b/backend/src/events/order-confirmed.event.ts
@@ -1,0 +1,10 @@
+export class OrderConfirmedEvent {
+  constructor(
+    public readonly orderId: string,
+    public readonly hospitalId: string,
+    public readonly bloodType: string,
+    public readonly quantity: number,
+    public readonly deliveryAddress: string,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/order-rider-assigned.event.ts
+++ b/backend/src/events/order-rider-assigned.event.ts
@@ -1,0 +1,7 @@
+export class OrderRiderAssignedEvent {
+  constructor(
+    public readonly orderId: string,
+    public readonly riderId: string,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/order-status-updated.event.ts
+++ b/backend/src/events/order-status-updated.event.ts
@@ -1,0 +1,8 @@
+export class OrderStatusUpdatedEvent {
+  constructor(
+    public readonly orderId: string,
+    public readonly previousStatus: string,
+    public readonly newStatus: string,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 
 @Module({
+  imports: [EventEmitterModule.forRoot()],
   controllers: [OrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,8 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  OrderConfirmedEvent,
+  OrderCancelledEvent,
+  OrderStatusUpdatedEvent,
+  OrderRiderAssignedEvent,
+} from '../events';
 
 @Injectable()
 export class OrdersService {
-  constructor() {}
+  constructor(private readonly eventEmitter: EventEmitter2) {}
 
   async findAll(status?: string, hospitalId?: string) {
     // TODO: Implement find all orders logic
@@ -22,9 +29,27 @@ export class OrdersService {
 
   async create(createOrderDto: any) {
     // TODO: Implement create order logic
+    const order = {
+      id: `order-${Date.now()}`,
+      ...createOrderDto,
+      status: 'confirmed',
+    };
+
+    // Emit order confirmed event
+    this.eventEmitter.emit(
+      'order.confirmed',
+      new OrderConfirmedEvent(
+        order.id,
+        order.hospitalId,
+        order.bloodType,
+        order.quantity,
+        order.deliveryAddress,
+      ),
+    );
+
     return {
       message: 'Order created successfully',
-      data: createOrderDto,
+      data: order,
     };
   }
 
@@ -38,6 +63,14 @@ export class OrdersService {
 
   async remove(id: string) {
     // TODO: Implement delete order logic
+    const reason = 'Order cancelled by user';
+
+    // Emit order cancelled event
+    this.eventEmitter.emit(
+      'order.cancelled',
+      new OrderCancelledEvent(id, 'hospital-id', reason),
+    );
+
     return {
       message: 'Order deleted successfully',
       data: { id },
@@ -46,6 +79,14 @@ export class OrdersService {
 
   async updateStatus(id: string, status: string) {
     // TODO: Implement update order status logic
+    const previousStatus = 'pending'; // In real implementation, fetch from DB
+
+    // Emit status updated event
+    this.eventEmitter.emit(
+      'order.status.updated',
+      new OrderStatusUpdatedEvent(id, previousStatus, status),
+    );
+
     return {
       message: 'Order status updated successfully',
       data: { id, status },
@@ -54,6 +95,13 @@ export class OrdersService {
 
   async assignRider(orderId: string, riderId: string) {
     // TODO: Implement assign rider to order logic
+
+    // Emit rider assigned event
+    this.eventEmitter.emit(
+      'order.rider.assigned',
+      new OrderRiderAssignedEvent(orderId, riderId),
+    );
+
     return {
       message: 'Rider assigned successfully',
       data: { orderId, riderId },


### PR DESCRIPTION
…er2 listeners

- Define typed event classes in shared `events/` directory
- Add OrderConfirmedEvent, OrderCancelledEvent and any related event types
- Replace all OrderService imports in DispatchService with @OnEvent handlers
- Remove OrderModule from DispatchModule imports entirely
- Ensure all event handlers are idempotent against duplicate event delivery
- Add integration tests covering full dispatch flows via emitted events Decouple Dispatch Module from Orders Module via Domain Events Labels Fixes #51