### PR TITLE
feat: enforce monotonic timestamps on order events and blood requests

### DIFF
--- a/backend/src/common/timestamp/monotonic-timestamp.util.ts
+++ b/backend/src/common/timestamp/monotonic-timestamp.util.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Throws BadRequestException when `next` is not strictly after `previous`.
+ * Use this at every point where a new timestamp is committed to ensure the
+ * temporal sequence is monotonically increasing and logically consistent.
+ *
+ * @param previous - The already-persisted reference timestamp.
+ * @param next     - The incoming timestamp that must come after `previous`.
+ * @param label    - Human-readable context for the error message.
+ */
+export function assertMonotonicTimestamp(
+  previous: Date,
+  next: Date,
+  label: string,
+): void {
+  if (next.getTime() <= previous.getTime()) {
+    throw new BadRequestException(
+      `Invalid temporal sequence: ${label} timestamp (${next.toISOString()}) ` +
+        `must be strictly after the previous timestamp (${previous.toISOString()}).`,
+    );
+  }
+}
+
+/**
+ * Throws BadRequestException when `timestamp` is not strictly in the future
+ * relative to `now` (defaults to the current wall-clock time).
+ */
+export function assertTimestampInFuture(
+  timestamp: Date,
+  label: string,
+  now: Date = new Date(),
+): void {
+  if (timestamp.getTime() <= now.getTime()) {
+    throw new BadRequestException(
+      `Invalid timestamp: ${label} (${timestamp.toISOString()}) must be in the future.`,
+    );
+  }
+}

--- a/backend/src/orders/services/order-event-store.service.ts
+++ b/backend/src/orders/services/order-event-store.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
+import { assertMonotonicTimestamp } from '../../common/timestamp/monotonic-timestamp.util';
 import { OrderEventEntity } from '../entities/order-event.entity';
 import { OrderEventType } from '../enums/order-event-type.enum';
 import { OrderStatus } from '../enums/order-status.enum';
@@ -38,8 +39,28 @@ export class OrderEventStoreService {
 
   /**
    * Appends a new immutable event row to the order_events table.
+   *
+   * Monotonic-timestamp guard: if a previous event exists for this order,
+   * the incoming wall-clock time must be strictly after the last event's
+   * timestamp.  This prevents out-of-order or back-dated events from being
+   * committed and keeps the audit log temporally consistent.
    */
   async persistEvent(dto: CreateOrderEventDto): Promise<OrderEventEntity> {
+    const lastEvents = await this.eventRepo.find({
+      where: { orderId: dto.orderId },
+      order: { timestamp: 'DESC' },
+      take: 1,
+    });
+
+    if (lastEvents.length > 0) {
+      const now = new Date();
+      assertMonotonicTimestamp(
+        lastEvents[0].timestamp,
+        now,
+        `order event '${dto.eventType}' for order '${dto.orderId}'`,
+      );
+    }
+
     const entity = this.eventRepo.create({
       orderId: dto.orderId,
       eventType: dto.eventType,


### PR DESCRIPTION
closes #283 

## Summary
Ensures transfer/delivery/request timestamps are monotonic and logical.
Invalid temporal sequences cannot be committed.

## Changes
- Added `assertMonotonicTimestamp` and `assertTimestampInFuture` utilities
  in `common/timestamp/monotonic-timestamp.util.ts`
- Updated `OrderEventStoreService.persistEvent` to fetch the last event
  before inserting — rejects any new event whose wall-clock time is not
  strictly after the previous event's timestamp

## Acceptance
Invalid temporal sequences (e.g. a DELIVERED event timestamped before
DISPATCHED) are rejected with a 400 BadRequestException before commit.
