### PR TITLE
Implement identity contract initialization workflow

### DIFF
--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -17,6 +17,12 @@ pub enum Error {
     InvalidOrgType = 202,
     AlreadyInitialized = 203,
     Unauthorized = 204,
+    InvalidRating = 205,
+    AlreadyRated = 206,
+    OrganizationNotFound = 207,
+    BadgeAlreadyAwarded = 208,
+    BadgeNotFound = 209,
+    InvalidDeliveryProof = 210,
 }
 
 // ---------------------------------------------------------------------------
@@ -154,12 +160,37 @@ pub struct IdentityContract;
 impl IdentityContract {
     /// Initialize the contract with an admin
     pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Admin) {
+        if Self::is_initialized(env.clone()) {
             return Err(Error::AlreadyInitialized);
         }
+
         env.storage().instance().set(&DataKey::Admin, &admin);
-        Self::grant_role(env, admin, Role::Admin);
+        env.storage().instance().set(&DataKey::OrgCounter, &0u32);
+        Self::grant_role(env.clone(), admin.clone(), Role::Admin);
+
+        env.events()
+            .publish((symbol_short!("init"),), admin);
+
         Ok(())
+    }
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Admin)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)
+    }
+
+    pub fn get_org_counter(env: Env) -> Result<u32, Error> {
+        if !Self::is_initialized(env.clone()) {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(env.storage().instance().get(&DataKey::OrgCounter).unwrap_or(0))
     }
 
     /// Register a new organization
@@ -623,12 +654,6 @@ impl IdentityContract {
         count += 1;
         env.storage().instance().set(&key, &count);
         count
-    }
-}
-
-    /// Get organization by ID
-    pub fn get_organization(env: Env, org_id: Address) -> Option<Organization> {
-        env.storage().persistent().get(&DataKey::Org(org_id))
     }
 }
 

--- a/lifebank-soroban/contracts/identity/src/test.rs
+++ b/lifebank-soroban/contracts/identity/src/test.rs
@@ -1,11 +1,72 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, vec, Address, BytesN, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger as _},
+    vec, Address, BytesN, Env, String,
+};
 
 // ---------------------------------------------------------------------------
 // IdentityContract tests
 // ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_admin_counter_and_admin_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityContract, ());
+    let client = IdentityContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert!(client.is_initialized());
+    assert_eq!(client.get_admin(), admin.clone());
+    assert_eq!(client.get_org_counter(), 0);
+    assert_eq!(client.get_role(&admin).unwrap(), Role::Admin);
+}
+
+#[test]
+fn test_initialize_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityContract, ());
+    let client = IdentityContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_initialize_cannot_run_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityContract, ());
+    let client = IdentityContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let result = client.try_initialize(&admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+#[test]
+fn test_initialize_guards_readers_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityContract, ());
+    let client = IdentityContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.try_get_admin(), Err(Ok(Error::Unauthorized)));
+    assert_eq!(client.try_get_org_counter(), Err(Ok(Error::Unauthorized)));
+}
 
 #[test]
 fn test_register_organization() {


### PR DESCRIPTION
Implement identity contract initialization workflow

Complete the identity contract initialization path so the contract can be
safely bootstrapped and verified against the issue requirements.

Changes:
- fix the broken identity contract structure by removing the stray duplicate
  function/brace mismatch that prevented compilation
- add missing identity error variants already referenced by the contract tests
  and implementation paths
- update `initialize` to guard against re-initialization
- persist the contract admin in instance storage
- initialize the organization counter to zero
- grant the admin role during initialization
- emit an initialization event
- add initialization readers for `is_initialized`, `get_admin`, and
  `get_org_counter` so state can be verified directly in tests
- add initialization tests covering:
  - admin and counter setup
  - admin role assignment
  - initialization event emission
  - re-initialization guard
  - pre-initialization access guards for readers

Verification:
- run `cargo test -p identity-contract`
- result: 44 tests passed
resolve #187 