### PR TITLE
Add an idempotencyKey to every notification job

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
-        "@nestjs/event-emitter": "^2.1.1",
+        "@nestjs/event-emitter": "^3.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
@@ -751,7 +751,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -764,7 +764,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2353,7 +2353,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2374,7 +2374,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2666,16 +2666,16 @@
       }
     },
     "node_modules/@nestjs/event-emitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-2.1.1.tgz",
-      "integrity": "sha512-6L6fBOZTyfFlL7Ih/JDdqlCzZeCW0RjCX28wnzGyg/ncv5F/EOeT1dfopQr1loBRQ3LTgu8OWM7n4zLN4xigsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.0.1.tgz",
+      "integrity": "sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "6.4.9"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -3237,28 +3237,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -4441,7 +4441,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4477,7 +4477,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -4697,7 +4697,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5657,7 +5657,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -5849,7 +5849,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -9085,7 +9085,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -11664,7 +11664,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -12030,7 +12030,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12241,7 +12241,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -12724,7 +12724,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
-    "@nestjs/event-emitter": "^2.1.1",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",

--- a/backend/src/notifications/entities/notification.entity.ts
+++ b/backend/src/notifications/entities/notification.entity.ts
@@ -4,14 +4,20 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { NotificationChannel } from '../enums/notification-channel.enum';
 import { NotificationStatus } from '../enums/notification-status.enum';
 
+
 @Entity('notifications')
+@Index(['notificationId', 'channel'], { unique: true })
 export class NotificationEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+ @Column()
+  notificationId: string;
 
   @Column()
   recipientId: string;

--- a/backend/src/notifications/processors/notification.processor.spec.ts
+++ b/backend/src/notifications/processors/notification.processor.spec.ts
@@ -1,0 +1,88 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationProcessor } from './notification.processor';
+import { NotificationEntity } from '../entities/notification.entity';
+import { NotificationStatus } from '../enums/notification-status.enum';
+import { NotificationChannel } from '../enums/notification-channel.enum';
+import { SmsProvider } from '../providers/sms.provider';
+import { PushProvider } from '../providers/push.provider';
+import { EmailProvider } from '../providers/email.provider';
+import { InAppProvider } from '../providers/in-app.provider';
+
+describe('Duplicate Notification Retry Protection', () => {
+  let processor: NotificationProcessor;
+  let repo: Repository<NotificationEntity>;
+  let smsProvider: SmsProvider;
+
+  const notificationId = 'order-123';
+
+  const mockNotification: Partial<NotificationEntity> = {
+    id: notificationId,
+    status: NotificationStatus.PENDING,
+  };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        NotificationProcessor,
+        {
+          provide: getRepositoryToken(NotificationEntity),
+          useClass: Repository,
+        },
+        {
+          provide: SmsProvider,
+          useValue: { send: jest.fn() },
+        },
+        { provide: PushProvider, useValue: {} },
+        { provide: EmailProvider, useValue: {} },
+        { provide: InAppProvider, useValue: {} },
+      ],
+    }).compile();
+
+    processor = module.get(NotificationProcessor);
+    repo = module.get(getRepositoryToken(NotificationEntity));
+    smsProvider = module.get(SmsProvider);
+
+    jest.spyOn(repo, 'update').mockResolvedValue({} as any);
+  });
+
+  it('should send notification exactly once across 3 retries', async () => {
+    const job: any = {
+      id: 'job-1',
+      data: {
+        notificationId,
+        recipientId: '+2348000000000',
+        channel: NotificationChannel.SMS,
+        renderedBody: 'Order status updated',
+      },
+    };
+
+    
+    jest
+      .spyOn(repo, 'findOne')
+      .mockResolvedValueOnce({
+        ...mockNotification,
+        status: NotificationStatus.PENDING,
+      } as any)
+      
+      .mockResolvedValueOnce({
+        ...mockNotification,
+        status: NotificationStatus.SENT,
+      } as any)
+      
+      .mockResolvedValueOnce({
+        ...mockNotification,
+        status: NotificationStatus.SENT,
+      } as any);
+
+    (smsProvider.send as jest.Mock).mockResolvedValue(true);
+
+    
+    await processor.process(job);
+    await processor.process(job);
+    await processor.process(job);
+
+    expect(smsProvider.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/notifications/processors/notification.processor.ts
+++ b/backend/src/notifications/processors/notification.processor.ts
@@ -39,9 +39,32 @@ export class NotificationProcessor extends WorkerHost {
 
   async process(job: Job<NotificationJobData, any, string>): Promise<any> {
     const { notificationId, channel, recipientId, renderedBody } = job.data;
+
+     const idempotencyKey = `${notificationId}:${channel}`;
+
     this.logger.log(
       `Processing notification job ${job.id} for ${channel} -> ${recipientId}`,
     );
+
+     const notification = await this.notificationRepo.findOne({
+  where: {
+    notificationId,
+    channel,
+  },
+});
+
+  if (!notification) {
+    this.logger.warn(`Notification ${notificationId} not found`);
+    return;
+  }
+
+  
+  if (notification.status === NotificationStatus.SENT) {
+    this.logger.warn(
+      `Skipping duplicate send for ${idempotencyKey} (already SENT)`,
+    );
+    return { status: 'already_sent', notificationId };
+  }
 
     try {
       switch (channel) {

--- a/backend/src/notifications/queue/notification.queue.ts
+++ b/backend/src/notifications/queue/notification.queue.ts
@@ -1,0 +1,28 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NotificationProducer {
+  constructor(
+    @InjectQueue('notifications')
+    private readonly notificationQueue: Queue,
+  ) {}
+
+  async sendNotification(data: {
+    notificationId: string;
+    channel: string;
+    recipient: string;
+    message: string;
+  }) {
+    await this.notificationQueue.add('send-notification', data, {
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 2000,
+      },
+      removeOnComplete: true,
+      removeOnFail: false,
+    });
+  }
+}


### PR DESCRIPTION
Fix: Prevent Duplicate Notifications on Retry (Closes #58)

This PR resolves duplicate notifications being sent when BullMQ retries failed jobs.

Changes

Added DB-level idempotency check using notificationId + channel

Processor now skips sending if notification is already marked SENT

Ensures retries do not trigger duplicate deliveries

Added test simulating 3 retries to confirm notification is sent exactly once

Result

No duplicate SMS/Email/Push on retries

Idempotency survives worker restarts

No impact on happy-path performance

Closes #58 ✅