### PR TITLE
feat: add Dependabot + npm audit/OSS Index CI with policy thresholds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Hahfyeex"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+      include: "scope"
+    ignore:
+      # Ignore major version bumps — review manually
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,242 @@
+name: Dependency Security Audit
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - '.github/workflows/dependency-audit.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+  schedule:
+    # Run every day at 03:00 UTC to catch newly-disclosed CVEs
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ./backend
+
+# ─── Policy thresholds ────────────────────────────────────────────────────────
+# critical  → always fail the build
+# high      → fail the build
+# moderate  → reported, does NOT fail (warn only)
+# low       → reported, does NOT fail (warn only)
+# See SECURITY_POLICY.md for rationale and exception process.
+# ─────────────────────────────────────────────────────────────────────────────
+
+jobs:
+  npm-audit:
+    name: npm audit (critical + high)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Fail on critical or high vulnerabilities (policy threshold)
+      - name: npm audit — fail on critical/high
+        run: npm audit --audit-level=high --json > npm-audit-report.json || true
+
+      - name: Evaluate audit results
+        id: audit-eval
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          const report = JSON.parse(fs.readFileSync('npm-audit-report.json', 'utf8'));
+
+          const vulns = report.vulnerabilities ?? {};
+          const counts = { critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
+
+          for (const v of Object.values(vulns)) {
+            const sev = v.severity ?? 'info';
+            counts[sev] = (counts[sev] ?? 0) + 1;
+          }
+
+          const metadata = report.metadata?.vulnerabilities ?? counts;
+
+          console.log('=== npm audit summary ===');
+          console.log(JSON.stringify(metadata, null, 2));
+
+          // Write counts to GITHUB_OUTPUT
+          const output = process.env.GITHUB_OUTPUT;
+          const lines = Object.entries(counts).map(([k, v]) => `${k}=${v}`).join('\n');
+          fs.appendFileSync(output, lines + '\n');
+
+          // Policy: fail on critical or high
+          if (counts.critical > 0 || counts.high > 0) {
+            console.error(`\nPOLICY VIOLATION: ${counts.critical} critical, ${counts.high} high vulnerabilities found.`);
+            console.error('Fix or apply an exception (see SECURITY_POLICY.md) before merging.');
+            process.exit(1);
+          }
+
+          if (counts.moderate > 0 || counts.low > 0) {
+            console.warn(`\nWARNING: ${counts.moderate} moderate, ${counts.low} low vulnerabilities found.`);
+            console.warn('These do not block the build but should be addressed.');
+          }
+
+          console.log('\nAll policy thresholds passed.');
+          EOF
+
+      - name: Upload npm audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: backend/npm-audit-report.json
+          retention-days: 30
+
+      - name: Post audit summary to PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const critical = '${{ steps.audit-eval.outputs.critical }}';
+            const high     = '${{ steps.audit-eval.outputs.high }}';
+            const moderate = '${{ steps.audit-eval.outputs.moderate }}';
+            const low      = '${{ steps.audit-eval.outputs.low }}';
+
+            const passed = Number(critical) === 0 && Number(high) === 0;
+            const icon   = passed ? '✅' : '❌';
+
+            const body = [
+              `### ${icon} npm audit — Dependency Security Report`,
+              '',
+              '| Severity | Count | Policy |',
+              '|----------|-------|--------|',
+              `| 🔴 Critical | ${critical} | **Fail build** |`,
+              `| 🟠 High     | ${high}     | **Fail build** |`,
+              `| 🟡 Moderate | ${moderate} | Warn only      |`,
+              `| 🔵 Low      | ${low}      | Warn only      |`,
+              '',
+              passed
+                ? '_All policy thresholds passed. Safe to merge from a dependency-security perspective._'
+                : '_Policy threshold breached. Resolve critical/high vulnerabilities or follow the exception process in [SECURITY_POLICY.md](../blob/main/SECURITY_POLICY.md)._',
+            ].join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+  oss-index-audit:
+    name: OSS Index audit (Sonatype)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # OSS Index requires credentials; skip on forks to avoid secret exposure
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install auditjs (OSS Index CLI)
+        run: npm install -g auditjs@latest
+        working-directory: .
+
+      # auditjs exits non-zero when vulnerabilities are found.
+      # We capture the output and apply our own threshold policy.
+      - name: Run OSS Index scan
+        id: oss-scan
+        run: |
+          auditjs ossi --json > oss-index-report.json 2>&1 || true
+        env:
+          OSSINDEX_USER: ${{ secrets.OSSINDEX_USER }}
+          OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
+
+      - name: Evaluate OSS Index results
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          let report;
+          try {
+            report = JSON.parse(fs.readFileSync('oss-index-report.json', 'utf8'));
+          } catch {
+            console.warn('Could not parse OSS Index report — skipping threshold check.');
+            process.exit(0);
+          }
+
+          // auditjs report is an array of package results
+          const packages = Array.isArray(report) ? report : [];
+          let critical = 0, high = 0, moderate = 0, low = 0;
+
+          for (const pkg of packages) {
+            for (const vuln of pkg.vulnerabilities ?? []) {
+              const score = vuln.cvssScore ?? 0;
+              if (score >= 9.0)      critical++;
+              else if (score >= 7.0) high++;
+              else if (score >= 4.0) moderate++;
+              else                   low++;
+            }
+          }
+
+          console.log('=== OSS Index summary ===');
+          console.log({ critical, high, moderate, low });
+
+          // Same policy thresholds as npm audit
+          if (critical > 0 || high > 0) {
+            console.error(`\nPOLICY VIOLATION: ${critical} critical (CVSS>=9), ${high} high (CVSS>=7) found.`);
+            process.exit(1);
+          }
+
+          console.log('\nAll OSS Index policy thresholds passed.');
+          EOF
+
+      - name: Upload OSS Index report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oss-index-report
+          path: backend/oss-index-report.json
+          retention-days: 30
+
+  audit-gate:
+    name: Security audit gate
+    runs-on: ubuntu-latest
+    needs: [npm-audit, oss-index-audit]
+    if: always()
+
+    steps:
+      - name: Enforce policy gate
+        run: |
+          NPM_RESULT="${{ needs.npm-audit.result }}"
+          OSS_RESULT="${{ needs.oss-index-audit.result }}"
+
+          echo "npm audit:    $NPM_RESULT"
+          echo "OSS Index:    $OSS_RESULT"
+
+          if [ "$NPM_RESULT" = "failure" ] || [ "$OSS_RESULT" = "failure" ]; then
+            echo ""
+            echo "One or more security audits failed the policy threshold."
+            echo "See SECURITY_POLICY.md for the exception and remediation process."
+            exit 1
+          fi
+
+          echo "All security audits passed."

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -1,0 +1,75 @@
+# Security Policy — Dependency Vulnerability Thresholds
+
+## Workflow
+
+The `dependency-audit` CI workflow runs on every PR that touches
+`backend/package.json` or `backend/package-lock.json`, on every push to
+`main`/`develop`, and on a nightly schedule (03:00 UTC) to catch newly-disclosed
+CVEs between dependency updates.
+
+Two scanners are used in parallel:
+
+| Scanner | Tool | Source |
+|---------|------|--------|
+| npm audit | `npm audit --audit-level=high` | npm advisory database |
+| OSS Index | `auditjs ossi` | Sonatype OSS Index (NVD-backed) |
+
+A final **audit-gate** job aggregates both results and fails the build if either
+scanner breaches the policy threshold.
+
+---
+
+## Policy Thresholds
+
+| Severity | CVSS range | npm audit | OSS Index | Build outcome |
+|----------|-----------|-----------|-----------|---------------|
+| Critical | 9.0 – 10.0 | ❌ | ❌ | **Fail — blocks merge** |
+| High | 7.0 – 8.9 | ❌ | ❌ | **Fail — blocks merge** |
+| Moderate | 4.0 – 6.9 | ⚠️ | ⚠️ | Warn only — does not block |
+| Low | 0.1 – 3.9 | ⚠️ | ⚠️ | Warn only — does not block |
+
+> Rationale: Critical and High vulnerabilities represent exploitable attack
+> vectors that could compromise patient data or system integrity. Moderate/Low
+> are tracked and must be resolved within 30 days of disclosure.
+
+---
+
+## Dependabot
+
+Dependabot is configured (`.github/dependabot.yml`) to open weekly PRs for:
+- `backend/` npm dependencies
+- GitHub Actions
+
+Major version bumps are excluded from automatic PRs and must be reviewed
+manually. All Dependabot PRs are labelled `dependencies` and `security`.
+
+---
+
+## Exception Process
+
+If a critical or high vulnerability **cannot** be remediated immediately (e.g.
+no fix available upstream), follow this process:
+
+1. Open a GitHub Issue tagged `security-exception` documenting:
+   - CVE identifier
+   - Affected package and version
+   - Reason a fix is not yet available
+   - Mitigating controls in place
+   - Target remediation date (max 14 days for critical, 30 days for high)
+
+2. Add the package to the `npm audit` ignore list in the workflow using
+   `--ignore-path .nsprc` or an inline `audit-resolve.json` entry.
+
+3. Get sign-off from a maintainer before merging.
+
+---
+
+## Secrets Required
+
+| Secret | Purpose |
+|--------|---------|
+| `OSSINDEX_USER` | Sonatype OSS Index account email (optional — unauthenticated rate-limited) |
+| `OSSINDEX_TOKEN` | Sonatype OSS Index API token (optional — unauthenticated rate-limited) |
+
+OSS Index works without credentials but is rate-limited. Add credentials in
+**Settings → Secrets → Actions** for reliable CI runs.


### PR DESCRIPTION
closes #278 

## Summary
Adds automated dependency vulnerability scanning with documented policy thresholds.

## Changes
- `.github/dependabot.yml` — weekly PRs for npm deps and GitHub Actions
- `.github/workflows/dependency-audit.yml` — parallel npm audit + OSS Index
  (auditjs) scans on every PR touching package files, push to main/develop,
  and nightly at 03:00 UTC
- `SECURITY_POLICY.md` — documents thresholds, workflow behavior, exception
  process, and required secrets

## Thresholds
| Severity | Build outcome |
|----------|---------------|
| Critical (CVSS ≥ 9.0) | Fail — blocks merge |
| High (CVSS ≥ 7.0) | Fail — blocks merge |
| Moderate / Low | Warn only |

## Acceptance
- Workflow reports on every PR via comment with severity table
- Failing threshold (critical/high) documented in SECURITY_POLICY.md
- audit-gate job aggregates both scanners and enforces the policy
