### PR TITLE
feat: initialize analytics contract (#201)

### DIFF
--- a/lifebank-soroban/contracts/analytics/Cargo.toml
+++ b/lifebank-soroban/contracts/analytics/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "analytics-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/lifebank-soroban/contracts/analytics/src/error.rs
+++ b/lifebank-soroban/contracts/analytics/src/error.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AnalyticsError {
+    AlreadyInitialized = 900,
+    NotInitialized = 901,
+    Unauthorized = 902,
+    InvalidPeriod = 903,
+    PeriodNotFound = 904,
+    MetricNotFound = 905,
+}

--- a/lifebank-soroban/contracts/analytics/src/lib.rs
+++ b/lifebank-soroban/contracts/analytics/src/lib.rs
@@ -1,0 +1,274 @@
+#![no_std]
+
+mod error;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+pub use error::AnalyticsError;
+pub use types::{AnalyticsConfig, DataKey, MetricsSnapshot, PeriodType, ReportingPeriod};
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const DAILY_SECS: u64 = 86_400;
+const WEEKLY_SECS: u64 = 604_800;
+const MONTHLY_SECS: u64 = 2_592_000; // 30 days
+
+// ── Storage helpers ───────────────────────────────────────────────────────────
+
+fn require_initialized(env: &Env) -> Result<AnalyticsConfig, AnalyticsError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(AnalyticsError::NotInitialized)
+}
+
+fn require_admin(env: &Env) -> Result<AnalyticsConfig, AnalyticsError> {
+    let cfg = require_initialized(env)?;
+    cfg.admin.require_auth();
+    Ok(cfg)
+}
+
+fn current_period_index(env: &Env, duration_secs: u64) -> u64 {
+    env.ledger().timestamp() / duration_secs
+}
+
+fn load_snapshot(env: &Env, period_index: u64) -> MetricsSnapshot {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Snapshot(period_index))
+        .unwrap_or(MetricsSnapshot {
+            period_index,
+            total_donations: 0,
+            total_requests: 0,
+            total_deliveries: 0,
+            total_payments_released: 0,
+            total_volume: 0,
+            last_updated: 0,
+        })
+}
+
+fn save_snapshot(env: &Env, snapshot: &MetricsSnapshot) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Snapshot(snapshot.period_index), snapshot);
+}
+
+fn get_counter_u64(env: &Env, key: &DataKey) -> u64 {
+    env.storage().instance().get(key).unwrap_or(0u64)
+}
+
+fn get_counter_i128(env: &Env, key: &DataKey) -> i128 {
+    env.storage().instance().get(key).unwrap_or(0i128)
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct AnalyticsContract;
+
+#[contractimpl]
+impl AnalyticsContract {
+    /// Initialize the analytics contract.
+    ///
+    /// Links all domain contracts, sets the default reporting period (daily),
+    /// and zeroes all lifetime counters. Can only be called once.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        inventory_contract: Address,
+        requests_contract: Address,
+        payments_contract: Address,
+        reputation_contract: Address,
+    ) -> Result<(), AnalyticsError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Config) {
+            return Err(AnalyticsError::AlreadyInitialized);
+        }
+
+        let now = env.ledger().timestamp();
+
+        let config = AnalyticsConfig {
+            admin: admin.clone(),
+            inventory_contract,
+            requests_contract,
+            payments_contract,
+            reputation_contract,
+            reporting_period: ReportingPeriod {
+                period_type: PeriodType::Daily,
+                duration_secs: DAILY_SECS,
+                configured_at: now,
+            },
+            initialized_at: now,
+        };
+
+        env.storage().instance().set(&DataKey::Config, &config);
+
+        // Initialize lifetime counters to zero.
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDonations, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalRequests, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDeliveries, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalPaymentsReleased, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalVolume, &0i128);
+
+        env.events()
+            .publish((symbol_short!("anlytcs"), symbol_short!("init")), admin);
+
+        Ok(())
+    }
+
+    // ── Configuration ─────────────────────────────────────────────────────────
+
+    /// Update the reporting period. Admin only.
+    pub fn set_reporting_period(
+        env: Env,
+        period_type: PeriodType,
+    ) -> Result<(), AnalyticsError> {
+        let mut cfg = require_admin(&env)?;
+
+        let duration_secs = match period_type {
+            PeriodType::Daily => DAILY_SECS,
+            PeriodType::Weekly => WEEKLY_SECS,
+            PeriodType::Monthly => MONTHLY_SECS,
+        };
+
+        cfg.reporting_period = ReportingPeriod {
+            period_type,
+            duration_secs,
+            configured_at: env.ledger().timestamp(),
+        };
+
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        Ok(())
+    }
+
+    // ── Metric ingestion ──────────────────────────────────────────────────────
+
+    /// Record a new donation. Admin only.
+    pub fn record_donation(env: Env) -> Result<(), AnalyticsError> {
+        let cfg = require_admin(&env)?;
+        let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
+        let mut snap = load_snapshot(&env, idx);
+        snap.total_donations += 1;
+        snap.last_updated = env.ledger().timestamp();
+        save_snapshot(&env, &snap);
+
+        let total = get_counter_u64(&env, &DataKey::TotalDonations) + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDonations, &total);
+        Ok(())
+    }
+
+    /// Record a new blood request. Admin only.
+    pub fn record_request(env: Env) -> Result<(), AnalyticsError> {
+        let cfg = require_admin(&env)?;
+        let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
+        let mut snap = load_snapshot(&env, idx);
+        snap.total_requests += 1;
+        snap.last_updated = env.ledger().timestamp();
+        save_snapshot(&env, &snap);
+
+        let total = get_counter_u64(&env, &DataKey::TotalRequests) + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalRequests, &total);
+        Ok(())
+    }
+
+    /// Record a completed delivery. Admin only.
+    pub fn record_delivery(env: Env) -> Result<(), AnalyticsError> {
+        let cfg = require_admin(&env)?;
+        let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
+        let mut snap = load_snapshot(&env, idx);
+        snap.total_deliveries += 1;
+        snap.last_updated = env.ledger().timestamp();
+        save_snapshot(&env, &snap);
+
+        let total = get_counter_u64(&env, &DataKey::TotalDeliveries) + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDeliveries, &total);
+        Ok(())
+    }
+
+    /// Record a released payment with its amount. Admin only.
+    pub fn record_payment_released(env: Env, amount: i128) -> Result<(), AnalyticsError> {
+        let cfg = require_admin(&env)?;
+        let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
+        let mut snap = load_snapshot(&env, idx);
+        snap.total_payments_released += 1;
+        snap.total_volume += amount;
+        snap.last_updated = env.ledger().timestamp();
+        save_snapshot(&env, &snap);
+
+        let total_payments = get_counter_u64(&env, &DataKey::TotalPaymentsReleased) + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalPaymentsReleased, &total_payments);
+
+        let total_volume = get_counter_i128(&env, &DataKey::TotalVolume) + amount;
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalVolume, &total_volume);
+        Ok(())
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    /// Get the metrics snapshot for the current period.
+    pub fn get_current_snapshot(env: Env) -> Result<MetricsSnapshot, AnalyticsError> {
+        let cfg = require_initialized(&env)?;
+        let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
+        Ok(load_snapshot(&env, idx))
+    }
+
+    /// Get the metrics snapshot for a specific period index.
+    pub fn get_snapshot(
+        env: Env,
+        period_index: u64,
+    ) -> Result<MetricsSnapshot, AnalyticsError> {
+        require_initialized(&env)?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::Snapshot(period_index))
+            .ok_or(AnalyticsError::PeriodNotFound)
+    }
+
+    /// Get lifetime totals across all periods.
+    pub fn get_lifetime_totals(env: Env) -> Result<MetricsSnapshot, AnalyticsError> {
+        require_initialized(&env)?;
+        Ok(MetricsSnapshot {
+            period_index: u64::MAX,
+            total_donations: get_counter_u64(&env, &DataKey::TotalDonations),
+            total_requests: get_counter_u64(&env, &DataKey::TotalRequests),
+            total_deliveries: get_counter_u64(&env, &DataKey::TotalDeliveries),
+            total_payments_released: get_counter_u64(&env, &DataKey::TotalPaymentsReleased),
+            total_volume: get_counter_i128(&env, &DataKey::TotalVolume),
+            last_updated: env.ledger().timestamp(),
+        })
+    }
+
+    /// Get the current contract configuration.
+    pub fn get_config(env: Env) -> Result<AnalyticsConfig, AnalyticsError> {
+        require_initialized(&env)
+    }
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Config)
+    }
+}

--- a/lifebank-soroban/contracts/analytics/src/test.rs
+++ b/lifebank-soroban/contracts/analytics/src/test.rs
@@ -1,0 +1,167 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::{AnalyticsContract, AnalyticsContractClient, AnalyticsError, PeriodType};
+
+fn setup<'a>() -> (Env, Address, AnalyticsContractClient<'a>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let inventory = Address::generate(&env);
+    let requests = Address::generate(&env);
+    let payments = Address::generate(&env);
+    let reputation = Address::generate(&env);
+
+    let id = env.register(AnalyticsContract, ());
+    let client = AnalyticsContractClient::new(&env, &id);
+
+    client.initialize(&admin, &inventory, &requests, &payments, &reputation);
+
+    (env, admin, client)
+}
+
+// ── Initialization ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_succeeds() {
+    let (_, _, client) = setup();
+    assert!(client.is_initialized());
+}
+
+#[test]
+fn test_initialize_sets_config() {
+    let (env, admin, client) = setup();
+    let cfg = client.get_config();
+    assert_eq!(cfg.admin, admin);
+    assert_eq!(cfg.reporting_period.duration_secs, 86_400);
+    assert_eq!(cfg.initialized_at, env.ledger().timestamp());
+}
+
+#[test]
+fn test_double_initialize_fails() {
+    let (_, _, client) = setup();
+    let admin2 = Address::generate(&client.env);
+    let dummy = Address::generate(&client.env);
+    let result = client.try_initialize(&admin2, &dummy, &dummy, &dummy, &dummy);
+    assert_eq!(result, Err(Ok(AnalyticsError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_is_initialized_false_before_init() {
+    let env = Env::default();
+    let id = env.register(AnalyticsContract, ());
+    let client = AnalyticsContractClient::new(&env, &id);
+    assert!(!client.is_initialized());
+}
+
+// ── Lifetime counters start at zero ──────────────────────────────────────────
+
+#[test]
+fn test_lifetime_totals_zero_after_init() {
+    let (_, _, client) = setup();
+    let totals = client.get_lifetime_totals();
+    assert_eq!(totals.total_donations, 0);
+    assert_eq!(totals.total_requests, 0);
+    assert_eq!(totals.total_deliveries, 0);
+    assert_eq!(totals.total_payments_released, 0);
+    assert_eq!(totals.total_volume, 0);
+}
+
+// ── Metric recording ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_record_donation_increments_counters() {
+    let (_, _, client) = setup();
+    client.record_donation();
+    client.record_donation();
+
+    let snap = client.get_current_snapshot();
+    assert_eq!(snap.total_donations, 2);
+
+    let totals = client.get_lifetime_totals();
+    assert_eq!(totals.total_donations, 2);
+}
+
+#[test]
+fn test_record_request_increments_counters() {
+    let (_, _, client) = setup();
+    client.record_request();
+
+    let snap = client.get_current_snapshot();
+    assert_eq!(snap.total_requests, 1);
+}
+
+#[test]
+fn test_record_delivery_increments_counters() {
+    let (_, _, client) = setup();
+    client.record_delivery();
+
+    let snap = client.get_current_snapshot();
+    assert_eq!(snap.total_deliveries, 1);
+}
+
+#[test]
+fn test_record_payment_released_increments_counters() {
+    let (_, _, client) = setup();
+    client.record_payment_released(&500_i128);
+    client.record_payment_released(&300_i128);
+
+    let snap = client.get_current_snapshot();
+    assert_eq!(snap.total_payments_released, 2);
+    assert_eq!(snap.total_volume, 800);
+
+    let totals = client.get_lifetime_totals();
+    assert_eq!(totals.total_volume, 800);
+}
+
+// ── Reporting period ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_reporting_period_weekly() {
+    let (_, _, client) = setup();
+    client.set_reporting_period(&PeriodType::Weekly);
+    let cfg = client.get_config();
+    assert_eq!(cfg.reporting_period.duration_secs, 604_800);
+}
+
+#[test]
+fn test_set_reporting_period_monthly() {
+    let (_, _, client) = setup();
+    client.set_reporting_period(&PeriodType::Monthly);
+    let cfg = client.get_config();
+    assert_eq!(cfg.reporting_period.duration_secs, 2_592_000);
+}
+
+// ── Period snapshot isolation ─────────────────────────────────────────────────
+
+#[test]
+fn test_get_snapshot_not_found_returns_error() {
+    let (_, _, client) = setup();
+    let result = client.try_get_snapshot(&9999u64);
+    assert_eq!(result, Err(Ok(AnalyticsError::PeriodNotFound)));
+}
+
+#[test]
+fn test_get_snapshot_returns_correct_period() {
+    let (env, _, client) = setup();
+    client.record_donation();
+
+    let period_index = env.ledger().timestamp() / 86_400;
+    let snap = client.get_snapshot(&period_index);
+    assert_eq!(snap.total_donations, 1);
+    assert_eq!(snap.period_index, period_index);
+}
+
+// ── Guard: not initialized ────────────────────────────────────────────────────
+
+#[test]
+fn test_record_donation_fails_when_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AnalyticsContract, ());
+    let client = AnalyticsContractClient::new(&env, &id);
+    let result = client.try_record_donation();
+    assert_eq!(result, Err(Ok(AnalyticsError::NotInitialized)));
+}

--- a/lifebank-soroban/contracts/analytics/src/types.rs
+++ b/lifebank-soroban/contracts/analytics/src/types.rs
@@ -1,0 +1,65 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Reporting period granularity.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PeriodType {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+/// A single reporting period window.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReportingPeriod {
+    pub period_type: PeriodType,
+    /// Duration in seconds (e.g. 86400 for daily).
+    pub duration_secs: u64,
+    /// Ledger timestamp when this period configuration was set.
+    pub configured_at: u64,
+}
+
+/// Aggregate metrics snapshot for a given period bucket.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MetricsSnapshot {
+    /// Period bucket index (floor(timestamp / duration_secs)).
+    pub period_index: u64,
+    pub total_donations: u64,
+    pub total_requests: u64,
+    pub total_deliveries: u64,
+    pub total_payments_released: u64,
+    /// Sum of payment amounts released (smallest units).
+    pub total_volume: i128,
+    pub last_updated: u64,
+}
+
+/// Contract-level configuration stored at initialization.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnalyticsConfig {
+    pub admin: Address,
+    pub inventory_contract: Address,
+    pub requests_contract: Address,
+    pub payments_contract: Address,
+    pub reputation_contract: Address,
+    pub reporting_period: ReportingPeriod,
+    pub initialized_at: u64,
+}
+
+/// Storage keys.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// AnalyticsConfig — instance storage.
+    Config,
+    /// MetricsSnapshot keyed by period_index — persistent storage.
+    Snapshot(u64),
+    /// Global lifetime counters — instance storage.
+    TotalDonations,
+    TotalRequests,
+    TotalDeliveries,
+    TotalPaymentsReleased,
+    TotalVolume,
+}


### PR DESCRIPTION
Closes #201

## Changes
- New `analytics-contract` crate at `lifebank-soroban/contracts/analytics/`
- `initialize()` links all domain contracts (inventory, requests, payments, reputation), sets daily reporting period, and zeroes all lifetime counters
- Configurable reporting periods: Daily / Weekly / Monthly via `set_reporting_period()`
- Admin-only metric ingestion: `record_donation`, `record_request`, `record_delivery`, `record_payment_released`
- Per-period `MetricsSnapshot` in persistent storage + lifetime counters in instance storage
- Query functions: `get_current_snapshot`, `get_snapshot`, `get_lifetime_totals`, `get_config`, `is_initialized`
- 14 tests covering all tasks in the issue
