### PR TITLE
feat: implement order splitting across multiple blood banks and riders

### DIFF
--- a/backend/src/blood-requests/blood-requests.module.ts
+++ b/backend/src/blood-requests/blood-requests.module.ts
@@ -9,20 +9,31 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { BloodRequestsController } from './blood-requests.controller';
 import { BloodRequestsService } from './blood-requests.service';
 import { RequestQueryController } from './controllers/request-query.controller';
+import { OrderSplittingController } from './controllers/order-splitting.controller';
 import { BloodRequestItemEntity } from './entities/blood-request-item.entity';
 import { BloodRequestEntity } from './entities/blood-request.entity';
+import { FulfillmentLegEntity } from './entities/fulfillment-leg.entity';
 import { RequestQueryService } from './services/request-query.service';
+import { OrderSplittingService } from './services/order-splitting.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([BloodRequestEntity, BloodRequestItemEntity]),
+    TypeOrmModule.forFeature([
+      BloodRequestEntity,
+      BloodRequestItemEntity,
+      FulfillmentLegEntity,
+    ]),
     InventoryModule,
     BlockchainModule,
     NotificationsModule,
     CompensationModule,
   ],
-  controllers: [BloodRequestsController, RequestQueryController],
-  providers: [BloodRequestsService, RequestQueryService],
-  exports: [BloodRequestsService, RequestQueryService],
+  controllers: [
+    BloodRequestsController,
+    RequestQueryController,
+    OrderSplittingController,
+  ],
+  providers: [BloodRequestsService, RequestQueryService, OrderSplittingService],
+  exports: [BloodRequestsService, RequestQueryService, OrderSplittingService],
 })
 export class BloodRequestsModule {}

--- a/backend/src/blood-requests/controllers/order-splitting.controller.ts
+++ b/backend/src/blood-requests/controllers/order-splitting.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Body,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { OrderSplittingService } from '../services/order-splitting.service';
+import { CreateSplitOrderDto } from '../dto/split-order.dto';
+import { BloodRequestEntity } from '../entities/blood-request.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FulfillmentLegStatus } from '../entities/fulfillment-leg.entity';
+
+@Controller('api/v1/orders/split')
+@UseGuards(JwtAuthGuard)
+export class OrderSplittingController {
+  constructor(
+    private readonly orderSplittingService: OrderSplittingService,
+    @InjectRepository(BloodRequestEntity)
+    private readonly bloodRequestRepository: Repository<BloodRequestEntity>,
+  ) {}
+
+  @Post()
+  async createSplitOrder(@Body() dto: CreateSplitOrderDto) {
+    const parentRequest = await this.bloodRequestRepository.findOne({
+      where: { id: dto.parentRequestId },
+    });
+
+    if (!parentRequest) {
+      throw new Error('Parent request not found');
+    }
+
+    return this.orderSplittingService.createSplitOrder(
+      parentRequest,
+      dto.allocationSources,
+    );
+  }
+
+  @Get(':parentRequestId/progress')
+  async getOrderProgress(@Param('parentRequestId') parentRequestId: string) {
+    return this.orderSplittingService.getParentOrderProgress(parentRequestId);
+  }
+
+  @Get(':parentRequestId/legs')
+  async getFulfillmentLegs(@Param('parentRequestId') parentRequestId: string) {
+    return this.orderSplittingService.getFulfillmentLegs(parentRequestId);
+  }
+
+  @Patch('legs/:legId/status')
+  async updateLegStatus(
+    @Param('legId') legId: string,
+    @Body()
+    body: {
+      status: FulfillmentLegStatus;
+      failureReason?: string;
+      deliveryTime?: number;
+    },
+  ) {
+    return this.orderSplittingService.updateLegStatus(legId, body.status, {
+      failureReason: body.failureReason,
+      deliveryTime: body.deliveryTime,
+    });
+  }
+
+  @Post('legs/:legId/fail')
+  async markLegAsFailed(
+    @Param('legId') legId: string,
+    @Body() body: { reason: string },
+  ) {
+    await this.orderSplittingService.handleLegFailure(legId, body.reason);
+    return { success: true, message: 'Leg marked as failed' };
+  }
+}

--- a/backend/src/blood-requests/dto/split-order.dto.ts
+++ b/backend/src/blood-requests/dto/split-order.dto.ts
@@ -1,0 +1,32 @@
+import { IsArray, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+
+export class AllocationSourceDto {
+  @IsString()
+  @IsNotEmpty()
+  bloodBankId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  bloodBankName: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  availableUnits: string[];
+
+  @IsNumber()
+  @Min(1)
+  quantityMl: number;
+
+  @IsString()
+  @IsNotEmpty()
+  pickupLocation: string;
+}
+
+export class CreateSplitOrderDto {
+  @IsString()
+  @IsNotEmpty()
+  parentRequestId: string;
+
+  @IsArray()
+  allocationSources: AllocationSourceDto[];
+}

--- a/backend/src/blood-requests/entities/fulfillment-leg.entity.ts
+++ b/backend/src/blood-requests/entities/fulfillment-leg.entity.ts
@@ -1,0 +1,127 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+
+import { BloodRequestEntity } from './blood-request.entity';
+
+export enum FulfillmentLegStatus {
+  PENDING = 'PENDING',
+  ALLOCATED = 'ALLOCATED',
+  RIDER_ASSIGNED = 'RIDER_ASSIGNED',
+  IN_TRANSIT = 'IN_TRANSIT',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+
+@Entity('fulfillment_legs')
+@Index('idx_fulfillment_legs_parent_request', ['parentRequestId'])
+@Index('idx_fulfillment_legs_status', ['status'])
+@Index('idx_fulfillment_legs_blood_bank', ['bloodBankId'])
+@Index('idx_fulfillment_legs_rider', ['riderId'])
+export class FulfillmentLegEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'parent_request_id', type: 'varchar', length: 64 })
+  parentRequestId: string;
+
+  @ManyToOne(() => BloodRequestEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'parent_request_id' })
+  parentRequest: BloodRequestEntity;
+
+  @Column({ name: 'leg_number', type: 'int' })
+  legNumber: number;
+
+  @Column({ name: 'blood_bank_id', type: 'varchar', length: 64 })
+  bloodBankId: string;
+
+  @Column({ name: 'blood_bank_name', type: 'varchar', length: 255 })
+  bloodBankName: string;
+
+  @Column({ name: 'allocated_units', type: 'simple-array' })
+  allocatedUnits: string[];
+
+  @Column({ name: 'quantity_ml', type: 'int' })
+  quantityMl: number;
+
+  @Column({ name: 'rider_id', type: 'varchar', length: 64, nullable: true })
+  riderId: string | null;
+
+  @Column({ name: 'rider_name', type: 'varchar', length: 255, nullable: true })
+  riderName: string | null;
+
+  @Column({
+    type: 'varchar',
+    length: 24,
+    default: FulfillmentLegStatus.PENDING,
+  })
+  status: FulfillmentLegStatus;
+
+  @Column({ name: 'estimated_delivery_time', type: 'bigint', nullable: true })
+  estimatedDeliveryTime: number | null;
+
+  @Column({ name: 'actual_delivery_time', type: 'bigint', nullable: true })
+  actualDeliveryTime: number | null;
+
+  @Column({ name: 'pickup_location', type: 'text', nullable: true })
+  pickupLocation: string | null;
+
+  @Column({ name: 'delivery_location', type: 'text', nullable: true })
+  deliveryLocation: string | null;
+
+  @Column({ name: 'failure_reason', type: 'text', nullable: true })
+  failureReason: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  isCompleted(): boolean {
+    return this.status === FulfillmentLegStatus.DELIVERED;
+  }
+
+  isFailed(): boolean {
+    return this.status === FulfillmentLegStatus.FAILED;
+  }
+
+  isInProgress(): boolean {
+    return [
+      FulfillmentLegStatus.ALLOCATED,
+      FulfillmentLegStatus.RIDER_ASSIGNED,
+      FulfillmentLegStatus.IN_TRANSIT,
+    ].includes(this.status);
+  }
+
+  markAsDelivered(deliveryTime: number): void {
+    this.status = FulfillmentLegStatus.DELIVERED;
+    this.actualDeliveryTime = deliveryTime;
+  }
+
+  markAsFailed(reason: string): void {
+    this.status = FulfillmentLegStatus.FAILED;
+    this.failureReason = reason;
+  }
+
+  assignRider(riderId: string, riderName: string): void {
+    this.riderId = riderId;
+    this.riderName = riderName;
+    this.status = FulfillmentLegStatus.RIDER_ASSIGNED;
+  }
+
+  startTransit(): void {
+    this.status = FulfillmentLegStatus.IN_TRANSIT;
+  }
+}

--- a/backend/src/blood-requests/services/order-splitting.service.ts
+++ b/backend/src/blood-requests/services/order-splitting.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { BloodRequestEntity } from '../entities/blood-request.entity';
+import {
+  FulfillmentLegEntity,
+  FulfillmentLegStatus,
+} from '../entities/fulfillment-leg.entity';
+
+export interface AllocationSource {
+  bloodBankId: string;
+  bloodBankName: string;
+  availableUnits: string[];
+  quantityMl: number;
+  pickupLocation: string;
+}
+
+export interface SplitOrderResult {
+  parentRequestId: string;
+  legs: FulfillmentLegEntity[];
+  totalLegs: number;
+}
+
+@Injectable()
+export class OrderSplittingService {
+  private readonly logger = new Logger(OrderSplittingService.name);
+
+  constructor(
+    @InjectRepository(FulfillmentLegEntity)
+    private readonly fulfillmentLegRepository: Repository<FulfillmentLegEntity>,
+    @InjectRepository(BloodRequestEntity)
+    private readonly bloodRequestRepository: Repository<BloodRequestEntity>,
+  ) {}
+
+  async createSplitOrder(
+    parentRequest: BloodRequestEntity,
+    allocationSources: AllocationSource[],
+  ): Promise<SplitOrderResult> {
+    this.logger.log(
+      `Creating split order for request ${parentRequest.id} across ${allocationSources.length} sources`,
+    );
+
+    const legs: FulfillmentLegEntity[] = [];
+
+    for (let i = 0; i < allocationSources.length; i++) {
+      const source = allocationSources[i];
+      const leg = this.fulfillmentLegRepository.create({
+        parentRequestId: parentRequest.id,
+        legNumber: i + 1,
+        bloodBankId: source.bloodBankId,
+        bloodBankName: source.bloodBankName,
+        allocatedUnits: source.availableUnits,
+        quantityMl: source.quantityMl,
+        status: FulfillmentLegStatus.ALLOCATED,
+        pickupLocation: source.pickupLocation,
+        deliveryLocation: parentRequest.deliveryAddress,
+      });
+
+      const savedLeg = await this.fulfillmentLegRepository.save(leg);
+      legs.push(savedLeg);
+    }
+
+    return {
+      parentRequestId: parentRequest.id,
+      legs,
+      totalLegs: legs.length,
+    };
+  }
+
+  async getFulfillmentLegs(
+    parentRequestId: string,
+  ): Promise<FulfillmentLegEntity[]> {
+    return this.fulfillmentLegRepository.find({
+      where: { parentRequestId },
+      order: { legNumber: 'ASC' },
+    });
+  }
+
+  async updateLegStatus(
+    legId: string,
+    status: FulfillmentLegStatus,
+    metadata?: { failureReason?: string; deliveryTime?: number },
+  ): Promise<FulfillmentLegEntity> {
+    const leg = await this.fulfillmentLegRepository.findOne({
+      where: { id: legId },
+    });
+
+    if (!leg) {
+      throw new Error(`Fulfillment leg ${legId} not found`);
+    }
+
+    leg.status = status;
+
+    if (metadata?.failureReason) {
+      leg.failureReason = metadata.failureReason;
+    }
+
+    if (metadata?.deliveryTime) {
+      leg.actualDeliveryTime = metadata.deliveryTime;
+    }
+
+    return this.fulfillmentLegRepository.save(leg);
+  }
+
+  async getParentOrderProgress(parentRequestId: string): Promise<{
+    totalLegs: number;
+    completedLegs: number;
+    failedLegs: number;
+    inProgressLegs: number;
+    overallStatus: string;
+    legs: FulfillmentLegEntity[];
+  }> {
+    const legs = await this.getFulfillmentLegs(parentRequestId);
+
+    const completedLegs = legs.filter((leg) => leg.isCompleted()).length;
+    const failedLegs = legs.filter((leg) => leg.isFailed()).length;
+    const inProgressLegs = legs.filter((leg) => leg.isInProgress()).length;
+
+    let overallStatus = 'PENDING';
+    if (completedLegs === legs.length) {
+      overallStatus = 'FULLY_DELIVERED';
+    } else if (completedLegs > 0) {
+      overallStatus = 'PARTIALLY_DELIVERED';
+    } else if (failedLegs === legs.length) {
+      overallStatus = 'ALL_FAILED';
+    } else if (inProgressLegs > 0) {
+      overallStatus = 'IN_PROGRESS';
+    }
+
+    return {
+      totalLegs: legs.length,
+      completedLegs,
+      failedLegs,
+      inProgressLegs,
+      overallStatus,
+      legs,
+    };
+  }
+
+  async handleLegFailure(
+    legId: string,
+    failureReason: string,
+  ): Promise<void> {
+    const leg = await this.fulfillmentLegRepository.findOne({
+      where: { id: legId },
+    });
+
+    if (!leg) {
+      throw new Error(`Fulfillment leg ${legId} not found`);
+    }
+
+    leg.markAsFailed(failureReason);
+    await this.fulfillmentLegRepository.save(leg);
+
+    this.logger.warn(
+      `Leg ${legId} failed: ${failureReason}. Other legs continue.`,
+    );
+
+    const progress = await this.getParentOrderProgress(leg.parentRequestId);
+    if (progress.completedLegs > 0) {
+      this.logger.log(
+        `Parent order ${leg.parentRequestId} has ${progress.completedLegs} successful legs despite failure`,
+      );
+    }
+  }
+}

--- a/frontend/health-chain/components/orders/SplitOrderView.tsx
+++ b/frontend/health-chain/components/orders/SplitOrderView.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface FulfillmentLeg {
+  id: string;
+  legNumber: number;
+  bloodBankName: string;
+  quantityMl: number;
+  status: string;
+  riderName: string | null;
+  estimatedDeliveryTime: number | null;
+  actualDeliveryTime: number | null;
+  failureReason: string | null;
+}
+
+interface OrderProgress {
+  totalLegs: number;
+  completedLegs: number;
+  failedLegs: number;
+  inProgressLegs: number;
+  overallStatus: string;
+  legs: FulfillmentLeg[];
+}
+
+interface SplitOrderViewProps {
+  parentRequestId: string;
+}
+
+export default function SplitOrderView({ parentRequestId }: SplitOrderViewProps) {
+  const [progress, setProgress] = useState<OrderProgress | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchOrderProgress();
+    const interval = setInterval(fetchOrderProgress, 30000);
+    return () => clearInterval(interval);
+  }, [parentRequestId]);
+
+  const fetchOrderProgress = async () => {
+    try {
+      const response = await fetch(
+        `/api/v1/orders/split/${parentRequestId}/progress`
+      );
+      const data = await response.json();
+      setProgress(data);
+    } catch (error) {
+      console.error('Failed to fetch order progress:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'DELIVERED':
+        return 'bg-green-100 text-green-800';
+      case 'FAILED':
+        return 'bg-red-100 text-red-800';
+      case 'IN_TRANSIT':
+        return 'bg-blue-100 text-blue-800';
+      case 'RIDER_ASSIGNED':
+        return 'bg-yellow-100 text-yellow-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const formatTimestamp = (timestamp: number | null) => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp * 1000).toLocaleString();
+  };
+
+  if (loading) {
+    return <div className="p-4">Loading order details...</div>;
+  }
+
+  if (!progress) {
+    return <div className="p-4">No order data available</div>;
+  }
+
+  return (
+    <div className="p-6 bg-white rounded-lg shadow">
+      <h2 className="text-2xl font-bold mb-4">Split Order Progress</h2>
+      
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="p-4 bg-blue-50 rounded">
+          <div className="text-sm text-gray-600">Total Legs</div>
+          <div className="text-2xl font-bold">{progress.totalLegs}</div>
+        </div>
+        <div className="p-4 bg-green-50 rounded">
+          <div className="text-sm text-gray-600">Completed</div>
+          <div className="text-2xl font-bold text-green-600">
+            {progress.completedLegs}
+          </div>
+        </div>
+        <div className="p-4 bg-yellow-50 rounded">
+          <div className="text-sm text-gray-600">In Progress</div>
+          <div className="text-2xl font-bold text-yellow-600">
+            {progress.inProgressLegs}
+          </div>
+        </div>
+        <div className="p-4 bg-red-50 rounded">
+          <div className="text-sm text-gray-600">Failed</div>
+          <div className="text-2xl font-bold text-red-600">
+            {progress.failedLegs}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <span className="text-sm font-medium">Overall Status: </span>
+        <span className={`px-3 py-1 rounded-full text-sm ${getStatusColor(progress.overallStatus)}`}>
+          {progress.overallStatus}
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold">Fulfillment Legs</h3>
+        {progress.legs.map((leg) => (
+          <div key={leg.id} className="border rounded-lg p-4">
+            <div className="flex justify-between items-start mb-2">
+              <div>
+                <h4 className="font-semibold">
+                  Leg {leg.legNumber} - {leg.bloodBankName}
+                </h4>
+                <p className="text-sm text-gray-600">
+                  Quantity: {leg.quantityMl} ml
+                </p>
+              </div>
+              <span className={`px-3 py-1 rounded-full text-sm ${getStatusColor(leg.status)}`}>
+                {leg.status}
+              </span>
+            </div>
+            
+            {leg.riderName && (
+              <p className="text-sm text-gray-600">Rider: {leg.riderName}</p>
+            )}
+            
+            <div className="mt-2 text-sm">
+              {leg.estimatedDeliveryTime && (
+                <p>ETA: {formatTimestamp(leg.estimatedDeliveryTime)}</p>
+              )}
+              {leg.actualDeliveryTime && (
+                <p className="text-green-600">
+                  Delivered: {formatTimestamp(leg.actualDeliveryTime)}
+                </p>
+              )}
+              {leg.failureReason && (
+                <p className="text-red-600">
+                  Failure Reason: {leg.failureReason}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add FulfillmentLegEntity to track individual fulfillment legs
- Create OrderSplittingService for managing split orders
- Add OrderSplittingController with REST endpoints
- Implement leg-level status tracking and failure handling
- Add SplitOrderView component for frontend visualization
- Support parallel fulfillment with independent leg progress
- Enable partial completion without cancelling successful legs

Closes #378