### PR TITLE
feat(testing): enforce minimum coverage thresholds per module (#271)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -8,4 +8,30 @@ module.exports = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
+    './src/auth/**/*.ts': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    './src/blockchain/**/*.ts': {
+      branches: 75,
+      functions: 75,
+      lines: 75,
+      statements: 75,
+    },
+    './src/inventory/**/*.ts': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };


### PR DESCRIPTION
- Set global coverage floor at 70% for all metrics
- Enforce 80% coverage for auth module (critical security component)
- Enforce 75% coverage for blockchain module (transaction integrity)
- Enforce 80% coverage for inventory module (core business logic)
- CI will now fail if any module falls below configured thresholds

This ensures critical modules maintain high test coverage and prevents regression in code quality. Thresholds are enforced on branches, functions, lines, and statements.

Closes #271 