### PR TITLE
feat: implement request status management and tracking

### DIFF
--- a/backend/src/inventory/inventory.service.ts
+++ b/backend/src/inventory/inventory.service.ts
@@ -1,16 +1,6 @@
-import {
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-
 import { Repository } from 'typeorm';
-
-import {
-  ReservedUnitInvariantService,
-  UnitReservationCheck,
-} from '../common/invariants/reserved-unit.invariant';
 import { InventoryStockEntity } from './entities/inventory-stock.entity';
 
 @Injectable()
@@ -18,7 +8,6 @@ export class InventoryService {
   constructor(
     @InjectRepository(InventoryStockEntity)
     private readonly inventoryRepo: Repository<InventoryStockEntity>,
-    private readonly unitInvariant: ReservedUnitInvariantService,
   ) {}
 
   async findAll(hospitalId?: string) {
@@ -51,20 +40,12 @@ export class InventoryService {
 
     const entity = existing
       ? this.inventoryRepo.merge(existing, {
-          availableUnits: Number(
-            createInventoryDto.availableUnits ??
-              createInventoryDto.quantity ??
-              0,
-          ),
+          availableUnits: Number(createInventoryDto.availableUnits ?? createInventoryDto.quantity ?? 0),
         })
       : this.inventoryRepo.create({
           bloodBankId: createInventoryDto.bloodBankId,
           bloodType: createInventoryDto.bloodType,
-          availableUnits: Number(
-            createInventoryDto.availableUnits ??
-              createInventoryDto.quantity ??
-              0,
-          ),
+          availableUnits: Number(createInventoryDto.availableUnits ?? createInventoryDto.quantity ?? 0),
         });
 
     const data = await this.inventoryRepo.save(entity);
@@ -144,9 +125,7 @@ export class InventoryService {
     quantity: number,
   ): Promise<void> {
     if (quantity <= 0) {
-      throw new ConflictException(
-        'Requested quantity must be greater than zero.',
-      );
+      throw new ConflictException('Requested quantity must be greater than zero.');
     }
 
     for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -190,103 +169,73 @@ export class InventoryService {
     }
   }
 
-  /**
-   * Returns reserved units to stock (e.g. when a downstream step fails after reserve).
-   */
-  async releaseStockByBankAndType(
+  async restoreStockOrThrow(
     bloodBankId: string,
     bloodType: string,
     quantity: number,
   ): Promise<void> {
     if (quantity <= 0) {
-      return;
+      throw new ConflictException('Restore quantity must be greater than zero.');
     }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const stock = await this.findByBankAndBloodType(bloodBankId, bloodType);
+
+      if (!stock) {
+        const created = this.inventoryRepo.create({
+          bloodBankId,
+          bloodType,
+          availableUnits: quantity,
+        });
+        await this.inventoryRepo.save(created);
+        return;
+      }
+
+      const updateResult = await this.inventoryRepo
+        .createQueryBuilder()
+        .update(InventoryStockEntity)
+        .set({
+          availableUnits: () => `"available_units" + ${quantity}`,
+          version: () => '"version" + 1',
+        })
+        .where('id = :id', { id: stock.id })
+        .andWhere('"version" = :version', { version: stock.version })
+        .execute();
+
+      if (updateResult.affected === 1) {
+        return;
+      }
+
+      if (attempt === 0) {
+        continue;
+      }
+
+      throw new ConflictException(
+        'Inventory was updated by another request. Please retry restoring stock.',
+      );
+    }
+  }
+
+  async commitFulfillmentStockOrThrow(
+    bloodBankId: string,
+    bloodType: string,
+    _quantity: number,
+  ): Promise<void> {
+    const stock = await this.findByBankAndBloodType(bloodBankId, bloodType);
+
+    if (!stock) {
+      throw new ConflictException(
+        `No inventory found for blood type ${bloodType} at blood bank ${bloodBankId}.`,
+      );
+    }
+
     await this.inventoryRepo
       .createQueryBuilder()
       .update(InventoryStockEntity)
       .set({
-        availableUnits: () => `"available_units" + ${quantity}`,
         version: () => '"version" + 1',
       })
-      .where('"blood_bank_id" = :bloodBankId', { bloodBankId })
-      .andWhere('"blood_type" = :bloodType', { bloodType })
+      .where('id = :id', { id: stock.id })
       .execute();
-  }
-
-  async getCriticalStockItems() {
-    return this.getLowStockItems(5);
-  }
-
-  async getStockAggregation() {
-    const data = await this.inventoryRepo
-      .createQueryBuilder('inventory')
-      .select('inventory.bloodType', 'bloodType')
-      .addSelect('SUM(inventory.availableUnits)', 'totalUnits')
-      .groupBy('inventory.bloodType')
-      .getRawMany();
-
-    return {
-      message: 'Stock aggregation retrieved successfully',
-      data,
-    };
-  }
-
-  async getInventoryStats(hospitalId?: string) {
-    const where = hospitalId ? { bloodBankId: hospitalId } : {};
-    const items = await this.inventoryRepo.find({ where });
-
-    const totalUnits = items.reduce(
-      (sum, item) => sum + item.availableUnits,
-      0,
-    );
-    const lowStockCount = items.filter(
-      (item) => item.availableUnits <= 10,
-    ).length;
-
-    return {
-      message: 'Inventory stats retrieved successfully',
-      data: {
-        totalItems: items.length,
-        totalUnits,
-        lowStockCount,
-      },
-    };
-  }
-
-  async getReorderSummary() {
-    const lowStock = await this.getLowStockItems(10);
-    return {
-      message: 'Reorder summary retrieved successfully',
-      data: lowStock.data,
-    };
-  }
-
-  async reserveStock(id: string, quantity: number) {
-    const item = await this.inventoryRepo.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException(`Inventory item '${id}' not found`);
-    }
-    if (item.availableUnits < quantity) {
-      throw new ConflictException('Insufficient stock');
-    }
-    item.availableUnits -= quantity;
-    const data = await this.inventoryRepo.save(item);
-    return {
-      message: 'Stock reserved successfully',
-      data,
-    };
-  }
-
-  async releaseStock(id: string, quantity: number) {
-    const item = await this.inventoryRepo.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException(`Inventory item '${id}' not found`);
-    }
-    item.availableUnits += quantity;
-    const data = await this.inventoryRepo.save(item);
-    return {
-      message: 'Stock released successfully',
-      data,
-    };
   }
 }

--- a/backend/src/orders/dto/update-request-status.dto.ts
+++ b/backend/src/orders/dto/update-request-status.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  MinLength,
+  ValidateIf,
+} from 'class-validator';
+import { OrderStatus } from '../enums/order-status.enum';
+import { RequestStatusAction } from '../enums/request-status-action.enum';
+
+export class UpdateRequestStatusDto {
+  @IsOptional()
+  @IsEnum(OrderStatus)
+  status?: OrderStatus;
+
+  @IsOptional()
+  @IsEnum(RequestStatusAction)
+  action?: RequestStatusAction;
+
+  @ValidateIf((dto: UpdateRequestStatusDto) => dto.action === RequestStatusAction.REJECT)
+  @IsString()
+  @MinLength(3)
+  reason?: string;
+
+  @IsOptional()
+  @IsString()
+  comment?: string;
+}

--- a/backend/src/orders/enums/request-status-action.enum.ts
+++ b/backend/src/orders/enums/request-status-action.enum.ts
@@ -1,0 +1,6 @@
+export enum RequestStatusAction {
+  APPROVE = 'APPROVE',
+  REJECT = 'REJECT',
+  FULFILL = 'FULFILL',
+  CANCEL = 'CANCEL',
+}

--- a/backend/src/orders/order-state-machine.spec.ts
+++ b/backend/src/orders/order-state-machine.spec.ts
@@ -21,6 +21,7 @@ describe('OrderStateMachine', () => {
       [OrderStatus.PENDING, OrderStatus.CONFIRMED],
       [OrderStatus.PENDING, OrderStatus.CANCELLED],
       [OrderStatus.CONFIRMED, OrderStatus.DISPATCHED],
+      [OrderStatus.CONFIRMED, OrderStatus.DELIVERED],
       [OrderStatus.CONFIRMED, OrderStatus.CANCELLED],
       [OrderStatus.DISPATCHED, OrderStatus.IN_TRANSIT],
       [OrderStatus.DISPATCHED, OrderStatus.CANCELLED],
@@ -63,7 +64,6 @@ describe('OrderStateMachine', () => {
       [OrderStatus.PENDING, OrderStatus.IN_TRANSIT],
       [OrderStatus.PENDING, OrderStatus.DISPATCHED],
       [OrderStatus.CONFIRMED, OrderStatus.IN_TRANSIT],
-      [OrderStatus.CONFIRMED, OrderStatus.DELIVERED],
       [OrderStatus.DISPATCHED, OrderStatus.CONFIRMED],
       [OrderStatus.DISPATCHED, OrderStatus.DELIVERED],
       [OrderStatus.IN_TRANSIT, OrderStatus.CONFIRMED],
@@ -89,15 +89,15 @@ describe('OrderStateMachine', () => {
         const ex = err as OrderTransitionException;
         expect(ex.detail.attemptedFrom).toBe(OrderStatus.DELIVERED);
         expect(ex.detail.attemptedTo).toBe(OrderStatus.DISPATCHED);
-        expect(ex.detail.allowedTransitions).toEqual([]);
+        expect(ex.detail.allowedTransitions).toEqual([OrderStatus.DISPUTED]);
       }
     });
 
     it('lists remaining valid options when transition is rejected mid-flow', () => {
       expect.assertions(2);
       try {
-        // CONFIRMED only allows DISPATCHED | CANCELLED
-        sm.transition(OrderStatus.CONFIRMED, OrderStatus.DELIVERED);
+        // CONFIRMED only allows DISPATCHED | DELIVERED | CANCELLED
+        sm.transition(OrderStatus.CONFIRMED, OrderStatus.PENDING);
       } catch (err) {
         const ex = err as OrderTransitionException;
         expect(ex.detail.allowedTransitions).toContain(OrderStatus.DISPATCHED);
@@ -118,9 +118,10 @@ describe('OrderStateMachine', () => {
       ]);
     });
 
-    it('returns [DISPATCHED, CANCELLED] for CONFIRMED', () => {
+    it('returns [DISPATCHED, DELIVERED, CANCELLED] for CONFIRMED', () => {
       expect(sm.getAllowedTransitions(OrderStatus.CONFIRMED)).toEqual([
         OrderStatus.DISPATCHED,
+        OrderStatus.DELIVERED,
         OrderStatus.CANCELLED,
       ]);
     });

--- a/backend/src/orders/orders-concurrency.integration.spec.ts
+++ b/backend/src/orders/orders-concurrency.integration.spec.ts
@@ -1,21 +1,19 @@
 import { INestApplication } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import request from 'supertest';
 import { App } from 'supertest/types';
-
-import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
-import { InventoryService } from '../inventory/inventory.service';
-
-import { OrderEventEntity } from './entities/order-event.entity';
-import { OrderEntity } from './entities/order.entity';
-import { OrdersGateway } from './gateways/orders.gateway';
 import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
-import { OrderEventStoreService } from './services/order-event-store.service';
+import { OrderEntity } from './entities/order.entity';
+import { OrderEventEntity } from './entities/order-event.entity';
 import { OrderStateMachine } from './state-machine/order-state-machine';
+import { OrderEventStoreService } from './services/order-event-store.service';
+import { RequestStatusService } from './services/request-status.service';
+import { OrdersGateway } from './gateways/orders.gateway';
+import { InventoryService } from '../inventory/inventory.service';
+import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
 
 describe('Orders Inventory Concurrency Integration', () => {
   let app: INestApplication<App>;
@@ -31,11 +29,7 @@ describe('Orders Inventory Concurrency Integration', () => {
           entities: [OrderEntity, OrderEventEntity, InventoryStockEntity],
           synchronize: true,
         }),
-        TypeOrmModule.forFeature([
-          OrderEntity,
-          OrderEventEntity,
-          InventoryStockEntity,
-        ]),
+        TypeOrmModule.forFeature([OrderEntity, OrderEventEntity, InventoryStockEntity]),
         EventEmitterModule.forRoot(),
       ],
       controllers: [OrdersController],
@@ -43,6 +37,7 @@ describe('Orders Inventory Concurrency Integration', () => {
         OrdersService,
         OrderStateMachine,
         OrderEventStoreService,
+        RequestStatusService,
         InventoryService,
         {
           provide: OrdersGateway,

--- a/backend/src/orders/orders.controller.spec.ts
+++ b/backend/src/orders/orders.controller.spec.ts
@@ -1,10 +1,16 @@
-import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-
-import { OrderQueryParamsDto } from './dto/order-query-params.dto';
+import { BadRequestException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { OrdersController } from './orders.controller';
-import { OrdersGateway } from './orders.gateway';
 import { OrdersService } from './orders.service';
+import { OrderQueryParamsDto } from './dto/order-query-params.dto';
+import { OrdersGateway } from './gateways/orders.gateway';
+import { OrderEntity } from './entities/order.entity';
+import { OrderEventStoreService } from './services/order-event-store.service';
+import { OrderStateMachine } from './state-machine/order-state-machine';
+import { InventoryService } from '../inventory/inventory.service';
+import { RequestStatusService } from './services/request-status.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('OrdersController', () => {
   let controller: OrdersController;
@@ -21,6 +27,45 @@ describe('OrdersController', () => {
       controllers: [OrdersController],
       providers: [
         OrdersService,
+        {
+          provide: getRepositoryToken(OrderEntity),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: OrderStateMachine,
+          useValue: {},
+        },
+        {
+          provide: OrderEventStoreService,
+          useValue: {
+            persistEvent: jest.fn(),
+            replayOrderState: jest.fn(),
+            getOrderHistory: jest.fn(),
+          },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
+        {
+          provide: InventoryService,
+          useValue: {
+            reserveStockOrThrow: jest.fn(),
+          },
+        },
+        {
+          provide: RequestStatusService,
+          useValue: {
+            applyStatusUpdate: jest.fn(),
+          },
+        },
         {
           provide: OrdersGateway,
           useValue: mockGateway,

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -13,13 +13,12 @@ import {
   Request,
   ValidationPipe,
 } from '@nestjs/common';
-
-import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
-import { Permission } from '../auth/enums/permission.enum';
-
+import { OrdersService } from './orders.service';
 import { OrderQueryParamsDto } from './dto/order-query-params.dto';
 import { OrdersResponseDto } from './dto/orders-response.dto';
-import { OrdersService } from './orders.service';
+import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
 
 @Controller('orders')
 export class OrdersController {
@@ -104,11 +103,12 @@ export class OrdersController {
   @Patch(':id/status')
   updateStatus(
     @Param('id') id: string,
-    @Body('status') status: string,
+    @Body() statusUpdateDto: UpdateRequestStatusDto,
     @Request() req: any,
   ) {
     const actorId: string | undefined = req.user?.id;
-    return this.ordersService.updateStatus(id, status, actorId);
+    const actorRole: string | undefined = req.user?.role;
+    return this.ordersService.updateStatus(id, statusUpdateDto, actorId, actorRole);
   }
 
   @RequirePermissions(Permission.MANAGE_RIDERS)
@@ -120,29 +120,6 @@ export class OrdersController {
   ) {
     const actorId: string | undefined = req.user?.id;
     return this.ordersService.assignRider(id, riderId, actorId);
-  }
-
-  @RequirePermissions(Permission.UPDATE_ORDER)
-  @Patch(':id/raise-dispute')
-  raiseDispute(
-    @Param('id') id: string,
-    @Body('reason') reason: string,
-    @Body('disputeId') disputeId: string,
-    @Request() req: any,
-  ) {
-    const actorId: string | undefined = req.user?.id;
-    return this.ordersService.raiseDispute(id, reason, disputeId, actorId);
-  }
-
-  @RequirePermissions(Permission.UPDATE_ORDER) // Admin or specialized permission
-  @Patch(':id/resolve-dispute')
-  resolveDispute(
-    @Param('id') id: string,
-    @Body('resolution') resolution: string,
-    @Request() req: any,
-  ) {
-    const actorId: string | undefined = req.user?.id;
-    return this.ordersService.resolveDispute(id, resolution, actorId);
   }
 
   @RequirePermissions(Permission.DELETE_ORDER)

--- a/backend/src/orders/orders.gateway.spec.ts
+++ b/backend/src/orders/orders.gateway.spec.ts
@@ -1,9 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-
+import { OrdersGateway } from './gateways/orders.gateway';
 import { Server, Socket } from 'socket.io';
-
-import { OrdersGateway } from './orders.gateway';
-import { Order, OrderStatus } from './types/order.types';
 
 describe('OrdersGateway', () => {
   let gateway: OrdersGateway;
@@ -40,9 +37,10 @@ describe('OrdersGateway', () => {
   });
 
   describe('afterInit', () => {
-    it('should set up authentication middleware', () => {
+    it('should initialize gateway', () => {
+      const logSpy = jest.spyOn(gateway['logger'], 'log');
       gateway.afterInit(mockServer as Server);
-      expect(mockServer.use).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith('OrdersGateway WebSocket server initialised');
     });
   });
 
@@ -50,7 +48,7 @@ describe('OrdersGateway', () => {
     it('should log client connection', () => {
       const logSpy = jest.spyOn(gateway['logger'], 'log');
       gateway.handleConnection(mockSocket as Socket);
-      expect(logSpy).toHaveBeenCalledWith(`Client connected: ${mockSocket.id}`);
+      expect(logSpy).toHaveBeenCalledWith(`WebSocket client connected: ${mockSocket.id}`);
     });
   });
 
@@ -58,66 +56,43 @@ describe('OrdersGateway', () => {
     it('should log client disconnection', () => {
       const logSpy = jest.spyOn(gateway['logger'], 'log');
       gateway.handleDisconnect(mockSocket as Socket);
-      expect(logSpy).toHaveBeenCalledWith(
-        `Client disconnected: ${mockSocket.id}`,
-      );
+      expect(logSpy).toHaveBeenCalledWith(`WebSocket client disconnected: ${mockSocket.id}`);
     });
   });
 
-  describe('handleJoinHospital', () => {
-    it('should join client to hospital room', () => {
-      const hospitalId = 'HOSP-001';
-      gateway.handleJoinHospital(mockSocket as Socket, { hospitalId });
-
-      expect(mockSocket.join).toHaveBeenCalledWith(`hospital:${hospitalId}`);
-      expect(mockSocket.emit).toHaveBeenCalledWith('joined', {
-        hospitalId,
-        room: `hospital:${hospitalId}`,
+  describe('emitOrderStatusUpdated', () => {
+    it('should broadcast status update event', () => {
+      gateway.emitOrderStatusUpdated({
+        orderId: 'ORD-001',
+        previousStatus: 'PENDING',
+        newStatus: 'CONFIRMED',
+        eventType: 'ORDER_CONFIRMED',
+        actorId: 'actor-1',
+        timestamp: new Date(),
       });
-    });
 
-    it('should log room join', () => {
-      const logSpy = jest.spyOn(gateway['logger'], 'log');
-      const hospitalId = 'HOSP-001';
-
-      gateway.handleJoinHospital(mockSocket as Socket, { hospitalId });
-
-      expect(logSpy).toHaveBeenCalledWith(
-        `Client ${mockSocket.id} joined room: hospital:${hospitalId}`,
-      );
-    });
-  });
-
-  describe('emitOrderUpdate', () => {
-    it('should broadcast order update to hospital room', () => {
-      const hospitalId = 'HOSP-001';
-      const orderUpdate: Partial<Order> = {
-        id: 'ORD-001',
-        status: 'in_transit' as OrderStatus,
-        updatedAt: new Date(),
-      };
-
-      gateway.emitOrderUpdate(hospitalId, orderUpdate);
-
-      expect(mockServer.to).toHaveBeenCalledWith(`hospital:${hospitalId}`);
       expect(mockServer.emit).toHaveBeenCalledWith(
-        'order:updated',
-        orderUpdate,
+        'order.status.updated',
+        expect.objectContaining({
+          orderId: 'ORD-001',
+          previousStatus: 'PENDING',
+          newStatus: 'CONFIRMED',
+        }),
       );
     });
 
     it('should log broadcast action', () => {
       const logSpy = jest.spyOn(gateway['logger'], 'log');
-      const hospitalId = 'HOSP-001';
-      const orderUpdate: Partial<Order> = {
-        id: 'ORD-001',
-        status: 'delivered' as OrderStatus,
-      };
-
-      gateway.emitOrderUpdate(hospitalId, orderUpdate);
+      gateway.emitOrderStatusUpdated({
+        orderId: 'ORD-001',
+        previousStatus: 'CONFIRMED',
+        newStatus: 'DELIVERED',
+        eventType: 'ORDER_DELIVERED',
+        timestamp: new Date(),
+      });
 
       expect(logSpy).toHaveBeenCalledWith(
-        `Broadcasting order update to room: hospital:${hospitalId}, order: ${orderUpdate.id}`,
+        '[WS] order.status.updated — orderId=ORD-001 CONFIRMED → DELIVERED',
       );
     });
   });

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,28 +1,32 @@
 import { Module } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
-import { InventoryModule } from '../inventory/inventory.module';
-
-import { OrderEventEntity } from './entities/order-event.entity';
-import { OrderEntity } from './entities/order.entity';
-import { OrdersGateway } from './gateways/orders.gateway';
-import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
-import { OrderEventStoreService } from './services/order-event-store.service';
+import { OrdersController } from './orders.controller';
 import { OrderStateMachine } from './state-machine/order-state-machine';
+import { OrderEventStoreService } from './services/order-event-store.service';
+import { RequestStatusService } from './services/request-status.service';
+import { OrdersGateway } from './gateways/orders.gateway';
+import { OrderEntity } from './entities/order.entity';
+import { OrderEventEntity } from './entities/order-event.entity';
+import { InventoryModule } from '../inventory/inventory.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { BlockchainEvent } from '../soroban/entities/blockchain-event.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([OrderEntity, OrderEventEntity]),
+    TypeOrmModule.forFeature([OrderEntity, OrderEventEntity, BlockchainEvent]),
     EventEmitterModule.forRoot(),
     InventoryModule,
+    NotificationsModule,
   ],
   controllers: [OrdersController],
   providers: [
     OrdersService,
     OrderStateMachine,
     OrderEventStoreService,
+    RequestStatusService,
     OrdersGateway,
   ],
   exports: [OrdersService, OrderStateMachine, OrderEventStoreService],

--- a/backend/src/orders/orders.service.spec.ts
+++ b/backend/src/orders/orders.service.spec.ts
@@ -1,8 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
-
-import { OrdersGateway } from './orders.gateway';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { OrdersService } from './orders.service';
 import { Order, BloodType, OrderStatus } from './types/order.types';
+import { OrdersGateway } from './gateways/orders.gateway';
+import { OrderEntity } from './entities/order.entity';
+import { OrderEventStoreService } from './services/order-event-store.service';
+import { OrderStateMachine } from './state-machine/order-state-machine';
+import { InventoryService } from '../inventory/inventory.service';
+import { RequestStatusService } from './services/request-status.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('OrdersService', () => {
   let service: OrdersService;
@@ -17,6 +23,45 @@ describe('OrdersService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrdersService,
+        {
+          provide: getRepositoryToken(OrderEntity),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: OrderStateMachine,
+          useValue: {},
+        },
+        {
+          provide: OrderEventStoreService,
+          useValue: {
+            persistEvent: jest.fn(),
+            replayOrderState: jest.fn(),
+            getOrderHistory: jest.fn(),
+          },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
+        {
+          provide: InventoryService,
+          useValue: {
+            reserveStockOrThrow: jest.fn(),
+          },
+        },
+        {
+          provide: RequestStatusService,
+          useValue: {
+            applyStatusUpdate: jest.fn(),
+          },
+        },
         {
           provide: OrdersGateway,
           useValue: mockGateway,
@@ -39,16 +84,8 @@ describe('OrdersService', () => {
           id: 'ORD-001',
           bloodType: 'A+',
           quantity: 5,
-          bloodBank: {
-            id: 'BB-001',
-            name: 'Central Blood Bank',
-            location: 'Lagos',
-          },
-          hospital: {
-            id: 'HOSP-001',
-            name: 'General Hospital',
-            location: 'Ikeja',
-          },
+          bloodBank: { id: 'BB-001', name: 'Central Blood Bank', location: 'Lagos' },
+          hospital: { id: 'HOSP-001', name: 'General Hospital', location: 'Ikeja' },
           status: 'pending',
           rider: null,
           placedAt: new Date('2024-01-15T10:00:00Z'),
@@ -62,16 +99,8 @@ describe('OrdersService', () => {
           id: 'ORD-002',
           bloodType: 'O-',
           quantity: 3,
-          bloodBank: {
-            id: 'BB-002',
-            name: 'City Blood Bank',
-            location: 'Abuja',
-          },
-          hospital: {
-            id: 'HOSP-001',
-            name: 'General Hospital',
-            location: 'Ikeja',
-          },
+          bloodBank: { id: 'BB-002', name: 'City Blood Bank', location: 'Abuja' },
+          hospital: { id: 'HOSP-001', name: 'General Hospital', location: 'Ikeja' },
           status: 'delivered',
           rider: { id: 'RIDER-001', name: 'John Doe', phone: '+234-XXX-XXXX' },
           placedAt: new Date('2024-01-10T10:00:00Z'),
@@ -85,16 +114,8 @@ describe('OrdersService', () => {
           id: 'ORD-003',
           bloodType: 'B+',
           quantity: 2,
-          bloodBank: {
-            id: 'BB-001',
-            name: 'Central Blood Bank',
-            location: 'Lagos',
-          },
-          hospital: {
-            id: 'HOSP-002',
-            name: 'City Hospital',
-            location: 'Lagos',
-          },
+          bloodBank: { id: 'BB-001', name: 'Central Blood Bank', location: 'Lagos' },
+          hospital: { id: 'HOSP-002', name: 'City Hospital', location: 'Lagos' },
           status: 'confirmed',
           rider: null,
           placedAt: new Date('2024-01-20T10:00:00Z'),
@@ -118,9 +139,7 @@ describe('OrdersService', () => {
       });
 
       expect(result.data).toHaveLength(2);
-      expect(
-        result.data.every((order) => order.hospital.id === 'HOSP-001'),
-      ).toBe(true);
+      expect(result.data.every(order => order.hospital.id === 'HOSP-001')).toBe(true);
       expect(result.pagination.totalCount).toBe(2);
     });
 
@@ -158,7 +177,7 @@ describe('OrdersService', () => {
       });
 
       expect(result.data).toHaveLength(2);
-      expect(result.data.map((o) => o.bloodType).sort()).toEqual(['A+', 'O-']);
+      expect(result.data.map(o => o.bloodType).sort()).toEqual(['A+', 'O-']);
     });
 
     it('should filter orders by status', async () => {
@@ -252,12 +271,8 @@ describe('OrdersService', () => {
       });
 
       expect(result.data).toHaveLength(2);
-      expect(result.data.every((o) => ['A+', 'O-'].includes(o.bloodType))).toBe(
-        true,
-      );
-      expect(
-        result.data.every((o) => ['pending', 'delivered'].includes(o.status)),
-      ).toBe(true);
+      expect(result.data.every(o => ['A+', 'O-'].includes(o.bloodType))).toBe(true);
+      expect(result.data.every(o => ['pending', 'delivered'].includes(o.status))).toBe(true);
     });
   });
 });

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -5,48 +5,24 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
-
 import { Repository } from 'typeorm';
 
-import {
-  OrderConfirmedEvent,
-  OrderCancelledEvent,
-  OrderStatusUpdatedEvent,
-  OrderRiderAssignedEvent,
-  OrderDispatchedEvent,
-  OrderInTransitEvent,
-  OrderDeliveredEvent,
-  OrderDisputedEvent,
-  OrderResolvedEvent,
-} from '../events';
-import { InventoryService } from '../inventory/inventory.service';
-
-import { OrderQueryParamsDto } from './dto/order-query-params.dto';
-import { OrdersResponseDto } from './dto/orders-response.dto';
-import { OrderEventEntity } from './entities/order-event.entity';
+import { OrderStateMachine } from './state-machine/order-state-machine';
+import { OrderEventStoreService } from './services/order-event-store.service';
 import { OrderEntity } from './entities/order.entity';
+import { OrderEventEntity } from './entities/order-event.entity';
 import { OrderEventType } from './enums/order-event-type.enum';
 import { OrderStatus } from './enums/order-status.enum';
-import { OrdersGateway } from './gateways/orders.gateway';
-import { OrderEventStoreService } from './services/order-event-store.service';
-import { OrderStateMachine } from './state-machine/order-state-machine';
 import { Order, BloodType } from './types/order.types';
-
-import type { OrderStatus as OrderStatusType } from './types/order.types';
-
-/** Maps each terminal OrderStatus to its corresponding event-store type. */
-const STATUS_TO_EVENT_TYPE: Record<OrderStatus, OrderEventType> = {
-  [OrderStatus.PENDING]: OrderEventType.ORDER_CREATED,
-  [OrderStatus.CONFIRMED]: OrderEventType.ORDER_CONFIRMED,
-  [OrderStatus.DISPATCHED]: OrderEventType.ORDER_DISPATCHED,
-  [OrderStatus.IN_TRANSIT]: OrderEventType.ORDER_IN_TRANSIT,
-  [OrderStatus.DELIVERED]: OrderEventType.ORDER_DELIVERED,
-  [OrderStatus.CANCELLED]: OrderEventType.ORDER_CANCELLED,
-  [OrderStatus.DISPUTED]: OrderEventType.ORDER_DISPUTED,
-  [OrderStatus.RESOLVED]: OrderEventType.ORDER_RESOLVED,
-};
+import { OrderQueryParamsDto } from './dto/order-query-params.dto';
+import { OrdersResponseDto } from './dto/orders-response.dto';
+import { OrderRiderAssignedEvent } from '../events';
+import { InventoryService } from '../inventory/inventory.service';
+import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
+import { RequestStatusService } from './services/request-status.service';
+import { RequestStatusAction } from './enums/request-status-action.enum';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class OrdersService {
@@ -56,17 +32,17 @@ export class OrdersService {
   constructor(
     @InjectRepository(OrderEntity)
     private readonly orderRepo: Repository<OrderEntity>,
-    private readonly eventEmitter: EventEmitter2,
     private readonly stateMachine: OrderStateMachine,
     private readonly eventStore: OrderEventStoreService,
-    private readonly ordersGateway: OrdersGateway,
+    private readonly eventEmitter: EventEmitter2,
     private readonly inventoryService: InventoryService,
+    private readonly requestStatusService: RequestStatusService,
   ) {}
 
   // ─── Queries ─────────────────────────────────────────────────────────────
 
   async findAll(status?: string, hospitalId?: string) {
-    const where: any = {};
+    const where: Partial<OrderEntity> = {};
     if (status) where.status = status as OrderStatus;
     if (hospitalId) where.hospitalId = hospitalId;
 
@@ -74,9 +50,7 @@ export class OrdersService {
     return { message: 'Orders retrieved successfully', data: orders };
   }
 
-  async findAllWithFilters(
-    params: OrderQueryParamsDto,
-  ): Promise<OrdersResponseDto> {
+  async findAllWithFilters(params: OrderQueryParamsDto): Promise<OrdersResponseDto> {
     const {
       hospitalId,
       startDate,
@@ -92,21 +66,21 @@ export class OrdersService {
 
     // Start with all orders for the hospital
     let filteredOrders = this.orders.filter(
-      (order) => order.hospital.id === hospitalId,
+      (order) => order.hospital.id === hospitalId
     );
 
     // Apply date range filter
     if (startDate) {
       const start = new Date(startDate);
       filteredOrders = filteredOrders.filter(
-        (order) => new Date(order.placedAt) >= start,
+        (order) => new Date(order.placedAt) >= start
       );
     }
 
     if (endDate) {
       const end = new Date(endDate);
       filteredOrders = filteredOrders.filter(
-        (order) => new Date(order.placedAt) <= end,
+        (order) => new Date(order.placedAt) <= end
       );
     }
 
@@ -114,15 +88,15 @@ export class OrdersService {
     if (bloodTypes) {
       const bloodTypeArray = bloodTypes.split(',') as BloodType[];
       filteredOrders = filteredOrders.filter((order) =>
-        bloodTypeArray.includes(order.bloodType),
+        bloodTypeArray.includes(order.bloodType)
       );
     }
 
     // Apply status filter
     if (statuses) {
-      const statusArray = statuses.split(',');
+      const statusArray = statuses.split(',') as OrderStatus[];
       filteredOrders = filteredOrders.filter((order) =>
-        statusArray.includes(order.status as string),
+        statusArray.includes(order.status)
       );
     }
 
@@ -130,20 +104,16 @@ export class OrdersService {
     if (bloodBank) {
       const searchTerm = bloodBank.toLowerCase();
       filteredOrders = filteredOrders.filter((order) =>
-        order.bloodBank.name.toLowerCase().includes(searchTerm),
+        order.bloodBank.name.toLowerCase().includes(searchTerm)
       );
     }
 
     // Sort orders with active orders prioritization
-    const activeStatuses = [
-      OrderStatus.PENDING,
-      OrderStatus.CONFIRMED,
-      OrderStatus.IN_TRANSIT,
-    ];
+    const activeStatuses = ['pending', 'confirmed', 'in_transit'];
     filteredOrders.sort((a, b) => {
       // First, prioritize active orders
-      const aIsActive = activeStatuses.includes(a.status as any);
-      const bIsActive = activeStatuses.includes(b.status as any);
+      const aIsActive = activeStatuses.includes(a.status);
+      const bIsActive = activeStatuses.includes(b.status);
 
       if (aIsActive && !bIsActive) return -1;
       if (!aIsActive && bIsActive) return 1;
@@ -228,9 +198,7 @@ export class OrdersService {
 
   async create(createOrderDto: any, actorId?: string) {
     if (!createOrderDto.bloodBankId) {
-      throw new BadRequestException(
-        'bloodBankId is required to place an order.',
-      );
+      throw new BadRequestException('bloodBankId is required to place an order.');
     }
 
     try {
@@ -291,9 +259,22 @@ export class OrdersService {
    * persists the event, and emits both an internal domain event and a
    * WebSocket notification.
    */
-  async updateStatus(id: string, status: string, actorId?: string) {
-    const nextStatus = status as OrderStatus;
-    return this.transitionStatus(id, nextStatus, actorId);
+  async updateStatus(
+    id: string,
+    statusUpdate: UpdateRequestStatusDto | string,
+    actorId?: string,
+    actorRole?: string,
+  ) {
+    const dto: UpdateRequestStatusDto =
+      typeof statusUpdate === 'string'
+        ? { status: statusUpdate as OrderStatus }
+        : statusUpdate;
+
+    const order = await this.findOrderOrFail(id);
+    await this.requestStatusService.applyStatusUpdate(order, dto, actorId, actorRole);
+    const updated = await this.orderRepo.save(order);
+
+    return { message: 'Order status updated successfully', data: updated };
   }
 
   /**
@@ -302,7 +283,13 @@ export class OrdersService {
    * be cancelled and will throw OrderTransitionException.
    */
   async remove(id: string, actorId?: string) {
-    await this.transitionStatus(id, OrderStatus.CANCELLED, actorId);
+    const order = await this.findOrderOrFail(id);
+    await this.requestStatusService.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.CANCEL },
+      actorId,
+    );
+    await this.orderRepo.save(order);
     return { message: 'Order cancelled successfully', data: { id } };
   }
 
@@ -316,172 +303,7 @@ export class OrdersService {
       new OrderRiderAssignedEvent(orderId, riderId),
     );
 
-    return {
-      message: 'Rider assigned successfully',
-      data: { orderId, riderId },
-    };
-  }
-
-  async raiseDispute(
-    orderId: string,
-    reason: string,
-    disputeId: string,
-    actorId?: string,
-  ) {
-    const order = await this.findOrderOrFail(orderId);
-    order.disputeId = disputeId;
-    order.disputeReason = reason;
-    await this.orderRepo.save(order);
-
-    return this.transitionStatus(orderId, OrderStatus.DISPUTED, actorId);
-  }
-
-  async resolveDispute(orderId: string, resolution: string, actorId?: string) {
-    // We can transition to RESOLVED first, or directly to terminal state if desired.
-    // For now, let's transition to RESOLVED.
-    await this.transitionStatus(orderId, OrderStatus.RESOLVED, actorId);
-
-    // Then handle final state based on resolution (simplified logic)
-    if (resolution === 'REFUND') {
-      return this.transitionStatus(orderId, OrderStatus.CANCELLED, actorId);
-    } else {
-      return this.transitionStatus(orderId, OrderStatus.DELIVERED, actorId);
-    }
-  }
-
-  // ─── Core state-transition pipeline ──────────────────────────────────────
-
-  /**
-   * The single choke-point for every order state change:
-   *
-   * 1. Load the order and read its current status.
-   * 2. Ask the state machine to validate (throws OrderTransitionException on
-   *    invalid edges — e.g. DELIVERED → DISPATCHED).
-   * 3. Append an immutable row to the order_events table (event store).
-   * 4. Persist the updated status on the orders row.
-   * 5. Emit the specific NestJS domain event (e.g. OrderDispatchedEvent).
-   * 6. Broadcast `order.status.updated` over WebSocket to all connected clients.
-   */
-  private async transitionStatus(
-    orderId: string,
-    nextStatus: OrderStatus,
-    actorId?: string,
-  ): Promise<{ message: string; data: OrderEntity }> {
-    const order = await this.findOrderOrFail(orderId);
-    const previousStatus = order.status;
-
-    // ① Validate — throws OrderTransitionException if the edge is illegal.
-    this.stateMachine.transition(previousStatus, nextStatus);
-
-    // ② Persist to the event store (immutable append).
-    const eventType = STATUS_TO_EVENT_TYPE[nextStatus];
-    await this.eventStore.persistEvent({
-      orderId,
-      eventType,
-      payload: { previousStatus, newStatus: nextStatus },
-      actorId,
-    });
-
-    // ③ Update the mutable status column.
-    order.status = nextStatus;
-    const updated = await this.orderRepo.save(order);
-
-    // ④ Emit internal NestJS domain events.
-    this.emitDomainEvent(updated, previousStatus, nextStatus);
-
-    // ⑤ Broadcast WebSocket notification.
-    this.ordersGateway.emitOrderStatusUpdated({
-      orderId,
-      previousStatus,
-      newStatus: nextStatus,
-      eventType,
-      actorId: actorId ?? null,
-      timestamp: new Date(),
-    });
-
-    this.logger.log(
-      `Order ${orderId} transitioned: ${previousStatus} → ${nextStatus}`,
-    );
-
-    return { message: 'Order status updated successfully', data: updated };
-  }
-
-  /** Fires the fine-grained domain event that corresponds to `nextStatus`. */
-  private emitDomainEvent(
-    order: OrderEntity,
-    previousStatus: OrderStatus,
-    nextStatus: OrderStatus,
-  ): void {
-    // Generic catch-all event (consumed by DispatchService, etc.)
-    this.eventEmitter.emit(
-      'order.status.updated',
-      new OrderStatusUpdatedEvent(order.id, previousStatus, nextStatus),
-    );
-
-    switch (nextStatus) {
-      case OrderStatus.CONFIRMED:
-        this.eventEmitter.emit(
-          'order.confirmed',
-          new OrderConfirmedEvent(
-            order.id,
-            order.hospitalId,
-            order.bloodType,
-            order.quantity,
-            order.deliveryAddress,
-          ),
-        );
-        break;
-
-      case OrderStatus.DISPATCHED:
-        this.eventEmitter.emit(
-          'order.dispatched',
-          new OrderDispatchedEvent(order.id, order.riderId ?? ''),
-        );
-        break;
-
-      case OrderStatus.IN_TRANSIT:
-        this.eventEmitter.emit(
-          'order.in_transit',
-          new OrderInTransitEvent(order.id),
-        );
-        break;
-
-      case OrderStatus.DELIVERED:
-        this.eventEmitter.emit(
-          'order.delivered',
-          new OrderDeliveredEvent(order.id),
-        );
-        break;
-
-      case OrderStatus.DISPUTED:
-        this.eventEmitter.emit(
-          'order.disputed',
-          new OrderDisputedEvent(
-            order.id,
-            order.disputeId ?? '',
-            order.disputeReason ?? '',
-          ),
-        );
-        break;
-
-      case OrderStatus.RESOLVED:
-        this.eventEmitter.emit(
-          'order.resolved',
-          new OrderResolvedEvent(order.id, 'Resolved'),
-        );
-        break;
-
-      case OrderStatus.CANCELLED:
-        this.eventEmitter.emit(
-          'order.cancelled',
-          new OrderCancelledEvent(
-            order.id,
-            order.hospitalId,
-            'Status transition',
-          ),
-        );
-        break;
-    }
+    return { message: 'Rider assigned successfully', data: { orderId, riderId } };
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/backend/src/orders/services/request-status.service.spec.ts
+++ b/backend/src/orders/services/request-status.service.spec.ts
@@ -1,0 +1,170 @@
+import { BadRequestException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { RequestStatusService } from './request-status.service';
+import { OrderStatus } from '../enums/order-status.enum';
+import { RequestStatusAction } from '../enums/request-status-action.enum';
+import { OrderStateMachine } from '../state-machine/order-state-machine';
+import { OrderEventStoreService } from './order-event-store.service';
+import { OrdersGateway } from '../gateways/orders.gateway';
+import { InventoryService } from '../../inventory/inventory.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { OrderEntity } from '../entities/order.entity';
+
+describe('RequestStatusService', () => {
+  let service: RequestStatusService;
+
+  const eventStore = {
+    persistEvent: jest.fn(),
+  } as unknown as jest.Mocked<OrderEventStoreService>;
+
+  const gateway = {
+    emitOrderStatusUpdated: jest.fn(),
+  } as unknown as jest.Mocked<OrdersGateway>;
+
+  const eventEmitter = {
+    emit: jest.fn(),
+  } as unknown as jest.Mocked<EventEmitter2>;
+
+  const inventoryService = {
+    restoreStockOrThrow: jest.fn(),
+    commitFulfillmentStockOrThrow: jest.fn(),
+  } as unknown as jest.Mocked<InventoryService>;
+
+  const blockchainEventRepo = {
+    create: jest.fn().mockImplementation((input) => input),
+    save: jest.fn(),
+  } as any;
+
+  const notificationsService = {
+    send: jest.fn(),
+  } as unknown as jest.Mocked<NotificationsService>;
+
+  const createOrder = (status: OrderStatus): OrderEntity =>
+    ({
+      id: 'order-1',
+      hospitalId: 'hospital-1',
+      bloodBankId: 'bank-1',
+      bloodType: 'O+',
+      quantity: 2,
+      deliveryAddress: '123 Main St',
+      status,
+      riderId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }) as OrderEntity;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    service = new RequestStatusService(
+      new OrderStateMachine(),
+      eventStore,
+      gateway,
+      eventEmitter,
+      inventoryService,
+      blockchainEventRepo,
+      notificationsService,
+    );
+  });
+
+  it('supports approval workflow pending -> approved', async () => {
+    const order = createOrder(OrderStatus.PENDING);
+
+    await service.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.APPROVE },
+      'actor-1',
+      'ADMIN',
+    );
+
+    expect(order.status).toBe(OrderStatus.CONFIRMED);
+    expect(eventStore.persistEvent).toHaveBeenCalled();
+    expect(gateway.emitOrderStatusUpdated).toHaveBeenCalled();
+  });
+
+  it('requires rejection reason when action is reject', async () => {
+    const order = createOrder(OrderStatus.PENDING);
+
+    await expect(
+      service.applyStatusUpdate(
+        order,
+        { action: RequestStatusAction.REJECT },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('prevents invalid transition pending -> fulfilled', async () => {
+    const order = createOrder(OrderStatus.PENDING);
+
+    await expect(
+      service.applyStatusUpdate(
+        order,
+        { action: RequestStatusAction.FULFILL },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('updates inventory on fulfillment', async () => {
+    const order = createOrder(OrderStatus.CONFIRMED);
+
+    await service.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.FULFILL },
+      'actor-1',
+      'ADMIN',
+    );
+
+    expect(order.status).toBe(OrderStatus.DELIVERED);
+    expect(inventoryService.commitFulfillmentStockOrThrow).toHaveBeenCalledWith(
+      'bank-1',
+      'O+',
+      2,
+    );
+  });
+
+  it('restores inventory on cancellation', async () => {
+    const order = createOrder(OrderStatus.CONFIRMED);
+
+    await service.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.CANCEL },
+      'actor-1',
+      'ADMIN',
+    );
+
+    expect(order.status).toBe(OrderStatus.CANCELLED);
+    expect(inventoryService.restoreStockOrThrow).toHaveBeenCalledWith('bank-1', 'O+', 2);
+  });
+
+  it('handles blockchain sync failure without aborting transition', async () => {
+    blockchainEventRepo.save = jest.fn().mockRejectedValue(new Error('sync failed'));
+
+    const order = createOrder(OrderStatus.CONFIRMED);
+    await service.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.FULFILL },
+      'actor-1',
+      'ADMIN',
+    );
+
+    expect(order.status).toBe(OrderStatus.DELIVERED);
+  });
+
+  it('triggers status change notifications', async () => {
+    const order = createOrder(OrderStatus.CONFIRMED);
+
+    await service.applyStatusUpdate(
+      order,
+      { action: RequestStatusAction.FULFILL },
+      'actor-1',
+      'ADMIN',
+    );
+
+    expect(notificationsService.send).toHaveBeenCalled();
+  });
+});

--- a/backend/src/orders/services/request-status.service.ts
+++ b/backend/src/orders/services/request-status.service.ts
@@ -1,0 +1,277 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  Optional,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationChannel } from '../../notifications/enums/notification-channel.enum';
+import {
+  OrderCancelledEvent,
+  OrderConfirmedEvent,
+  OrderDeliveredEvent,
+  OrderDispatchedEvent,
+  OrderInTransitEvent,
+  OrderStatusUpdatedEvent,
+} from '../../events';
+import { BlockchainEvent } from '../../soroban/entities/blockchain-event.entity';
+
+import { OrderEntity } from '../entities/order.entity';
+import { OrderEventType } from '../enums/order-event-type.enum';
+import { OrderStatus } from '../enums/order-status.enum';
+import { RequestStatusAction } from '../enums/request-status-action.enum';
+import { OrdersGateway } from '../gateways/orders.gateway';
+import { OrderStateMachine } from '../state-machine/order-state-machine';
+import { OrderEventStoreService } from './order-event-store.service';
+import { UpdateRequestStatusDto } from '../dto/update-request-status.dto';
+import { InventoryService } from '../../inventory/inventory.service';
+
+const STATUS_TO_EVENT_TYPE: Record<OrderStatus, OrderEventType> = {
+  [OrderStatus.PENDING]: OrderEventType.ORDER_CREATED,
+  [OrderStatus.CONFIRMED]: OrderEventType.ORDER_CONFIRMED,
+  [OrderStatus.DISPATCHED]: OrderEventType.ORDER_DISPATCHED,
+  [OrderStatus.IN_TRANSIT]: OrderEventType.ORDER_IN_TRANSIT,
+  [OrderStatus.DELIVERED]: OrderEventType.ORDER_DELIVERED,
+  [OrderStatus.CANCELLED]: OrderEventType.ORDER_CANCELLED,
+};
+
+@Injectable()
+export class RequestStatusService {
+  private readonly logger = new Logger(RequestStatusService.name);
+
+  constructor(
+    private readonly stateMachine: OrderStateMachine,
+    private readonly eventStore: OrderEventStoreService,
+    private readonly ordersGateway: OrdersGateway,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly inventoryService: InventoryService,
+    @Optional()
+    @InjectRepository(BlockchainEvent)
+    private readonly blockchainEventRepo?: Repository<BlockchainEvent>,
+    @Optional()
+    private readonly notificationsService?: NotificationsService,
+  ) {}
+
+  async applyStatusUpdate(
+    order: OrderEntity,
+    dto: UpdateRequestStatusDto,
+    actorId?: string,
+    actorRole?: string,
+  ): Promise<{ nextStatus: OrderStatus; eventType: OrderEventType }> {
+    const nextStatus = this.resolveNextStatus(dto);
+    const previousStatus = order.status;
+
+    this.enforceActionRole(dto.action, actorRole);
+    this.stateMachine.transition(previousStatus, nextStatus);
+
+    const eventType = STATUS_TO_EVENT_TYPE[nextStatus];
+    await this.eventStore.persistEvent({
+      orderId: order.id,
+      eventType,
+      payload: {
+        previousStatus,
+        newStatus: nextStatus,
+        action: dto.action ?? null,
+        reason: dto.reason ?? null,
+        comment: dto.comment ?? null,
+      },
+      actorId,
+    });
+
+    if (nextStatus === OrderStatus.CANCELLED && previousStatus !== OrderStatus.DELIVERED) {
+      await this.inventoryService.restoreStockOrThrow(
+        order.bloodBankId ?? '',
+        order.bloodType,
+        Number(order.quantity),
+      );
+    }
+
+    if (nextStatus === OrderStatus.DELIVERED) {
+      await this.inventoryService.commitFulfillmentStockOrThrow(
+        order.bloodBankId ?? '',
+        order.bloodType,
+        Number(order.quantity),
+      );
+    }
+
+    order.status = nextStatus;
+
+    this.emitDomainEvent(order, previousStatus, nextStatus, dto.reason);
+
+    this.ordersGateway.emitOrderStatusUpdated({
+      orderId: order.id,
+      previousStatus,
+      newStatus: nextStatus,
+      eventType,
+      actorId: actorId ?? null,
+      timestamp: new Date(),
+    });
+
+    await this.trySyncWithBlockchain(order, previousStatus, nextStatus, actorId, dto.reason);
+    await this.tryNotifyStatusChange(order, previousStatus, nextStatus, dto.reason);
+
+    this.logger.log(
+      `Request ${order.id} status updated: ${previousStatus} -> ${nextStatus}`,
+    );
+
+    return { nextStatus, eventType };
+  }
+
+  private resolveNextStatus(dto: UpdateRequestStatusDto): OrderStatus {
+    if (dto.status) {
+      return dto.status;
+    }
+
+    switch (dto.action) {
+      case RequestStatusAction.APPROVE:
+        return OrderStatus.CONFIRMED;
+      case RequestStatusAction.REJECT:
+        if (!dto.reason) {
+          throw new BadRequestException('A reason is required when rejecting a request.');
+        }
+        return OrderStatus.CANCELLED;
+      case RequestStatusAction.FULFILL:
+        return OrderStatus.DELIVERED;
+      case RequestStatusAction.CANCEL:
+        return OrderStatus.CANCELLED;
+      default:
+        throw new BadRequestException('Either action or status must be provided.');
+    }
+  }
+
+  private enforceActionRole(action: RequestStatusAction | undefined, actorRole?: string): void {
+    if (!action || !actorRole) {
+      return;
+    }
+
+    const normalizedRole = actorRole.toUpperCase();
+
+    const approvalRoles = new Set(['ADMIN', 'BLOOD_BANK', 'BLOOD_BANK_STAFF']);
+    const fulfillmentRoles = new Set(['ADMIN', 'RIDER', 'DISPATCHER', 'BLOOD_BANK', 'BLOOD_BANK_STAFF']);
+
+    if ((action === RequestStatusAction.APPROVE || action === RequestStatusAction.REJECT) && !approvalRoles.has(normalizedRole)) {
+      throw new BadRequestException(`Role '${actorRole}' is not allowed to ${action.toLowerCase()} requests.`);
+    }
+
+    if (action === RequestStatusAction.FULFILL && !fulfillmentRoles.has(normalizedRole)) {
+      throw new BadRequestException(`Role '${actorRole}' is not allowed to fulfill requests.`);
+    }
+  }
+
+  private emitDomainEvent(
+    order: OrderEntity,
+    previousStatus: OrderStatus,
+    nextStatus: OrderStatus,
+    reason?: string,
+  ): void {
+    this.eventEmitter.emit(
+      'order.status.updated',
+      new OrderStatusUpdatedEvent(order.id, previousStatus, nextStatus),
+    );
+
+    switch (nextStatus) {
+      case OrderStatus.CONFIRMED:
+        this.eventEmitter.emit(
+          'order.confirmed',
+          new OrderConfirmedEvent(
+            order.id,
+            order.hospitalId,
+            order.bloodType,
+            order.quantity,
+            order.deliveryAddress,
+          ),
+        );
+        break;
+
+      case OrderStatus.DISPATCHED:
+        this.eventEmitter.emit(
+          'order.dispatched',
+          new OrderDispatchedEvent(order.id, order.riderId ?? ''),
+        );
+        break;
+
+      case OrderStatus.IN_TRANSIT:
+        this.eventEmitter.emit('order.in_transit', new OrderInTransitEvent(order.id));
+        break;
+
+      case OrderStatus.DELIVERED:
+        this.eventEmitter.emit('order.delivered', new OrderDeliveredEvent(order.id));
+        break;
+
+      case OrderStatus.CANCELLED:
+        this.eventEmitter.emit(
+          'order.cancelled',
+          new OrderCancelledEvent(order.id, order.hospitalId, reason ?? 'Status transition'),
+        );
+        break;
+    }
+  }
+
+  private async trySyncWithBlockchain(
+    order: OrderEntity,
+    previousStatus: OrderStatus,
+    nextStatus: OrderStatus,
+    actorId?: string,
+    reason?: string,
+  ): Promise<void> {
+    if (!this.blockchainEventRepo) {
+      return;
+    }
+
+    try {
+      const txHash = `order-status-${order.id}-${Date.now()}`;
+      const entity = this.blockchainEventRepo.create({
+        eventType: 'ORDER_STATUS_UPDATED',
+        transactionHash: txHash,
+        eventData: {
+          orderId: order.id,
+          previousStatus,
+          nextStatus,
+          actorId: actorId ?? null,
+          reason: reason ?? null,
+        },
+        blockchainTimestamp: new Date(),
+        processed: false,
+      });
+
+      await this.blockchainEventRepo.save(entity);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Blockchain sync failed for order ${order.id}: ${message}`);
+    }
+  }
+
+  private async tryNotifyStatusChange(
+    order: OrderEntity,
+    previousStatus: OrderStatus,
+    nextStatus: OrderStatus,
+    reason?: string,
+  ): Promise<void> {
+    if (!this.notificationsService) {
+      return;
+    }
+
+    try {
+      await this.notificationsService.send({
+        recipientId: order.hospitalId,
+        channels: [NotificationChannel.IN_APP],
+        templateKey: 'order.status.updated',
+        variables: {
+          orderId: order.id,
+          previousStatus,
+          newStatus: nextStatus,
+          reason: reason ?? '',
+        },
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `Status notification failed for order ${order.id}: ${message}`,
+      );
+    }
+  }
+}

--- a/backend/src/orders/state-machine/order-state-machine.ts
+++ b/backend/src/orders/state-machine/order-state-machine.ts
@@ -9,7 +9,7 @@ import { OrderTransitionException } from '../exceptions/order-transition.excepti
  */
 export const VALID_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PENDING]: [OrderStatus.CONFIRMED, OrderStatus.CANCELLED],
-  [OrderStatus.CONFIRMED]: [OrderStatus.DISPATCHED, OrderStatus.CANCELLED],
+  [OrderStatus.CONFIRMED]: [OrderStatus.DISPATCHED, OrderStatus.DELIVERED, OrderStatus.CANCELLED],
   [OrderStatus.DISPATCHED]: [OrderStatus.IN_TRANSIT, OrderStatus.CANCELLED],
   [OrderStatus.IN_TRANSIT]: [
     OrderStatus.DELIVERED,


### PR DESCRIPTION
## Summary
- add `UpdateRequestStatusDto` and `RequestStatusAction` to support action-based request/order status updates
- introduce `RequestStatusService` to centralize transition validation, approval/rejection/cancellation/fulfillment flow, history events, inventory side effects, blockchain sync, and notifications
- wire orders controller/service/module to use the new status workflow with actor role gating
- extend state-machine transitions to allow `CONFIRMED -> DELIVERED` for approved-to-fulfilled flow
- add/update unit and integration tests for orders status lifecycle and concurrency paths

## Validation
- `cd backend && npm test -- src/orders --runInBand`

Closes #167