### PR TITLE
feat: add incident review system

### DIFF
--- a/backend/src/incident-reviews/dto/create-incident-review.dto.ts
+++ b/backend/src/incident-reviews/dto/create-incident-review.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+
+import { IncidentRootCause } from '../enums/incident-root-cause.enum';
+import { IncidentSeverity } from '../enums/incident-severity.enum';
+
+export class CreateIncidentReviewDto {
+  @IsUUID()
+  orderId: string;
+
+  @IsOptional()
+  @IsUUID()
+  riderId?: string;
+
+  @IsOptional()
+  @IsString()
+  hospitalId?: string;
+
+  @IsOptional()
+  @IsString()
+  bloodBankId?: string;
+
+  @IsEnum(IncidentRootCause)
+  rootCause: IncidentRootCause;
+
+  @IsEnum(IncidentSeverity)
+  @IsOptional()
+  severity?: IncidentSeverity;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  correctiveAction?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  affectsScoring?: boolean;
+
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}

--- a/backend/src/incident-reviews/dto/query-incident-review.dto.ts
+++ b/backend/src/incident-reviews/dto/query-incident-review.dto.ts
@@ -1,0 +1,69 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+import { IncidentRootCause } from '../enums/incident-root-cause.enum';
+import { IncidentReviewStatus } from '../enums/incident-review-status.enum';
+import { IncidentSeverity } from '../enums/incident-severity.enum';
+
+export class QueryIncidentReviewDto {
+  @IsOptional()
+  @IsString()
+  orderId?: string;
+
+  @IsOptional()
+  @IsString()
+  riderId?: string;
+
+  @IsOptional()
+  @IsString()
+  hospitalId?: string;
+
+  @IsOptional()
+  @IsString()
+  bloodBankId?: string;
+
+  @IsOptional()
+  @IsEnum(IncidentRootCause)
+  rootCause?: IncidentRootCause;
+
+  @IsOptional()
+  @IsEnum(IncidentSeverity)
+  severity?: IncidentSeverity;
+
+  @IsOptional()
+  @IsEnum(IncidentReviewStatus)
+  status?: IncidentReviewStatus;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  affectsScoring?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageSize?: number = 25;
+}

--- a/backend/src/incident-reviews/dto/update-incident-review.dto.ts
+++ b/backend/src/incident-reviews/dto/update-incident-review.dto.ts
@@ -1,0 +1,38 @@
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+
+import { IncidentRootCause } from '../enums/incident-root-cause.enum';
+import { IncidentReviewStatus } from '../enums/incident-review-status.enum';
+import { IncidentSeverity } from '../enums/incident-severity.enum';
+
+export class UpdateIncidentReviewDto {
+  @IsOptional()
+  @IsEnum(IncidentRootCause)
+  rootCause?: IncidentRootCause;
+
+  @IsOptional()
+  @IsEnum(IncidentSeverity)
+  severity?: IncidentSeverity;
+
+  @IsOptional()
+  @IsEnum(IncidentReviewStatus)
+  status?: IncidentReviewStatus;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  correctiveAction?: string;
+
+  @IsOptional()
+  @IsString()
+  resolutionNotes?: string;
+
+  @IsOptional()
+  @IsUUID()
+  reviewedByUserId?: string;
+
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}

--- a/backend/src/incident-reviews/entities/incident-review.entity.ts
+++ b/backend/src/incident-reviews/entities/incident-review.entity.ts
@@ -1,0 +1,81 @@
+import { Column, Entity, Index } from 'typeorm';
+
+import { BaseEntity } from '../../common/entities/base.entity';
+
+import { IncidentRootCause } from '../enums/incident-root-cause.enum';
+import { IncidentReviewStatus } from '../enums/incident-review-status.enum';
+import { IncidentSeverity } from '../enums/incident-severity.enum';
+
+@Entity('incident_reviews')
+@Index('idx_incident_reviews_order_id', ['orderId'])
+@Index('idx_incident_reviews_rider_id', ['riderId'])
+@Index('idx_incident_reviews_status', ['status'])
+@Index('idx_incident_reviews_root_cause', ['rootCause'])
+@Index('idx_incident_reviews_created_at', ['createdAt'])
+@Index('idx_incident_reviews_hospital_id', ['hospitalId'])
+@Index('idx_incident_reviews_blood_bank_id', ['bloodBankId'])
+export class IncidentReviewEntity extends BaseEntity {
+  @Column({ name: 'order_id', type: 'uuid' })
+  orderId: string;
+
+  @Column({ name: 'rider_id', type: 'uuid', nullable: true })
+  riderId: string | null;
+
+  @Column({ name: 'hospital_id', type: 'varchar', nullable: true })
+  hospitalId: string | null;
+
+  @Column({ name: 'blood_bank_id', type: 'varchar', nullable: true })
+  bloodBankId: string | null;
+
+  @Column({ name: 'reported_by_user_id', type: 'uuid' })
+  reportedByUserId: string;
+
+  @Column({ name: 'reviewed_by_user_id', type: 'uuid', nullable: true })
+  reviewedByUserId: string | null;
+
+  @Column({
+    name: 'root_cause',
+    type: 'enum',
+    enum: IncidentRootCause,
+  })
+  rootCause: IncidentRootCause;
+
+  @Column({
+    name: 'severity',
+    type: 'enum',
+    enum: IncidentSeverity,
+    default: IncidentSeverity.MEDIUM,
+  })
+  severity: IncidentSeverity;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: IncidentReviewStatus,
+    default: IncidentReviewStatus.OPEN,
+  })
+  status: IncidentReviewStatus;
+
+  @Column({ name: 'description', type: 'text' })
+  description: string;
+
+  @Column({ name: 'corrective_action', type: 'text', nullable: true })
+  correctiveAction: string | null;
+
+  @Column({ name: 'resolution_notes', type: 'text', nullable: true })
+  resolutionNotes: string | null;
+
+  /** Whether this incident should feed into scoring adjustments */
+  @Column({ name: 'affects_scoring', type: 'boolean', default: true })
+  affectsScoring: boolean;
+
+  /** Set to true once reputation/rating adjustments have been applied */
+  @Column({ name: 'scoring_applied', type: 'boolean', default: false })
+  scoringApplied: boolean;
+
+  @Column({ name: 'closed_at', type: 'timestamptz', nullable: true })
+  closedAt: Date | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+}

--- a/backend/src/incident-reviews/enums/incident-review-status.enum.ts
+++ b/backend/src/incident-reviews/enums/incident-review-status.enum.ts
@@ -1,0 +1,5 @@
+export enum IncidentReviewStatus {
+  OPEN = 'open',
+  IN_REVIEW = 'in_review',
+  CLOSED = 'closed',
+}

--- a/backend/src/incident-reviews/enums/incident-root-cause.enum.ts
+++ b/backend/src/incident-reviews/enums/incident-root-cause.enum.ts
@@ -1,0 +1,14 @@
+export enum IncidentRootCause {
+  TRAFFIC_DELAY = 'traffic_delay',
+  STOCK_MISMATCH = 'stock_mismatch',
+  PROOF_FAILURE = 'proof_failure',
+  TEMPERATURE_BREACH = 'temperature_breach',
+  COMMUNICATION_BREAKDOWN = 'communication_breakdown',
+  RIDER_NO_SHOW = 'rider_no_show',
+  WRONG_DELIVERY_ADDRESS = 'wrong_delivery_address',
+  RECIPIENT_UNAVAILABLE = 'recipient_unavailable',
+  VEHICLE_BREAKDOWN = 'vehicle_breakdown',
+  PACKAGING_FAILURE = 'packaging_failure',
+  SYSTEM_ERROR = 'system_error',
+  OTHER = 'other',
+}

--- a/backend/src/incident-reviews/enums/incident-severity.enum.ts
+++ b/backend/src/incident-reviews/enums/incident-severity.enum.ts
@@ -1,0 +1,6 @@
+export enum IncidentSeverity {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}

--- a/backend/src/incident-reviews/events/incident-review-closed.event.ts
+++ b/backend/src/incident-reviews/events/incident-review-closed.event.ts
@@ -1,0 +1,13 @@
+export class IncidentReviewClosedEvent {
+  constructor(
+    public readonly reviewId: string,
+    public readonly orderId: string,
+    public readonly riderId: string | null,
+    public readonly hospitalId: string | null,
+    public readonly bloodBankId: string | null,
+    public readonly rootCause: string,
+    public readonly severity: string,
+    public readonly affectsScoring: boolean,
+    public readonly closedAt: Date,
+  ) {}
+}

--- a/backend/src/incident-reviews/incident-reviews.controller.ts
+++ b/backend/src/incident-reviews/incident-reviews.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
+  ValidationPipe,
+} from '@nestjs/common';
+
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
+
+import { CreateIncidentReviewDto } from './dto/create-incident-review.dto';
+import { QueryIncidentReviewDto } from './dto/query-incident-review.dto';
+import { UpdateIncidentReviewDto } from './dto/update-incident-review.dto';
+import { IncidentReviewsService } from './incident-reviews.service';
+
+@Controller('incident-reviews')
+export class IncidentReviewsController {
+  constructor(private readonly service: IncidentReviewsService) {}
+
+  @Post()
+  @RequirePermissions(Permission.CREATE_INCIDENT_REVIEW)
+  create(@Body() dto: CreateIncidentReviewDto, @Request() req: any) {
+    return this.service.create(dto, req.user.sub);
+  }
+
+  @Get()
+  @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
+  findAll(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: QueryIncidentReviewDto,
+  ) {
+    return this.service.findAll(query);
+  }
+
+  @Get('stats')
+  @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
+  getStats(
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('riderId') riderId?: string,
+    @Query('hospitalId') hospitalId?: string,
+  ) {
+    return this.service.getStats({ startDate, endDate, riderId, hospitalId });
+  }
+
+  @Get(':id')
+  @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
+  update(@Param('id') id: string, @Body() dto: UpdateIncidentReviewDto) {
+    return this.service.update(id, dto);
+  }
+}

--- a/backend/src/incident-reviews/incident-reviews.module.ts
+++ b/backend/src/incident-reviews/incident-reviews.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ReputationModule } from '../reputation/reputation.module';
+
+import { IncidentReviewEntity } from './entities/incident-review.entity';
+import { IncidentReviewsController } from './incident-reviews.controller';
+import { IncidentReviewsService } from './incident-reviews.service';
+import { IncidentScoringListener } from './listeners/incident-scoring.listener';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([IncidentReviewEntity]), ReputationModule],
+  controllers: [IncidentReviewsController],
+  providers: [IncidentReviewsService, IncidentScoringListener],
+  exports: [IncidentReviewsService],
+})
+export class IncidentReviewsModule {}

--- a/backend/src/incident-reviews/incident-reviews.service.ts
+++ b/backend/src/incident-reviews/incident-reviews.service.ts
@@ -1,0 +1,249 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { PaginatedResponse, PaginationUtil } from '../common/pagination';
+
+import { CreateIncidentReviewDto } from './dto/create-incident-review.dto';
+import { QueryIncidentReviewDto } from './dto/query-incident-review.dto';
+import { UpdateIncidentReviewDto } from './dto/update-incident-review.dto';
+import { IncidentReviewEntity } from './entities/incident-review.entity';
+import { IncidentReviewStatus } from './enums/incident-review-status.enum';
+import { IncidentReviewClosedEvent } from './events/incident-review-closed.event';
+
+export interface IncidentTrendSummary {
+  rootCause: string;
+  count: number;
+  percentage: number;
+}
+
+export interface IncidentStatsSummary {
+  total: number;
+  open: number;
+  inReview: number;
+  closed: number;
+  byRootCause: IncidentTrendSummary[];
+  bySeverity: Record<string, number>;
+}
+
+@Injectable()
+export class IncidentReviewsService {
+  private readonly logger = new Logger(IncidentReviewsService.name);
+
+  constructor(
+    @InjectRepository(IncidentReviewEntity)
+    private readonly reviewRepo: Repository<IncidentReviewEntity>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async create(
+    dto: CreateIncidentReviewDto,
+    reportedByUserId: string,
+  ): Promise<IncidentReviewEntity> {
+    const review = this.reviewRepo.create({
+      ...dto,
+      riderId: dto.riderId ?? null,
+      hospitalId: dto.hospitalId ?? null,
+      bloodBankId: dto.bloodBankId ?? null,
+      correctiveAction: dto.correctiveAction ?? null,
+      reportedByUserId,
+      reviewedByUserId: null,
+      resolutionNotes: null,
+      affectsScoring: dto.affectsScoring ?? true,
+      scoringApplied: false,
+      closedAt: null,
+      metadata: dto.metadata ?? null,
+    });
+
+    const saved = await this.reviewRepo.save(review);
+    this.logger.log(
+      `Incident review created: ${saved.id} for order ${saved.orderId}`,
+    );
+    return saved;
+  }
+
+  async findAll(
+    query: QueryIncidentReviewDto,
+  ): Promise<PaginatedResponse<IncidentReviewEntity>> {
+    const { page = 1, pageSize = 25 } = query;
+
+    const qb = this.reviewRepo
+      .createQueryBuilder('review')
+      .orderBy('review.created_at', 'DESC');
+
+    if (query.orderId) {
+      qb.andWhere('review.order_id = :orderId', { orderId: query.orderId });
+    }
+    if (query.riderId) {
+      qb.andWhere('review.rider_id = :riderId', { riderId: query.riderId });
+    }
+    if (query.hospitalId) {
+      qb.andWhere('review.hospital_id = :hospitalId', {
+        hospitalId: query.hospitalId,
+      });
+    }
+    if (query.bloodBankId) {
+      qb.andWhere('review.blood_bank_id = :bloodBankId', {
+        bloodBankId: query.bloodBankId,
+      });
+    }
+    if (query.rootCause) {
+      qb.andWhere('review.root_cause = :rootCause', {
+        rootCause: query.rootCause,
+      });
+    }
+    if (query.severity) {
+      qb.andWhere('review.severity = :severity', { severity: query.severity });
+    }
+    if (query.status) {
+      qb.andWhere('review.status = :status', { status: query.status });
+    }
+    if (query.affectsScoring !== undefined) {
+      qb.andWhere('review.affects_scoring = :affectsScoring', {
+        affectsScoring: query.affectsScoring,
+      });
+    }
+    if (query.startDate) {
+      qb.andWhere('review.created_at >= :startDate', {
+        startDate: new Date(query.startDate),
+      });
+    }
+    if (query.endDate) {
+      qb.andWhere('review.created_at <= :endDate', {
+        endDate: new Date(query.endDate),
+      });
+    }
+
+    qb.skip(PaginationUtil.calculateSkip(page, pageSize)).take(pageSize);
+
+    const [data, total] = await qb.getManyAndCount();
+    return PaginationUtil.createResponse(data, page, pageSize, total);
+  }
+
+  async findOne(id: string): Promise<IncidentReviewEntity> {
+    const review = await this.reviewRepo.findOne({ where: { id } });
+    if (!review) {
+      throw new NotFoundException(`Incident review "${id}" not found`);
+    }
+    return review;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateIncidentReviewDto,
+  ): Promise<IncidentReviewEntity> {
+    const review = await this.findOne(id);
+
+    if (
+      review.status === IncidentReviewStatus.CLOSED &&
+      dto.status !== undefined
+    ) {
+      throw new BadRequestException('Cannot update a closed incident review');
+    }
+
+    const isClosing =
+      dto.status === IncidentReviewStatus.CLOSED &&
+      review.status !== IncidentReviewStatus.CLOSED;
+
+    Object.assign(review, {
+      ...dto,
+      closedAt: isClosing ? new Date() : review.closedAt,
+    });
+
+    const saved = await this.reviewRepo.save(review);
+
+    if (isClosing) {
+      this.eventEmitter.emit(
+        'incident.review.closed',
+        new IncidentReviewClosedEvent(
+          saved.id,
+          saved.orderId,
+          saved.riderId,
+          saved.hospitalId,
+          saved.bloodBankId,
+          saved.rootCause,
+          saved.severity,
+          saved.affectsScoring,
+          saved.closedAt!,
+        ),
+      );
+      this.logger.log(`Incident review closed: ${saved.id}`);
+    }
+
+    return saved;
+  }
+
+  async markScoringApplied(id: string): Promise<void> {
+    await this.reviewRepo.update(id, { scoringApplied: true });
+  }
+
+  async getStats(query: {
+    startDate?: string;
+    endDate?: string;
+    riderId?: string;
+    hospitalId?: string;
+  }): Promise<IncidentStatsSummary> {
+    const qb = this.reviewRepo.createQueryBuilder('review');
+
+    if (query.riderId) {
+      qb.andWhere('review.rider_id = :riderId', { riderId: query.riderId });
+    }
+    if (query.hospitalId) {
+      qb.andWhere('review.hospital_id = :hospitalId', {
+        hospitalId: query.hospitalId,
+      });
+    }
+    if (query.startDate) {
+      qb.andWhere('review.created_at >= :startDate', {
+        startDate: new Date(query.startDate),
+      });
+    }
+    if (query.endDate) {
+      qb.andWhere('review.created_at <= :endDate', {
+        endDate: new Date(query.endDate),
+      });
+    }
+
+    const all = await qb.getMany();
+    const total = all.length;
+
+    const open = all.filter(
+      (r) => r.status === IncidentReviewStatus.OPEN,
+    ).length;
+    const inReview = all.filter(
+      (r) => r.status === IncidentReviewStatus.IN_REVIEW,
+    ).length;
+    const closed = all.filter(
+      (r) => r.status === IncidentReviewStatus.CLOSED,
+    ).length;
+
+    // Root cause frequency
+    const rootCauseMap = new Map<string, number>();
+    for (const r of all) {
+      rootCauseMap.set(r.rootCause, (rootCauseMap.get(r.rootCause) ?? 0) + 1);
+    }
+    const byRootCause: IncidentTrendSummary[] = Array.from(
+      rootCauseMap.entries(),
+    )
+      .sort((a, b) => b[1] - a[1])
+      .map(([rootCause, count]) => ({
+        rootCause,
+        count,
+        percentage: total > 0 ? Math.round((count / total) * 100 * 10) / 10 : 0,
+      }));
+
+    // Severity breakdown
+    const bySeverity: Record<string, number> = {};
+    for (const r of all) {
+      bySeverity[r.severity] = (bySeverity[r.severity] ?? 0) + 1;
+    }
+
+    return { total, open, inReview, closed, byRootCause, bySeverity };
+  }
+}


### PR DESCRIPTION
## PR Description

### Description
Adds a structured post-delivery incident review system. When a delivery is late, rejected, or disputed, an incident review record can be created against the order with a categorised root cause, severity level, and workflow status. Closed reviews with `affectsScoring=true` automatically publish an event that feeds back into rider reputation scoring via the existing `ReputationService`. A stats endpoint provides aggregate breakdowns by root cause and severity for trend analysis.

### Related Issue
- Closes #399 

### Changes Made
- Added `IncidentReviewEntity` with fields for `orderId`, `riderId`, `hospitalId`, `bloodBankId`, `rootCause`, `severity`, `status`, `description`, `correctiveAction`, `resolutionNotes`, `affectsScoring`, `scoringApplied`, `closedAt`, and `metadata`
- Added enums: `IncidentRootCause` (12 categories including traffic delay, stock mismatch, proof failure, temperature breach, communication breakdown), `IncidentSeverity` (low/medium/high/critical), `IncidentReviewStatus` (open/in_review/closed)
- Added `IncidentReviewsService` with full CRUD, paginated filtering across all entity fields, a `getStats()` method returning root cause frequencies and severity breakdown, and `markScoringApplied()` to prevent double-processing
- Added `IncidentReviewClosedEvent` published via `EventEmitter2` when a review transitions to `closed`
- Added `IncidentScoringListener` that handles `incident.review.closed` and calls `ReputationService.recordDelivery()` with an outcome mapped from incident severity (`high`/`critical` → `failed`, others → `cancelled`)
- Added `IncidentReviewsController` with endpoints: `POST /incident-reviews`, `GET /incident-reviews`, `GET /incident-reviews/stats`, `GET /incident-reviews/:id`, `PATCH /incident-reviews/:id`
- Added `VIEW_INCIDENT_REVIEWS`, `CREATE_INCIDENT_REVIEW`, and `MANAGE_INCIDENT_REVIEWS` permissions
- Added migration `1743000001000-CreateIncidentReviews` with all enum types and indexed table
- Registered `IncidentReviewsModule` in `AppModule`

### Acceptance Criteria
- Failed or problematic deliveries can be reviewed in a structured way via the `POST /incident-reviews` endpoint with root cause categorisation
- Incident data is queryable for trend analysis via the `GET /incident-reviews` filtered endpoint and the `GET /incident-reviews/stats` summary endpoint
- Review outcomes influence future operational scoring: closing a review with `affectsScoring=true` triggers `IncidentScoringListener` which applies reputation point adjustments to the assigned rider