### PR TITLE
feat: add  hospital capacity and operating window constraints

### DIFF
--- a/backend/src/hospitals/dto/create-hospital.dto.ts
+++ b/backend/src/hospitals/dto/create-hospital.dto.ts
@@ -1,0 +1,53 @@
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+import { HospitalStatus } from '../enums/hospital-status.enum';
+
+export class CreateHospitalDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  address: string;
+
+  @IsOptional()
+  @IsString()
+  regionCode?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  latitude?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  longitude?: number;
+
+  @IsOptional()
+  @IsString()
+  phoneNumber?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsEnum(HospitalStatus)
+  status?: HospitalStatus;
+
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}

--- a/backend/src/hospitals/dto/hospital-capacity-config.dto.ts
+++ b/backend/src/hospitals/dto/hospital-capacity-config.dto.ts
@@ -1,0 +1,83 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+import {
+  BlackoutPeriod,
+  ReceivingWindowSlot,
+} from '../entities/hospital-capacity-config.entity';
+
+export class ReceivingWindowSlotDto implements ReceivingWindowSlot {
+  @IsInt()
+  @Min(0)
+  @Max(6)
+  dayOfWeek: number;
+
+  @IsString()
+  @IsNotEmpty()
+  openTime: string;
+
+  @IsString()
+  @IsNotEmpty()
+  closeTime: string;
+}
+
+export class BlackoutPeriodDto implements BlackoutPeriod {
+  @IsString()
+  @IsNotEmpty()
+  label: string;
+
+  @IsString()
+  @IsNotEmpty()
+  startIso: string;
+
+  @IsString()
+  @IsNotEmpty()
+  endIso: string;
+}
+
+export class UpsertCapacityConfigDto {
+  @IsInt()
+  @Min(0)
+  coldStorageCapacityUnits: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  currentStorageUnits?: number;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ReceivingWindowSlotDto)
+  receivingWindows?: ReceivingWindowSlotDto[] | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => BlackoutPeriodDto)
+  blackoutPeriods?: BlackoutPeriodDto[] | null;
+
+  @IsOptional()
+  @IsBoolean()
+  allowEmergencyOverride?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  intakeBufferMinutes?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  isEnforced?: boolean;
+}

--- a/backend/src/hospitals/dto/intake-window-check.dto.ts
+++ b/backend/src/hospitals/dto/intake-window-check.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+
+import { OverrideReason } from '../enums/override-reason.enum';
+
+export class IntakeWindowCheckDto {
+  @IsUUID()
+  hospitalId: string;
+
+  @IsDateString()
+  projectedDeliveryAt: string;
+
+  @IsOptional()
+  @IsNumber()
+  unitsRequested?: number;
+
+  @IsOptional()
+  @IsUUID()
+  orderId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  bloodRequestId?: string;
+}
+
+export class RequestEmergencyOverrideDto {
+  @IsUUID()
+  hospitalId: string;
+
+  @IsEnum(OverrideReason)
+  reason: OverrideReason;
+
+  @IsOptional()
+  @IsString()
+  reasonNotes?: string;
+
+  @IsOptional()
+  @IsUUID()
+  orderId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  bloodRequestId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  projectedDeliveryAt?: string;
+}
+
+export interface IntakeWindowCheckResult {
+  hospitalId: string;
+  projectedDeliveryAt: Date;
+  canReceive: boolean;
+  constraintViolations: ConstraintViolation[];
+  storageAvailable: boolean;
+  availableStorageUnits: number;
+  withinReceivingWindow: boolean;
+  withinBlackoutPeriod: boolean;
+  requiresOverride: boolean;
+}
+
+export interface ConstraintViolation {
+  type: 'receiving_window' | 'blackout_period' | 'storage_capacity';
+  message: string;
+  detail?: Record<string, unknown>;
+}

--- a/backend/src/hospitals/dto/update-hospital.dto.ts
+++ b/backend/src/hospitals/dto/update-hospital.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from '@nestjs/mapped-types';
+
+import { CreateHospitalDto } from './create-hospital.dto';
+
+export class UpdateHospitalDto extends PartialType(CreateHospitalDto) {}

--- a/backend/src/hospitals/entities/hospital-capacity-config.entity.ts
+++ b/backend/src/hospitals/entities/hospital-capacity-config.entity.ts
@@ -1,0 +1,65 @@
+import { Column, Entity, Index, JoinColumn, OneToOne } from 'typeorm';
+
+import { BaseEntity } from '../../common/entities/base.entity';
+import { HospitalEntity } from './hospital.entity';
+
+/**
+ * Receiving window slot: e.g. { dayOfWeek: 1, openTime: '08:00', closeTime: '18:00' }
+ * dayOfWeek: 0 = Sunday … 6 = Saturday (ISO-like, but JS Date convention)
+ */
+export interface ReceivingWindowSlot {
+  dayOfWeek: number; // 0–6
+  openTime: string; // 'HH:mm' UTC
+  closeTime: string; // 'HH:mm' UTC
+}
+
+/**
+ * Blackout period: hospital cannot receive during this window regardless of schedule.
+ * e.g. public holidays, planned maintenance.
+ */
+export interface BlackoutPeriod {
+  label: string;
+  startIso: string; // ISO 8601 datetime
+  endIso: string; // ISO 8601 datetime
+}
+
+@Entity('hospital_capacity_configs')
+@Index('idx_hospital_capacity_hospital_id', ['hospitalId'], { unique: true })
+export class HospitalCapacityConfigEntity extends BaseEntity {
+  @Column({ name: 'hospital_id', type: 'uuid', unique: true })
+  hospitalId: string;
+
+  @OneToOne(() => HospitalEntity, (h) => h.capacityConfig, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'hospital_id' })
+  hospital: HospitalEntity;
+
+  /** Maximum blood units the cold-storage facility can hold at one time */
+  @Column({ name: 'cold_storage_capacity_units', type: 'int', default: 0 })
+  coldStorageCapacityUnits: number;
+
+  /** Units currently reserved/stored (updated on each intake confirmation) */
+  @Column({ name: 'current_storage_units', type: 'int', default: 0 })
+  currentStorageUnits: number;
+
+  /** Weekly receiving schedule — null means 24/7 open */
+  @Column({ name: 'receiving_windows', type: 'jsonb', nullable: true })
+  receivingWindows: ReceivingWindowSlot[] | null;
+
+  /** One-off blackout periods (planned closures, holidays, etc.) */
+  @Column({ name: 'blackout_periods', type: 'jsonb', nullable: true })
+  blackoutPeriods: BlackoutPeriod[] | null;
+
+  /** When true, emergency overrides are permitted without pre-approval */
+  @Column({ name: 'allow_emergency_override', type: 'boolean', default: true })
+  allowEmergencyOverride: boolean;
+
+  /** Max lead-time buffer in minutes added to projected delivery window */
+  @Column({ name: 'intake_buffer_minutes', type: 'int', default: 30 })
+  intakeBufferMinutes: number;
+
+  /** Whether this config is actively enforced during matching */
+  @Column({ name: 'is_enforced', type: 'boolean', default: true })
+  isEnforced: boolean;
+}

--- a/backend/src/hospitals/entities/hospital-override-audit.entity.ts
+++ b/backend/src/hospitals/entities/hospital-override-audit.entity.ts
@@ -1,0 +1,47 @@
+import { Column, Entity, Index } from 'typeorm';
+
+import { BaseEntity } from '../../common/entities/base.entity';
+import { OverrideReason } from '../enums/override-reason.enum';
+
+@Entity('hospital_override_audits')
+@Index('idx_hospital_override_hospital_id', ['hospitalId'])
+@Index('idx_hospital_override_order_id', ['orderId'])
+@Index('idx_hospital_override_created_at', ['createdAt'])
+export class HospitalOverrideAuditEntity extends BaseEntity {
+  @Column({ name: 'hospital_id', type: 'uuid' })
+  hospitalId: string;
+
+  @Column({ name: 'order_id', type: 'uuid', nullable: true })
+  orderId: string | null;
+
+  @Column({ name: 'blood_request_id', type: 'uuid', nullable: true })
+  bloodRequestId: string | null;
+
+  @Column({ name: 'approved_by_user_id', type: 'uuid' })
+  approvedByUserId: string;
+
+  @Column({
+    name: 'reason',
+    type: 'enum',
+    enum: OverrideReason,
+  })
+  reason: OverrideReason;
+
+  @Column({ name: 'reason_notes', type: 'text', nullable: true })
+  reasonNotes: string | null;
+
+  /** Snapshot of the constraint that was bypassed */
+  @Column({ name: 'bypassed_constraint', type: 'jsonb' })
+  bypassedConstraint: Record<string, unknown>;
+
+  /** Projected delivery time that was flagged */
+  @Column({
+    name: 'projected_delivery_at',
+    type: 'timestamptz',
+    nullable: true,
+  })
+  projectedDeliveryAt: Date | null;
+
+  @Column({ name: 'is_emergency', type: 'boolean', default: false })
+  isEmergency: boolean;
+}

--- a/backend/src/hospitals/entities/hospital.entity.ts
+++ b/backend/src/hospitals/entities/hospital.entity.ts
@@ -1,0 +1,49 @@
+import { Column, Entity, Index, OneToOne } from 'typeorm';
+
+import { BaseEntity } from '../../common/entities/base.entity';
+
+import { HospitalStatus } from '../enums/hospital-status.enum';
+import { HospitalCapacityConfigEntity } from './hospital-capacity-config.entity';
+
+@Entity('hospitals')
+@Index('idx_hospitals_status', ['status'])
+@Index('idx_hospitals_region_code', ['regionCode'])
+export class HospitalEntity extends BaseEntity {
+  @Column({ type: 'varchar', length: 200 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  address: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true, name: 'region_code' })
+  regionCode: string | null;
+
+  @Column({ type: 'decimal', precision: 10, scale: 7, nullable: true })
+  latitude: number | null;
+
+  @Column({ type: 'decimal', precision: 10, scale: 7, nullable: true })
+  longitude: number | null;
+
+  @Column({ type: 'varchar', length: 40, nullable: true, name: 'phone_number' })
+  phoneNumber: string | null;
+
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  email: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: HospitalStatus,
+    default: HospitalStatus.ACTIVE,
+  })
+  status: HospitalStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @OneToOne(() => HospitalCapacityConfigEntity, (config) => config.hospital, {
+    cascade: true,
+    nullable: true,
+    eager: false,
+  })
+  capacityConfig?: HospitalCapacityConfigEntity | null;
+}

--- a/backend/src/hospitals/enums/hospital-status.enum.ts
+++ b/backend/src/hospitals/enums/hospital-status.enum.ts
@@ -1,0 +1,5 @@
+export enum HospitalStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  SUSPENDED = 'suspended',
+}

--- a/backend/src/hospitals/enums/override-reason.enum.ts
+++ b/backend/src/hospitals/enums/override-reason.enum.ts
@@ -1,0 +1,7 @@
+export enum OverrideReason {
+  MASS_CASUALTY_EVENT = 'mass_casualty_event',
+  CRITICAL_PATIENT = 'critical_patient',
+  ADMINISTRATIVE_APPROVAL = 'administrative_approval',
+  SYSTEM_ERROR_RECOVERY = 'system_error_recovery',
+  OTHER = 'other',
+}

--- a/backend/src/hospitals/hospitals.controller.ts
+++ b/backend/src/hospitals/hospitals.controller.ts
@@ -1,24 +1,39 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
-  Query,
+  Get,
   HttpCode,
   HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
 } from '@nestjs/common';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
 
+import { CreateHospitalDto } from './dto/create-hospital.dto';
+import { UpsertCapacityConfigDto } from './dto/hospital-capacity-config.dto';
+import {
+  IntakeWindowCheckDto,
+  RequestEmergencyOverrideDto,
+} from './dto/intake-window-check.dto';
+import { UpdateHospitalDto } from './dto/update-hospital.dto';
+import { OverrideReason } from './enums/override-reason.enum';
+import { HospitalIntakeWindowService } from './services/hospital-intake-window.service';
 import { HospitalsService } from './hospitals.service';
 
 @Controller('hospitals')
 export class HospitalsController {
-  constructor(private readonly hospitalsService: HospitalsService) {}
+  constructor(
+    private readonly hospitalsService: HospitalsService,
+    private readonly intakeWindowService: HospitalIntakeWindowService,
+  ) {}
+
+  // ── Core CRUD ─────────────────────────────────────────────────────────────
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
   @Get()
@@ -48,14 +63,14 @@ export class HospitalsController {
 
   @RequirePermissions(Permission.CREATE_HOSPITAL)
   @Post()
-  create(@Body() createHospitalDto: any) {
-    return this.hospitalsService.create(createHospitalDto);
+  create(@Body() dto: CreateHospitalDto) {
+    return this.hospitalsService.create(dto);
   }
 
   @RequirePermissions(Permission.UPDATE_HOSPITAL)
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateHospitalDto: any) {
-    return this.hospitalsService.update(id, updateHospitalDto);
+  update(@Param('id') id: string, @Body() dto: UpdateHospitalDto) {
+    return this.hospitalsService.update(id, dto);
   }
 
   @RequirePermissions(Permission.DELETE_HOSPITAL)
@@ -63,5 +78,82 @@ export class HospitalsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {
     return this.hospitalsService.remove(id);
+  }
+
+  // ── Capacity config ───────────────────────────────────────────────────────
+
+  @RequirePermissions(Permission.UPDATE_HOSPITAL)
+  @Post(':id/capacity-config')
+  upsertCapacityConfig(
+    @Param('id') id: string,
+    @Body() dto: UpsertCapacityConfigDto,
+  ) {
+    return this.hospitalsService.upsertCapacityConfig(id, dto);
+  }
+
+  @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @Get(':id/capacity-config')
+  getCapacityConfig(@Param('id') id: string) {
+    return this.hospitalsService.getCapacityConfig(id);
+  }
+
+  // ── Intake window checks ──────────────────────────────────────────────────
+
+  @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @Post('intake-check')
+  checkIntakeWindow(@Body() dto: IntakeWindowCheckDto) {
+    return this.intakeWindowService.checkIntakeWindow(
+      dto.hospitalId,
+      new Date(dto.projectedDeliveryAt),
+      dto.unitsRequested,
+    );
+  }
+
+  // ── Emergency overrides ───────────────────────────────────────────────────
+
+  @RequirePermissions(Permission.MANAGE_HOSPITAL_OVERRIDES)
+  @Post('override')
+  async requestOverride(
+    @Body() dto: RequestEmergencyOverrideDto,
+    @Request() req: any,
+  ) {
+    // First run the check to capture what constraint is being bypassed
+    const checkResult = await this.intakeWindowService.checkIntakeWindow(
+      dto.hospitalId,
+      dto.projectedDeliveryAt ? new Date(dto.projectedDeliveryAt) : new Date(),
+    );
+
+    const audit = await this.intakeWindowService.recordOverride({
+      hospitalId: dto.hospitalId,
+      approvedByUserId: req.user.sub,
+      reason: dto.reason,
+      reasonNotes: dto.reasonNotes,
+      orderId: dto.orderId,
+      bloodRequestId: dto.bloodRequestId,
+      projectedDeliveryAt: dto.projectedDeliveryAt
+        ? new Date(dto.projectedDeliveryAt)
+        : undefined,
+      bypassedConstraint: {
+        violations: checkResult.constraintViolations,
+        checkResult,
+      },
+      isEmergency:
+        dto.reason === OverrideReason.MASS_CASUALTY_EVENT ||
+        dto.reason === OverrideReason.CRITICAL_PATIENT,
+    });
+
+    return {
+      message: 'Emergency override recorded',
+      data: audit,
+    };
+  }
+
+  @RequirePermissions(Permission.VIEW_HOSPITAL_OVERRIDES)
+  @Get(':id/overrides')
+  getOverrideAuditLog(@Param('id') id: string, @Query('limit') limit?: string) {
+    return this.intakeWindowService.getOverrideAuditLog(
+      id,
+      limit ? parseInt(limit, 10) : 50,
+    );
   }
 }

--- a/backend/src/hospitals/hospitals.service.ts
+++ b/backend/src/hospitals/hospitals.service.ts
@@ -1,58 +1,147 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateHospitalDto } from './dto/create-hospital.dto';
+import { UpsertCapacityConfigDto } from './dto/hospital-capacity-config.dto';
+import { UpdateHospitalDto } from './dto/update-hospital.dto';
+import { HospitalCapacityConfigEntity } from './entities/hospital-capacity-config.entity';
+import { HospitalEntity } from './entities/hospital.entity';
 
 @Injectable()
 export class HospitalsService {
-  constructor() {}
+  private readonly logger = new Logger(HospitalsService.name);
 
-  async findAll() {
-    // TODO: Implement find all hospitals logic
-    return {
-      message: 'Hospitals retrieved successfully',
-      data: [],
-    };
+  constructor(
+    @InjectRepository(HospitalEntity)
+    private readonly hospitalRepo: Repository<HospitalEntity>,
+    @InjectRepository(HospitalCapacityConfigEntity)
+    private readonly capacityRepo: Repository<HospitalCapacityConfigEntity>,
+  ) {}
+
+  async findAll(): Promise<{ message: string; data: HospitalEntity[] }> {
+    const data = await this.hospitalRepo.find({
+      order: { name: 'ASC' },
+    });
+    return { message: 'Hospitals retrieved successfully', data };
   }
 
-  async findOne(id: string) {
-    // TODO: Implement find hospital by id logic
-    return {
-      message: 'Hospital retrieved successfully',
-      data: { id },
-    };
+  async findOne(
+    id: string,
+  ): Promise<{ message: string; data: HospitalEntity }> {
+    const hospital = await this.hospitalRepo.findOne({
+      where: { id },
+      relations: ['capacityConfig'],
+    });
+    if (!hospital) {
+      throw new NotFoundException(`Hospital "${id}" not found`);
+    }
+    return { message: 'Hospital retrieved successfully', data: hospital };
   }
 
-  async create(createHospitalDto: any) {
-    // TODO: Implement create hospital logic
-    return {
-      message: 'Hospital created successfully',
-      data: createHospitalDto,
-    };
+  async create(
+    dto: CreateHospitalDto,
+  ): Promise<{ message: string; data: HospitalEntity }> {
+    const hospital = this.hospitalRepo.create({
+      ...dto,
+      regionCode: dto.regionCode ?? null,
+      latitude: dto.latitude ?? null,
+      longitude: dto.longitude ?? null,
+      phoneNumber: dto.phoneNumber ?? null,
+      email: dto.email ?? null,
+      metadata: dto.metadata ?? null,
+    });
+    const saved = await this.hospitalRepo.save(hospital);
+    this.logger.log(`Hospital created: ${saved.id} (${saved.name})`);
+    return { message: 'Hospital created successfully', data: saved };
   }
 
-  async update(id: string, updateHospitalDto: any) {
-    // TODO: Implement update hospital logic
-    return {
-      message: 'Hospital updated successfully',
-      data: { id, ...updateHospitalDto },
-    };
+  async update(
+    id: string,
+    dto: UpdateHospitalDto,
+  ): Promise<{ message: string; data: HospitalEntity }> {
+    const { data: hospital } = await this.findOne(id);
+    Object.assign(hospital, dto);
+    const saved = await this.hospitalRepo.save(hospital);
+    return { message: 'Hospital updated successfully', data: saved };
   }
 
-  async remove(id: string) {
-    // TODO: Implement delete hospital logic
-    return {
-      message: 'Hospital deleted successfully',
-      data: { id },
-    };
+  async remove(id: string): Promise<{ message: string; data: { id: string } }> {
+    const { data: hospital } = await this.findOne(id);
+    await this.hospitalRepo.remove(hospital);
+    return { message: 'Hospital deleted successfully', data: { id } };
   }
 
   async getNearbyHospitals(
     latitude: number,
     longitude: number,
-    radius: number,
-  ) {
-    // TODO: Implement find nearby hospitals logic
+    radiusKm: number,
+  ): Promise<{ message: string; data: HospitalEntity[] }> {
+    // Haversine approximation via raw query
+    const data = await this.hospitalRepo
+      .createQueryBuilder('hospital')
+      .where(
+        `(
+          6371 * acos(
+            cos(radians(:lat)) * cos(radians(hospital.latitude)) *
+            cos(radians(hospital.longitude) - radians(:lng)) +
+            sin(radians(:lat)) * sin(radians(hospital.latitude))
+          )
+        ) <= :radius`,
+        { lat: latitude, lng: longitude, radius: radiusKm },
+      )
+      .andWhere('hospital.latitude IS NOT NULL')
+      .andWhere('hospital.longitude IS NOT NULL')
+      .orderBy('hospital.name', 'ASC')
+      .getMany();
+
+    return { message: 'Nearby hospitals retrieved successfully', data };
+  }
+
+  // ── Capacity config ───────────────────────────────────────────────────────
+
+  async upsertCapacityConfig(
+    hospitalId: string,
+    dto: UpsertCapacityConfigDto,
+  ): Promise<{ message: string; data: HospitalCapacityConfigEntity }> {
+    await this.findOne(hospitalId); // ensure hospital exists
+
+    let config = await this.capacityRepo.findOne({ where: { hospitalId } });
+    if (!config) {
+      config = this.capacityRepo.create({ hospitalId });
+    }
+
+    Object.assign(config, {
+      coldStorageCapacityUnits: dto.coldStorageCapacityUnits,
+      currentStorageUnits:
+        dto.currentStorageUnits ?? config.currentStorageUnits ?? 0,
+      receivingWindows: dto.receivingWindows ?? config.receivingWindows ?? null,
+      blackoutPeriods: dto.blackoutPeriods ?? config.blackoutPeriods ?? null,
+      allowEmergencyOverride:
+        dto.allowEmergencyOverride ?? config.allowEmergencyOverride ?? true,
+      intakeBufferMinutes:
+        dto.intakeBufferMinutes ?? config.intakeBufferMinutes ?? 30,
+      isEnforced: dto.isEnforced ?? config.isEnforced ?? true,
+    });
+
+    const saved = await this.capacityRepo.save(config);
+    this.logger.log(`Capacity config upserted for hospital ${hospitalId}`);
+    return { message: 'Capacity config updated successfully', data: saved };
+  }
+
+  async getCapacityConfig(
+    hospitalId: string,
+  ): Promise<{ message: string; data: HospitalCapacityConfigEntity | null }> {
+    await this.findOne(hospitalId);
+    const config = await this.capacityRepo.findOne({ where: { hospitalId } });
     return {
-      message: 'Nearby hospitals retrieved successfully',
-      data: [],
+      message: 'Capacity config retrieved successfully',
+      data: config ?? null,
     };
   }
 }

--- a/backend/src/hospitals/services/hospital-intake-window.service.ts
+++ b/backend/src/hospitals/services/hospital-intake-window.service.ts
@@ -1,0 +1,231 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { HospitalCapacityConfigEntity } from '../entities/hospital-capacity-config.entity';
+import { HospitalOverrideAuditEntity } from '../entities/hospital-override-audit.entity';
+import { OverrideReason } from '../enums/override-reason.enum';
+import {
+  ConstraintViolation,
+  IntakeWindowCheckResult,
+} from '../dto/intake-window-check.dto';
+
+@Injectable()
+export class HospitalIntakeWindowService {
+  private readonly logger = new Logger(HospitalIntakeWindowService.name);
+
+  constructor(
+    @InjectRepository(HospitalCapacityConfigEntity)
+    private readonly configRepo: Repository<HospitalCapacityConfigEntity>,
+    @InjectRepository(HospitalOverrideAuditEntity)
+    private readonly overrideAuditRepo: Repository<HospitalOverrideAuditEntity>,
+  ) {}
+
+  /**
+   * Core check: can a hospital receive blood at the projected delivery time?
+   * Returns a structured result with individual constraint violations so callers
+   * can decide whether to block, warn, or request an override.
+   */
+  async checkIntakeWindow(
+    hospitalId: string,
+    projectedDeliveryAt: Date,
+    unitsRequested = 1,
+  ): Promise<IntakeWindowCheckResult> {
+    const config = await this.configRepo.findOne({ where: { hospitalId } });
+
+    // No config means no constraints — always receivable
+    if (!config || !config.isEnforced) {
+      return this.buildOpenResult(hospitalId, projectedDeliveryAt);
+    }
+
+    const violations: ConstraintViolation[] = [];
+
+    // 1. Storage capacity check
+    const availableStorage =
+      config.coldStorageCapacityUnits - config.currentStorageUnits;
+    const storageAvailable = availableStorage >= unitsRequested;
+    if (!storageAvailable) {
+      violations.push({
+        type: 'storage_capacity',
+        message: `Cold storage at capacity. Available: ${availableStorage} units, requested: ${unitsRequested}`,
+        detail: {
+          capacity: config.coldStorageCapacityUnits,
+          current: config.currentStorageUnits,
+          requested: unitsRequested,
+          available: availableStorage,
+        },
+      });
+    }
+
+    // 2. Blackout period check
+    const inBlackout = this.isInBlackoutPeriod(config, projectedDeliveryAt);
+    if (inBlackout) {
+      const period = this.getActiveBlackout(config, projectedDeliveryAt);
+      violations.push({
+        type: 'blackout_period',
+        message: `Hospital is in a blackout period: ${period?.label ?? 'unknown'}`,
+        detail: { period },
+      });
+    }
+
+    // 3. Receiving window check (only if not in blackout and windows are defined)
+    const hasWindows =
+      config.receivingWindows && config.receivingWindows.length > 0;
+    const withinWindow = hasWindows
+      ? this.isWithinReceivingWindow(config, projectedDeliveryAt)
+      : true; // null windows = 24/7
+
+    if (hasWindows && !withinWindow) {
+      violations.push({
+        type: 'receiving_window',
+        message: `Projected delivery time falls outside hospital receiving hours`,
+        detail: {
+          projectedDeliveryAt: projectedDeliveryAt.toISOString(),
+          receivingWindows: config.receivingWindows,
+        },
+      });
+    }
+
+    const canReceive = violations.length === 0;
+
+    return {
+      hospitalId,
+      projectedDeliveryAt,
+      canReceive,
+      constraintViolations: violations,
+      storageAvailable,
+      availableStorageUnits: Math.max(0, availableStorage),
+      withinReceivingWindow: withinWindow,
+      withinBlackoutPeriod: inBlackout,
+      requiresOverride: !canReceive && config.allowEmergencyOverride,
+    };
+  }
+
+  /**
+   * Record an emergency override approval with full audit trail.
+   */
+  async recordOverride(params: {
+    hospitalId: string;
+    approvedByUserId: string;
+    reason: OverrideReason;
+    reasonNotes?: string;
+    orderId?: string;
+    bloodRequestId?: string;
+    projectedDeliveryAt?: Date;
+    bypassedConstraint: Record<string, unknown>;
+    isEmergency: boolean;
+  }): Promise<HospitalOverrideAuditEntity> {
+    const audit = this.overrideAuditRepo.create({
+      hospitalId: params.hospitalId,
+      approvedByUserId: params.approvedByUserId,
+      reason: params.reason,
+      reasonNotes: params.reasonNotes ?? null,
+      orderId: params.orderId ?? null,
+      bloodRequestId: params.bloodRequestId ?? null,
+      projectedDeliveryAt: params.projectedDeliveryAt ?? null,
+      bypassedConstraint: params.bypassedConstraint,
+      isEmergency: params.isEmergency,
+    });
+
+    const saved = await this.overrideAuditRepo.save(audit);
+    this.logger.warn(
+      `Emergency override recorded for hospital ${params.hospitalId} by user ${params.approvedByUserId} — reason: ${params.reason}`,
+    );
+    return saved;
+  }
+
+  async getOverrideAuditLog(
+    hospitalId: string,
+    limit = 50,
+  ): Promise<HospitalOverrideAuditEntity[]> {
+    return this.overrideAuditRepo.find({
+      where: { hospitalId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  async incrementStorageUsage(
+    hospitalId: string,
+    units: number,
+  ): Promise<void> {
+    const config = await this.configRepo.findOne({ where: { hospitalId } });
+    if (!config) return;
+    config.currentStorageUnits = Math.min(
+      config.coldStorageCapacityUnits,
+      config.currentStorageUnits + units,
+    );
+    await this.configRepo.save(config);
+  }
+
+  async decrementStorageUsage(
+    hospitalId: string,
+    units: number,
+  ): Promise<void> {
+    const config = await this.configRepo.findOne({ where: { hospitalId } });
+    if (!config) return;
+    config.currentStorageUnits = Math.max(
+      0,
+      config.currentStorageUnits - units,
+    );
+    await this.configRepo.save(config);
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  private buildOpenResult(
+    hospitalId: string,
+    projectedDeliveryAt: Date,
+  ): IntakeWindowCheckResult {
+    return {
+      hospitalId,
+      projectedDeliveryAt,
+      canReceive: true,
+      constraintViolations: [],
+      storageAvailable: true,
+      availableStorageUnits: Infinity,
+      withinReceivingWindow: true,
+      withinBlackoutPeriod: false,
+      requiresOverride: false,
+    };
+  }
+
+  private isInBlackoutPeriod(
+    config: HospitalCapacityConfigEntity,
+    at: Date,
+  ): boolean {
+    if (!config.blackoutPeriods?.length) return false;
+    return config.blackoutPeriods.some(
+      (bp) => at >= new Date(bp.startIso) && at <= new Date(bp.endIso),
+    );
+  }
+
+  private getActiveBlackout(config: HospitalCapacityConfigEntity, at: Date) {
+    return (
+      config.blackoutPeriods?.find(
+        (bp) => at >= new Date(bp.startIso) && at <= new Date(bp.endIso),
+      ) ?? null
+    );
+  }
+
+  private isWithinReceivingWindow(
+    config: HospitalCapacityConfigEntity,
+    at: Date,
+  ): boolean {
+    if (!config.receivingWindows?.length) return true;
+
+    const bufferMs = (config.intakeBufferMinutes ?? 0) * 60_000;
+    // Apply buffer: delivery must arrive at least `buffer` minutes before window closes
+    const effectiveAt = new Date(at.getTime() + bufferMs);
+
+    const dayOfWeek = effectiveAt.getUTCDay();
+    const hhmm = `${String(effectiveAt.getUTCHours()).padStart(2, '0')}:${String(
+      effectiveAt.getUTCMinutes(),
+    ).padStart(2, '0')}`;
+
+    return config.receivingWindows.some(
+      (w) =>
+        w.dayOfWeek === dayOfWeek && hhmm >= w.openTime && hhmm <= w.closeTime,
+    );
+  }
+}


### PR DESCRIPTION
## PR Description

### Description
Implements hospital capacity and operating window constraints as a first-class backend feature. Introduces a proper `HospitalEntity` to replace the stub, a `HospitalCapacityConfigEntity` that stores receiving window schedules, blackout periods, cold-storage limits, and buffer settings, and a `HospitalOverrideAuditEntity` for a full audit trail of emergency approvals. A dedicated `HospitalIntakeWindowService` performs the constraint check and exposes individual violation types so matching and dispatch callers can decide to block, warn, or request an override without duplicating logic.

### Related Issue
- Closes #400 

### Changes Made
- Added `HospitalEntity` with name, address, region, coordinates, status, and metadata; replaces the previous stub
- Added `HospitalCapacityConfigEntity` with `coldStorageCapacityUnits`, `currentStorageUnits`, `receivingWindows` (JSONB array of `{ dayOfWeek, openTime, closeTime }` slots in UTC), `blackoutPeriods` (JSONB), `allowEmergencyOverride`, `intakeBufferMinutes`, and `isEnforced` flag
- Added `HospitalOverrideAuditEntity` capturing `approvedByUserId`, `reason` (enum), `reasonNotes`, `bypassedConstraint` (JSONB snapshot), `projectedDeliveryAt`, and `isEmergency`
- Added `HospitalIntakeWindowService` with `checkIntakeWindow()` returning structured `IntakeWindowCheckResult` with typed `ConstraintViolation[]` for storage capacity, blackout periods, and receiving window violations; `recordOverride()` for auditable emergency approvals; `incrementStorageUsage()` / `decrementStorageUsage()` for intake tracking
- Added `HospitalsService` fully implemented with CRUD, nearby search (Haversine), and `upsertCapacityConfig()` / `getCapacityConfig()`
- Added controller endpoints: `POST /hospitals/intake-check`, `POST /hospitals/override`, `GET /hospitals/:id/overrides`, `POST /hospitals/:id/capacity-config`, `GET /hospitals/:id/capacity-config`
- Added `VIEW_HOSPITAL_OVERRIDES` and `MANAGE_HOSPITAL_OVERRIDES` permissions
- Added migration `1743000002000-CreateHospitalCapacityEntities` creating `hospitals`, `hospital_capacity_configs`, and `hospital_override_audits` tables with all enum types and indexes
- `HospitalsModule` now exports `HospitalIntakeWindowService` so `BloodMatchingModule` and `DispatchModule` can import and call `checkIntakeWindow()` before proceeding with fulfillment

### Acceptance Criteria
- Matching and dispatch can reject or warn on requests outside hospital intake constraints via `HospitalIntakeWindowService.checkIntakeWindow()` which returns `canReceive`, `requiresOverride`, and per-violation detail
- Emergency overrides are explicit and auditable — `POST /hospitals/override` captures the approving user, reason, bypassed constraints snapshot, and emergency flag in `hospital_override_audits`
- Dashboard users can surface capacity and receiving-window conflicts before fulfillment proceeds via `POST /hospitals/intake-check` and `GET /hospitals/:id/capacity-config`