### PR TITLE
Add delivery contract initialization

### DIFF
--- a/lifebank-soroban/Cargo.lock
+++ b/lifebank-soroban/Cargo.lock
@@ -420,6 +420,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "delivery-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lifebank-soroban/contracts/delivery/Cargo.toml
+++ b/lifebank-soroban/contracts/delivery/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "delivery-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/lifebank-soroban/contracts/delivery/Makefile
+++ b/lifebank-soroban/contracts/delivery/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/lifebank-soroban/contracts/delivery/src/lib.rs
+++ b/lifebank-soroban/contracts/delivery/src/lib.rs
@@ -1,0 +1,123 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+};
+
+const DEFAULT_MIN_TEMPERATURE_C: i32 = 2;
+const DEFAULT_MAX_TEMPERATURE_C: i32 = 6;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 700,
+    NotInitialized = 701,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TemperatureThresholds {
+    pub min_celsius: i32,
+    pub max_celsius: i32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofRequirements {
+    pub requires_photo_proof: bool,
+    pub requires_recipient_signature: bool,
+    pub requires_temperature_log: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    RequestContract,
+    DeliveryCounter,
+    TemperatureThresholds,
+    ProofRequirements,
+}
+
+#[contract]
+pub struct DeliveryContract;
+
+#[contractimpl]
+impl DeliveryContract {
+    pub fn initialize(env: Env, admin: Address, request_contract: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        if Self::is_initialized(env.clone()) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        let thresholds = TemperatureThresholds {
+            min_celsius: DEFAULT_MIN_TEMPERATURE_C,
+            max_celsius: DEFAULT_MAX_TEMPERATURE_C,
+        };
+        let proof_requirements = ProofRequirements {
+            requires_photo_proof: true,
+            requires_recipient_signature: true,
+            requires_temperature_log: true,
+        };
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::RequestContract, &request_contract);
+        env.storage().instance().set(&DataKey::DeliveryCounter, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TemperatureThresholds, &thresholds);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProofRequirements, &proof_requirements);
+
+        env.events()
+            .publish((symbol_short!("init"),), (admin, request_contract));
+
+        Ok(())
+    }
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Admin)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)
+    }
+
+    pub fn get_request_contract(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::RequestContract)
+            .ok_or(Error::NotInitialized)
+    }
+
+    pub fn get_delivery_counter(env: Env) -> Result<u64, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::DeliveryCounter)
+            .ok_or(Error::NotInitialized)
+    }
+
+    pub fn get_temperature_thresholds(env: Env) -> Result<TemperatureThresholds, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::TemperatureThresholds)
+            .ok_or(Error::NotInitialized)
+    }
+
+    pub fn get_proof_requirements(env: Env) -> Result<ProofRequirements, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProofRequirements)
+            .ok_or(Error::NotInitialized)
+    }
+}
+
+mod test;

--- a/lifebank-soroban/contracts/delivery/src/test.rs
+++ b/lifebank-soroban/contracts/delivery/src/test.rs
@@ -1,0 +1,107 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    Address, Env,
+};
+
+fn create_uninitialized_contract<'a>() -> (Env, DeliveryContractClient<'a>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DeliveryContract, ());
+    let client = DeliveryContractClient::new(&env, &contract_id);
+
+    (env, client, contract_id)
+}
+
+fn create_initialized_contract<'a>() -> (Env, DeliveryContractClient<'a>, Address, Address, Address)
+{
+    let (env, client, contract_id) = create_uninitialized_contract();
+    let admin = Address::generate(&env);
+    let request_contract = Address::generate(&env);
+
+    client.initialize(&admin, &request_contract);
+
+    (env, client, contract_id, admin, request_contract)
+}
+
+#[test]
+fn test_initialize_sets_admin_request_contract_and_counter() {
+    let (_env, client, _contract_id, admin, request_contract) = create_initialized_contract();
+
+    assert!(client.is_initialized());
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_request_contract(), request_contract);
+    assert_eq!(client.get_delivery_counter(), 0);
+}
+
+#[test]
+fn test_initialize_sets_temperature_thresholds() {
+    let (_env, client, _contract_id, _admin, _request_contract) = create_initialized_contract();
+
+    assert_eq!(
+        client.get_temperature_thresholds(),
+        TemperatureThresholds {
+            min_celsius: DEFAULT_MIN_TEMPERATURE_C,
+            max_celsius: DEFAULT_MAX_TEMPERATURE_C,
+        }
+    );
+}
+
+#[test]
+fn test_initialize_sets_proof_requirements() {
+    let (_env, client, _contract_id, _admin, _request_contract) = create_initialized_contract();
+
+    assert_eq!(
+        client.get_proof_requirements(),
+        ProofRequirements {
+            requires_photo_proof: true,
+            requires_recipient_signature: true,
+            requires_temperature_log: true,
+        }
+    );
+}
+
+#[test]
+fn test_initialize_emits_event() {
+    let (env, _client, _contract_id, _admin, _request_contract) = create_initialized_contract();
+
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_initialize_cannot_run_twice() {
+    let (env, client, _contract_id) = create_uninitialized_contract();
+    let admin = Address::generate(&env);
+    let request_contract = Address::generate(&env);
+
+    client.initialize(&admin, &request_contract);
+
+    let result = client.try_initialize(&admin, &request_contract);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+#[test]
+fn test_getters_fail_before_initialization() {
+    let (_env, client, _contract_id) = create_uninitialized_contract();
+
+    assert_eq!(client.try_get_admin(), Err(Ok(Error::NotInitialized)));
+    assert_eq!(
+        client.try_get_request_contract(),
+        Err(Ok(Error::NotInitialized))
+    );
+    assert_eq!(
+        client.try_get_delivery_counter(),
+        Err(Ok(Error::NotInitialized))
+    );
+    assert_eq!(
+        client.try_get_temperature_thresholds(),
+        Err(Ok(Error::NotInitialized))
+    );
+    assert_eq!(
+        client.try_get_proof_requirements(),
+        Err(Ok(Error::NotInitialized))
+    );
+}


### PR DESCRIPTION
Create the delivery Soroban contract and implement its initialization workflow. Store the contract admin, link the request contract, initialize the delivery counter, configure default temperature thresholds, and set proof requirements during bootstrap. Add getters and initialization guards so the stored configuration can be verified directly.

Verification: cargo test -p delivery-contract

resolve #192 