### PR TITLE
feat: Implement job deduplication plugin for high-volume events (#268)

### DIFF
--- a/backend/src/blockchain/blockchain.module.ts
+++ b/backend/src/blockchain/blockchain.module.ts
@@ -9,6 +9,7 @@ import { SorobanDlqProcessor } from './processors/soroban-dlq.processor';
 import { SorobanTxProcessor } from './processors/soroban-tx.processor';
 import { IdempotencyService } from './services/idempotency.service';
 import { SorobanService } from './services/soroban.service';
+import { JobDeduplicationPlugin } from './plugins/job-deduplication.plugin';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { SorobanService } from './services/soroban.service';
   providers: [
     SorobanService,
     IdempotencyService,
+    JobDeduplicationPlugin,
     SorobanTxProcessor,
     SorobanDlqProcessor,
     AdminGuard,

--- a/backend/src/blockchain/plugins/job-deduplication.plugin.ts
+++ b/backend/src/blockchain/plugins/job-deduplication.plugin.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'crypto';
+
+import { Injectable, Inject, Optional, Logger } from '@nestjs/common';
+
+import type { RedisClientType } from 'redis';
+
+/**
+ * Job Deduplication Plugin
+ *
+ * Prevents queue bloat by suppressing duplicate job submissions within a time window.
+ * Uses Redis to track recent job payloads and detect equivalent jobs submitted rapidly.
+ *
+ * Strategy:
+ * 1. Compute deterministic hash of job payload (contractMethod + normalized args)
+ * 2. Check Redis for recent hash within dedup window (default 10 seconds)
+ * 3. Suppress duplicate if found, otherwise queue normally
+ * 4. Store hash in Redis with TTL matching dedup window
+ *
+ * This avoids queue bloat while allowing legitimate batch resubmissions after the window expires.
+ */
+@Injectable()
+export class JobDeduplicationPlugin {
+  private readonly logger = new Logger(JobDeduplicationPlugin.name);
+  private redis: RedisClientType;
+  private readonly DEDUP_PREFIX = 'job-dedup:';
+  private readonly DEDUP_WINDOW_MS = 10_000; // 10 seconds default
+  private readonly DEDUP_TTL_SECONDS = Math.ceil(this.DEDUP_WINDOW_MS / 1000);
+
+  constructor(@Optional() @Inject('REDIS_CLIENT') redis?: RedisClientType) {
+    if (redis) {
+      this.redis = redis;
+    } else {
+      // Lazy load Redis only if not provided (for testing)
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+      const { createClient } = require('redis');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      this.redis = createClient({
+        socket: {
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT || '6379'),
+        },
+      });
+    }
+  }
+
+  /**
+   * Compute deterministic hash of job payload.
+   * Normalizes args to handle equivalent objects with different reference identities.
+   *
+   * @param contractMethod - Smart contract method name
+   * @param args - Job arguments (normalized to canonical JSON)
+   * @returns SHA256 hash of normalized payload
+   */
+  private computeJobHash(contractMethod: string, args: unknown[]): string {
+    const normalized = {
+      contractMethod,
+      args: args.map((arg) => {
+        if (typeof arg === 'object' && arg !== null) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return JSON.parse(JSON.stringify(arg));
+        }
+        return arg;
+      }),
+    };
+
+    const canonical = JSON.stringify(normalized);
+
+    return createHash('sha256').update(canonical).digest('hex');
+  }
+
+  /**
+   * Check if job is duplicate within dedup window and cache it.
+   * Returns true if job is NEW, false if it's a DUPLICATE.
+   *
+   * @param contractMethod - Contract method name
+   * @param args - Job arguments
+   * @returns true if new (not recent duplicate), false if duplicate
+   */
+  async checkAndSetJobDedup(
+    contractMethod: string,
+    args: unknown[],
+  ): Promise<boolean> {
+    const jobHash = this.computeJobHash(contractMethod, args);
+    const dedupKey = `${this.DEDUP_PREFIX}${jobHash}`;
+
+    const exists = await this.redis.exists(dedupKey);
+    if (exists === 1) {
+      this.logger.debug(`Duplicate job suppressed: ${jobHash}`, {
+        contractMethod,
+      });
+      return false; // Duplicate
+    }
+
+    // Store hash with TTL
+    await this.redis.setEx(dedupKey, this.DEDUP_TTL_SECONDS, '1');
+    this.logger.debug(`New job cached for dedup window: ${jobHash}`, {
+      contractMethod,
+      window: this.DEDUP_WINDOW_MS,
+    });
+    return true; // New
+  }
+
+  /**
+   * Clear dedup cache for testing purposes.
+   * Resets Redis dedup keys matching prefix.
+   */
+  async clearDedup(): Promise<void> {
+    const keys = await this.redis.keys(`${this.DEDUP_PREFIX}*`);
+    if (keys.length > 0) {
+      await this.redis.del(keys);
+      this.logger.debug(`Cleared ${keys.length} dedup cache entries`);
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis.quit();
+  }
+}

--- a/backend/src/blockchain/services/soroban.service.ts
+++ b/backend/src/blockchain/services/soroban.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../types/soroban-tx.types';
 
 import { IdempotencyService } from './idempotency.service';
+import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
 
 import type { Queue } from 'bull';
 
@@ -22,6 +23,7 @@ export class SorobanService {
     @InjectQueue('soroban-tx-queue') private txQueue: Queue,
     @InjectQueue('soroban-dlq') private dlq: Queue,
     private idempotencyService: IdempotencyService,
+    private deduplicationPlugin: JobDeduplicationPlugin,
   ) {}
 
   /**
@@ -43,6 +45,20 @@ export class SorobanService {
         `Duplicate submission detected for idempotency key: ${job.idempotencyKey}`,
       );
       throw new Error('Duplicate submission - idempotency key already exists');
+    }
+
+    // Check for duplicate job within dedup window
+    const isDedupNew = await this.deduplicationPlugin.checkAndSetJobDedup(
+      job.contractMethod,
+      job.args,
+    );
+
+    if (!isDedupNew) {
+      this.logger.warn(
+        `Duplicate job suppressed (within dedup window): ${job.contractMethod}`,
+        { idempotencyKey: job.idempotencyKey },
+      );
+      throw new Error('Duplicate job - equivalent job enqueued recently');
     }
 
     const maxRetries = job.maxRetries ?? this.DEFAULT_MAX_RETRIES;

--- a/backend/src/blockchain/tests/job-deduplication.plugin.spec.ts
+++ b/backend/src/blockchain/tests/job-deduplication.plugin.spec.ts
@@ -1,0 +1,281 @@
+/// <reference types="jest" />
+
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
+
+describe('JobDeduplicationPlugin', () => {
+  let plugin: JobDeduplicationPlugin;
+  const mockRedis = {
+    exists: jest.fn(),
+    setEx: jest.fn(),
+    keys: jest.fn(),
+    del: jest.fn(),
+    quit: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: JobDeduplicationPlugin,
+          useValue: (() => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            const instance = new JobDeduplicationPlugin(mockRedis as any);
+            return instance;
+          })(),
+        },
+      ],
+    }).compile();
+
+    plugin = module.get<JobDeduplicationPlugin>(JobDeduplicationPlugin);
+  });
+
+  describe('checkAndSetJobDedup', () => {
+    it('should return true for new job', async () => {
+      mockRedis.exists.mockResolvedValueOnce(0);
+      mockRedis.setEx.mockResolvedValueOnce('OK');
+
+      const result = await plugin.checkAndSetJobDedup('test_method', [
+        'arg1',
+        'arg2',
+      ]);
+
+      expect(result).toBe(true);
+      expect(mockRedis.exists).toHaveBeenCalled();
+      expect(mockRedis.setEx).toHaveBeenCalled();
+    });
+
+    it('should return false for duplicate job', async () => {
+      mockRedis.exists.mockResolvedValueOnce(1);
+
+      const result = await plugin.checkAndSetJobDedup('test_method', [
+        'arg1',
+        'arg2',
+      ]);
+
+      expect(result).toBe(false);
+      expect(mockRedis.exists).toHaveBeenCalled();
+      expect(mockRedis.setEx).not.toHaveBeenCalled();
+    });
+
+    it('should compute consistent hash for same payload', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const method = 'register_blood';
+      const args = ['bank-123', 'O+', 100];
+
+      // First call
+      const result1 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result1).toBe(true);
+
+      // Simulate same job arriving again
+      mockRedis.exists.mockResolvedValueOnce(1);
+      const result2 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result2).toBe(false);
+    });
+
+    it('should handle object arguments normalization', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const method = 'process_payment';
+      const args1 = [{ amount: 100, currency: 'USD' }];
+      const args2 = [{ amount: 100, currency: 'USD' }]; // Same object, different reference
+
+      // First call
+      const result1 = await plugin.checkAndSetJobDedup(method, args1);
+      expect(result1).toBe(true);
+
+      // Second call with equivalent object
+      mockRedis.exists.mockResolvedValueOnce(1);
+      const result2 = await plugin.checkAndSetJobDedup(method, args2);
+      expect(result2).toBe(false);
+    });
+
+    it('should distinguish different jobs', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      // First job
+      const result1 = await plugin.checkAndSetJobDedup('method_a', ['arg1']);
+      expect(result1).toBe(true);
+
+      // Different job
+      const result2 = await plugin.checkAndSetJobDedup('method_b', ['arg1']);
+      expect(result2).toBe(true);
+
+      expect(mockRedis.setEx).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle complex nested objects', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const method = 'complex_operation';
+      const args = [
+        {
+          nested: {
+            value: 42,
+            array: [1, 2, 3],
+          },
+        },
+      ];
+
+      const result = await plugin.checkAndSetJobDedup(method, args);
+      expect(result).toBe(true);
+      expect(mockRedis.setEx).toHaveBeenCalled();
+    });
+
+    it('should set correct TTL on dedup key', async () => {
+      mockRedis.exists.mockResolvedValueOnce(0);
+      mockRedis.setEx.mockResolvedValueOnce('OK');
+
+      await plugin.checkAndSetJobDedup('test_method', ['arg']);
+
+      // Verify setEx was called with appropriate TTL (10 seconds)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const [, ttl] = mockRedis.setEx.mock.calls[0];
+      expect(ttl).toBe(10); // 10 second TTL
+    });
+
+    it('should handle null and undefined arguments', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const result = await plugin.checkAndSetJobDedup('test_method', [
+        null,
+        undefined,
+        'value',
+      ]);
+
+      expect(result).toBe(true);
+      expect(mockRedis.setEx).toHaveBeenCalled();
+    });
+
+    it('should detect duplicate with null/undefined arguments', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const args = [null, undefined, 'value'];
+
+      // First call
+      const result1 = await plugin.checkAndSetJobDedup('method', args);
+      expect(result1).toBe(true);
+
+      // Duplicate call
+      mockRedis.exists.mockResolvedValueOnce(1);
+      const result2 = await plugin.checkAndSetJobDedup('method', args);
+      expect(result2).toBe(false);
+    });
+  });
+
+  describe('clearDedup', () => {
+    it('should clear all dedup cache entries', async () => {
+      mockRedis.keys.mockResolvedValueOnce([
+        'job-dedup:abc123',
+        'job-dedup:def456',
+      ]);
+      mockRedis.del.mockResolvedValueOnce(2);
+
+      await plugin.clearDedup();
+
+      expect(mockRedis.keys).toHaveBeenCalledWith('job-dedup:*');
+      expect(mockRedis.del).toHaveBeenCalledWith([
+        'job-dedup:abc123',
+        'job-dedup:def456',
+      ]);
+    });
+
+    it('should handle empty cache gracefully', async () => {
+      mockRedis.keys.mockResolvedValueOnce([]);
+
+      await plugin.clearDedup();
+
+      expect(mockRedis.keys).toHaveBeenCalledWith('job-dedup:*');
+      expect(mockRedis.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Acceptance Criteria', () => {
+    it('should suppress duplicate high-volume events', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const method = 'rapid_fire_event';
+      const args = ['event-data'];
+
+      // First event - should be allowed
+      const result1 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result1).toBe(true);
+
+      // Rapid duplicate - should be suppressed
+      mockRedis.exists.mockResolvedValueOnce(1);
+      const result2 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result2).toBe(false);
+
+      // Prevent queue bloat - only 1 actual queue entry for 2 duplicate requests
+      expect(mockRedis.setEx).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow same event after dedup window expires', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const method = 'batched_event';
+      const args = ['data'];
+
+      // First event
+      const result1 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result1).toBe(true);
+
+      // Simulate dedup window expiration (key doesn't exist anymore)
+      mockRedis.exists.mockResolvedValueOnce(0);
+      const result2 = await plugin.checkAndSetJobDedup(method, args);
+      expect(result2).toBe(true); // Allowed after window expires
+
+      expect(mockRedis.setEx).toHaveBeenCalledTimes(2);
+    });
+
+    it('should verify duplicate job suppression with test data', async () => {
+      mockRedis.exists.mockResolvedValue(0);
+      mockRedis.setEx.mockResolvedValue('OK');
+
+      const suppressionTests = [
+        { method: 'order_placed', args: ['order-123', 'USD'] },
+        { method: 'payment_processed', args: [{ amount: 50 }] },
+        { method: 'inventory_updated', args: ['SKU-001', 10] },
+      ];
+
+      // Enqueue all jobs twice
+      const allowedCount: number[] = [];
+
+      for (const test of suppressionTests) {
+        // First submission
+        mockRedis.exists.mockResolvedValueOnce(0);
+        mockRedis.setEx.mockResolvedValueOnce('OK');
+        const result1 = await plugin.checkAndSetJobDedup(
+          test.method,
+          test.args,
+        );
+
+        // Second submission (duplicate)
+        mockRedis.exists.mockResolvedValueOnce(1);
+        const result2 = await plugin.checkAndSetJobDedup(
+          test.method,
+          test.args,
+        );
+
+        allowedCount.push(result1 ? 1 : 0);
+        allowedCount.push(result2 ? 1 : 0);
+      }
+
+      // Verify 3 allowed (first of each), 3 suppressed (duplicates)
+      const totalAllowed = allowedCount.reduce((a, b) => a + b, 0);
+      expect(totalAllowed).toBe(suppressionTests.length); // Only first of each allowed
+    });
+  });
+});

--- a/backend/src/blockchain/tests/soroban-deduplication.integration.spec.ts
+++ b/backend/src/blockchain/tests/soroban-deduplication.integration.spec.ts
@@ -1,0 +1,304 @@
+/// <reference types="jest" />
+
+import { getQueueToken } from '@nestjs/bull';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
+import { IdempotencyService } from '../services/idempotency.service';
+import { SorobanService } from '../services/soroban.service';
+import { SorobanTxJob } from '../types/soroban-tx.types';
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+describe('SorobanService - Job Deduplication Integration', () => {
+  let service: SorobanService;
+  let mockTxQueue: any;
+  let mockDlq: any;
+  let mockIdempotencyService: {
+    checkAndSetIdempotencyKey: jest.Mock;
+  };
+  let mockDeduplicationPlugin: {
+    checkAndSetJobDedup: jest.Mock;
+    clearDedup: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockTxQueue = {
+      add: jest
+        .fn()
+        .mockImplementation((_data: SorobanTxJob, opts: { jobId?: string }) =>
+          Promise.resolve({ id: opts?.jobId ?? 'job-123' }),
+        ),
+      count: jest.fn().mockResolvedValue(0),
+      getFailedCount: jest.fn().mockResolvedValue(0),
+      getJob: jest.fn(),
+    };
+
+    mockDlq = {
+      count: jest.fn().mockResolvedValue(0),
+    };
+
+    mockIdempotencyService = {
+      checkAndSetIdempotencyKey: jest.fn().mockResolvedValue(true),
+    };
+
+    mockDeduplicationPlugin = {
+      checkAndSetJobDedup: jest.fn().mockResolvedValue(true),
+      clearDedup: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanService,
+        {
+          provide: getQueueToken('soroban-tx-queue'),
+          useValue: mockTxQueue,
+        },
+        {
+          provide: getQueueToken('soroban-dlq'),
+          useValue: mockDlq,
+        },
+        {
+          provide: IdempotencyService,
+          useValue: mockIdempotencyService,
+        },
+        {
+          provide: JobDeduplicationPlugin,
+          useValue: mockDeduplicationPlugin,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SorobanService>(SorobanService);
+  });
+
+  describe('submitTransaction with deduplication', () => {
+    it('should pass through deduplication check for new job', async () => {
+      const job: SorobanTxJob = {
+        contractMethod: 'register_blood',
+        args: ['bank-123', 'O+', 100],
+        idempotencyKey: 'new-tx-1',
+      };
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(true);
+
+      const jobId = await service.submitTransaction(job);
+
+      expect(jobId).toBe('new-tx-1');
+      expect(mockDeduplicationPlugin.checkAndSetJobDedup).toHaveBeenCalledWith(
+        'register_blood',
+        ['bank-123', 'O+', 100],
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).toHaveBeenCalled();
+    });
+
+    it('should reject job if deduplication suppresses it', async () => {
+      const job: SorobanTxJob = {
+        contractMethod: 'register_blood',
+        args: ['bank-123', 'O+', 100],
+        idempotencyKey: 'dup-tx-1',
+      };
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(false); // Suppressed
+
+      await expect(service.submitTransaction(job)).rejects.toThrow(
+        'Duplicate job - equivalent job enqueued recently',
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should reject if idempotency key exists (even if dedup passes)', async () => {
+      const job: SorobanTxJob = {
+        contractMethod: 'register_blood',
+        args: ['bank-123', 'O+', 100],
+        idempotencyKey: 'existing-key',
+      };
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        false,
+      ); // Already exists
+
+      await expect(service.submitTransaction(job)).rejects.toThrow(
+        'Duplicate submission - idempotency key already exists',
+      );
+
+      // Should reject before checking dedup
+      expect(
+        mockDeduplicationPlugin.checkAndSetJobDedup,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should suppress multiple rapid submissions of equivalent jobs', async () => {
+      const job1: SorobanTxJob = {
+        contractMethod: 'order_payment',
+        args: ['order-456', 50],
+        idempotencyKey: 'pay-1',
+      };
+
+      const job2: SorobanTxJob = {
+        contractMethod: 'order_payment',
+        args: ['order-456', 50], // Same payload, different idempotency key
+        idempotencyKey: 'pay-2',
+      };
+
+      // First submission succeeds
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(true);
+      const result1 = await service.submitTransaction(job1);
+      expect(result1).toBe('pay-1');
+
+      // Second submission blocked by dedup (same payload)
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(false); // Suppressed
+
+      await expect(service.submitTransaction(job2)).rejects.toThrow(
+        'Duplicate job - equivalent job enqueued recently',
+      );
+
+      // Verify only one job added to queue
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow same payload after dedup window expired', async () => {
+      const job: SorobanTxJob = {
+        contractMethod: 'batch_operation',
+        args: ['data-set'],
+        idempotencyKey: 'batch-1',
+      };
+
+      // First submission
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(true);
+      const result1 = await service.submitTransaction(job);
+      expect(result1).toBe('batch-1');
+
+      // Same payload, new idempotency key, after dedup window
+      const job2 = {
+        ...job,
+        idempotencyKey: 'batch-2',
+      };
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(true); // Window expired
+      const result2 = await service.submitTransaction(job2);
+      expect(result2).toBe('batch-2');
+
+      // Verify both jobs added to queue
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).toHaveBeenCalledTimes(2);
+    });
+
+    it('should call dedup with correct contract method and args', async () => {
+      const job: SorobanTxJob = {
+        contractMethod: 'complex_operation',
+        args: [{ nested: { field: 'value' } }, [1, 2, 3], null, undefined],
+        idempotencyKey: 'complex-1',
+      };
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+        true,
+      );
+      mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(true);
+
+      await service.submitTransaction(job);
+
+      expect(mockDeduplicationPlugin.checkAndSetJobDedup).toHaveBeenCalledWith(
+        'complex_operation',
+        [{ nested: { field: 'value' } }, [1, 2, 3], null, undefined],
+      );
+    });
+  });
+
+  describe('Job Deduplication Acceptance Tests', () => {
+    it('should verify duplicate job suppression across high-volume submissions', async () => {
+      const baseJob: SorobanTxJob = {
+        contractMethod: 'user_event',
+        args: ['user-123', 'login'],
+        idempotencyKey: '',
+      };
+
+      // Simulate high-volume scenario: 10 rapid submissions of same event
+      const results: { allowed: boolean; error?: string }[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        const job = {
+          ...baseJob,
+          idempotencyKey: `event-${i}`,
+        };
+
+        mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValueOnce(
+          true,
+        );
+
+        // Only first is allowed, rest are suppressed
+        const isDedupNew = i === 0;
+        mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(
+          isDedupNew,
+        );
+
+        try {
+          await service.submitTransaction(job);
+          results.push({ allowed: true });
+        } catch (error) {
+          results.push({ allowed: false, error: (error as Error).message });
+        }
+      }
+
+      // Verify only 1 allowed, 9 suppressed
+      const allowedCount = results.filter((r) => r.allowed).length;
+      expect(allowedCount).toBe(1);
+
+      // Verify queue received only 1 job
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should demonstrate queue bloat prevention', async () => {
+      const createJob = (index: number): SorobanTxJob => ({
+        contractMethod: 'process_order',
+        args: ['order-id', 100], // Repeated args
+        idempotencyKey: `order-${index}`,
+      });
+
+      // Without deduplication, all 50 jobs would be queued
+      // With deduplication, only 1 queued, 49 suppressed
+
+      mockIdempotencyService.checkAndSetIdempotencyKey.mockResolvedValue(true);
+
+      for (let i = 0; i < 50; i++) {
+        const isDedupNew = i === 0;
+        mockDeduplicationPlugin.checkAndSetJobDedup.mockResolvedValueOnce(
+          isDedupNew,
+        );
+
+        try {
+          await service.submitTransaction(createJob(i));
+        } catch {
+          // Suppress expected errors for duplicates
+        }
+      }
+
+      // Only first job added to queue - bloat prevented
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockTxQueue.add).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/src/blockchain/tests/soroban.service.spec.ts
+++ b/backend/src/blockchain/tests/soroban.service.spec.ts
@@ -3,6 +3,7 @@
 import { getQueueToken } from '@nestjs/bull';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
 import { IdempotencyService } from '../services/idempotency.service';
 import { SorobanService } from '../services/soroban.service';
 import { SorobanTxJob } from '../types/soroban-tx.types';
@@ -20,6 +21,9 @@ describe('SorobanService', () => {
   };
   let mockIdempotencyService: {
     checkAndSetIdempotencyKey: jest.Mock;
+  };
+  let mockDeduplicationPlugin: {
+    checkAndSetJobDedup: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -42,6 +46,10 @@ describe('SorobanService', () => {
       checkAndSetIdempotencyKey: jest.fn().mockResolvedValue(true),
     };
 
+    mockDeduplicationPlugin = {
+      checkAndSetJobDedup: jest.fn().mockResolvedValue(true),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SorobanService,
@@ -56,6 +64,10 @@ describe('SorobanService', () => {
         {
           provide: IdempotencyService,
           useValue: mockIdempotencyService,
+        },
+        {
+          provide: JobDeduplicationPlugin,
+          useValue: mockDeduplicationPlugin,
         },
       ],
     }).compile();


### PR DESCRIPTION
This PR closes #268

- Add JobDeduplicationPlugin to prevent queue bloat from rapid equivalent job submissions
- Uses Redis-backed dedup window (10s default) with SHA256 hash of normalized payload
- Handles object argument normalization to catch equivalent jobs with different references
- Integrated into SorobanService.submitTransaction() flow after idempotency check
- Comprehensive test suite with 14 unit tests + 8 integration tests validating acceptance criteria
- Prevents queue bloat while allowing legitimate batch resubmissions after window expires