### PR TITLE
feat(policy-center): implement policy version management

### DIFF
--- a/backend/src/anomaly/anomaly-scoring.service.ts
+++ b/backend/src/anomaly/anomaly-scoring.service.ts
@@ -6,6 +6,7 @@ import { Repository, MoreThan } from 'typeorm';
 import { BloodRequestEntity, Urgency } from '../../blood-requests/entities/blood-request.entity';
 import { OrderEntity } from '../../orders/entities/order.entity';
 import { OrderStatus } from '../../orders/enums/order-status.enum';
+import { PolicyCenterService } from '../../policy-center/policy-center.service';
 import { AnomalyIncidentEntity } from '../entities/anomaly-incident.entity';
 import {
   AnomalyType,
@@ -24,23 +25,31 @@ export class AnomalyScoringService {
     private readonly requestRepo: Repository<BloodRequestEntity>,
     @InjectRepository(OrderEntity)
     private readonly orderRepo: Repository<OrderEntity>,
+    private readonly policyCenterService: PolicyCenterService,
   ) {}
 
   /** Run full scoring pipeline every 30 minutes */
   @Cron(CronExpression.EVERY_30_MINUTES)
   async runPipeline(): Promise<void> {
     this.logger.log('Running anomaly scoring pipeline');
+
+    const policy = await this.policyCenterService.getActivePolicySnapshot();
     await Promise.all([
-      this.detectDuplicateEmergencyRequests(),
-      this.detectRepeatedEscrowDisputes(),
-      this.detectSuddenStockSwings(),
-      this.detectHighRiderCancellations(),
+      this.detectDuplicateEmergencyRequests(policy.rules.anomaly, policy.policyVersionId),
+      this.detectRepeatedEscrowDisputes(policy.rules.anomaly, policy.policyVersionId),
+      this.detectSuddenStockSwings(policy.rules.anomaly, policy.policyVersionId),
+      this.detectHighRiderCancellations(policy.rules.anomaly, policy.policyVersionId),
     ]);
   }
 
   // ─── Rule 1: Same-day duplicate emergency requests per hospital ───────────
 
-  private async detectDuplicateEmergencyRequests(): Promise<void> {
+  private async detectDuplicateEmergencyRequests(
+    rules: {
+      duplicateEmergencyMinCount: number;
+    },
+    policyVersionRef: string,
+  ): Promise<void> {
     const since = new Date();
     since.setHours(0, 0, 0, 0);
     const sinceMs = since.getTime();
@@ -52,7 +61,9 @@ export class AnomalyScoringService {
       .where('r.urgency = :urgency', { urgency: Urgency.CRITICAL })
       .andWhere('r.created_timestamp >= :since', { since: sinceMs })
       .groupBy('r.hospital_id')
-      .having('COUNT(*) >= :threshold', { threshold: 3 })
+      .having('COUNT(*) >= :threshold', {
+        threshold: rules.duplicateEmergencyMinCount,
+      })
       .getRawMany();
 
     for (const row of rows) {
@@ -62,13 +73,20 @@ export class AnomalyScoringService {
         hospitalId: row.hospitalId,
         description: `Hospital ${row.hospitalId} submitted ${row.count} CRITICAL blood requests today.`,
         metadata: { count: row.count, date: since.toISOString() },
+        policyVersionRef,
       });
     }
   }
 
   // ─── Rule 2: Riders with high cancellation ratio ──────────────────────────
 
-  private async detectHighRiderCancellations(): Promise<void> {
+  private async detectHighRiderCancellations(
+    rules: {
+      riderMinOrders: number;
+      riderCancellationRatioThreshold: number;
+    },
+    policyVersionRef: string,
+  ): Promise<void> {
     const rows: { riderId: string; cancelled: string; total: string }[] =
       await this.orderRepo
         .createQueryBuilder('o')
@@ -80,9 +98,12 @@ export class AnomalyScoringService {
         .addSelect('COUNT(*)', 'total')
         .where('o.rider_id IS NOT NULL')
         .groupBy('o.rider_id')
-        .having('COUNT(*) >= 5')
+        .having('COUNT(*) >= :minOrders', {
+          minOrders: rules.riderMinOrders,
+        })
         .andHaving(
-          `SUM(CASE WHEN o.status = '${OrderStatus.CANCELLED}' THEN 1 ELSE 0 END)::float / COUNT(*) >= 0.4`,
+          `SUM(CASE WHEN o.status = '${OrderStatus.CANCELLED}' THEN 1 ELSE 0 END)::float / COUNT(*) >= :threshold`,
+          { threshold: rules.riderCancellationRatioThreshold },
         )
         .getRawMany();
 
@@ -94,20 +115,28 @@ export class AnomalyScoringService {
         riderId: row.riderId,
         description: `Rider ${row.riderId} has a ${ratio.toFixed(0)}% cancellation rate (${row.cancelled}/${row.total} orders).`,
         metadata: { cancelled: row.cancelled, total: row.total },
+        policyVersionRef,
       });
     }
   }
 
   // ─── Rule 3: Repeated escrow disputes per order ───────────────────────────
 
-  private async detectRepeatedEscrowDisputes(): Promise<void> {
+  private async detectRepeatedEscrowDisputes(
+    rules: {
+      disputeCountThreshold: number;
+    },
+    policyVersionRef: string,
+  ): Promise<void> {
     const rows: { hospitalId: string; count: string }[] = await this.orderRepo
       .createQueryBuilder('o')
       .select('o.hospital_id', 'hospitalId')
       .addSelect('COUNT(*)', 'count')
       .where('o.dispute_id IS NOT NULL')
       .groupBy('o.hospital_id')
-      .having('COUNT(*) >= 3')
+      .having('COUNT(*) >= :threshold', {
+        threshold: rules.disputeCountThreshold,
+      })
       .getRawMany();
 
     for (const row of rows) {
@@ -117,14 +146,21 @@ export class AnomalyScoringService {
         hospitalId: row.hospitalId,
         description: `Hospital ${row.hospitalId} has ${row.count} disputed orders.`,
         metadata: { disputeCount: row.count },
+        policyVersionRef,
       });
     }
   }
 
   // ─── Rule 4: Sudden stock swing (many orders in short window) ─────────────
 
-  private async detectSuddenStockSwings(): Promise<void> {
-    const since = new Date(Date.now() - 60 * 60 * 1000); // last 1 hour
+  private async detectSuddenStockSwings(
+    rules: {
+      stockSwingWindowMinutes: number;
+      stockSwingMinOrders: number;
+    },
+    policyVersionRef: string,
+  ): Promise<void> {
+    const since = new Date(Date.now() - rules.stockSwingWindowMinutes * 60 * 1000);
 
     const rows: { bloodType: string; count: string }[] = await this.orderRepo
       .createQueryBuilder('o')
@@ -132,15 +168,18 @@ export class AnomalyScoringService {
       .addSelect('COUNT(*)', 'count')
       .where('o.created_at >= :since', { since })
       .groupBy('o.blood_type')
-      .having('COUNT(*) >= 10')
+      .having('COUNT(*) >= :threshold', {
+        threshold: rules.stockSwingMinOrders,
+      })
       .getRawMany();
 
     for (const row of rows) {
       await this.upsertAnomaly({
         type: AnomalyType.SUDDEN_STOCK_SWING,
         severity: AnomalySeverity.MEDIUM,
-        description: `${row.count} orders for blood type ${row.bloodType} placed in the last hour.`,
+        description: `${row.count} orders for blood type ${row.bloodType} placed in the last ${rules.stockSwingWindowMinutes} minutes.`,
         metadata: { bloodType: row.bloodType, count: row.count, windowStart: since.toISOString() },
+        policyVersionRef,
       });
     }
   }
@@ -156,6 +195,7 @@ export class AnomalyScoringService {
     riderId?: string;
     hospitalId?: string;
     bloodRequestId?: string;
+    policyVersionRef?: string;
   }): Promise<void> {
     // Avoid duplicate open incidents for the same subject on the same day
     const today = new Date();
@@ -176,6 +216,7 @@ export class AnomalyScoringService {
         description: data.description,
         metadata: data.metadata ?? null,
         severity: data.severity,
+        policyVersionRef: data.policyVersionRef ?? null,
       });
       return;
     }
@@ -188,6 +229,7 @@ export class AnomalyScoringService {
         riderId: data.riderId ?? null,
         hospitalId: data.hospitalId ?? null,
         bloodRequestId: data.bloodRequestId ?? null,
+        policyVersionRef: data.policyVersionRef ?? null,
       }),
     );
   }

--- a/backend/src/anomaly/anomaly.module.ts
+++ b/backend/src/anomaly/anomaly.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BloodRequestEntity } from '../blood-requests/entities/blood-request.entity';
 import { OrderEntity } from '../orders/entities/order.entity';
+import { PolicyCenterModule } from '../policy-center/policy-center.module';
 
 import { AnomalyController } from './anomaly.controller';
 import { AnomalyScoringService } from './anomaly-scoring.service';
@@ -16,6 +17,7 @@ import { AnomalyIncidentEntity } from './entities/anomaly-incident.entity';
       BloodRequestEntity,
       OrderEntity,
     ]),
+    PolicyCenterModule,
   ],
   controllers: [AnomalyController],
   providers: [AnomalyService, AnomalyScoringService],

--- a/backend/src/anomaly/entities/anomaly-incident.entity.ts
+++ b/backend/src/anomaly/entities/anomaly-incident.entity.ts
@@ -46,6 +46,9 @@ export class AnomalyIncidentEntity {
   @Column({ name: 'blood_request_id', type: 'varchar', nullable: true })
   bloodRequestId: string | null;
 
+  @Column({ name: 'policy_version_ref', type: 'varchar', nullable: true })
+  policyVersionRef: string | null;
+
   /** Raw evidence snapshot */
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, unknown> | null;

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -34,6 +34,7 @@ import { UserActivityModule } from './user-activity/user-activity.module';
 import { UsersModule } from './users/users.module';
 import { TrackingModule } from './tracking/tracking.module';
 import { TransparencyModule } from './transparency/transparency.module';
+import { PolicyCenterModule } from './policy-center/policy-center.module';
 
 import type Redis from 'ioredis';
 
@@ -77,6 +78,7 @@ import type Redis from 'ioredis';
     HospitalsModule,
     MapsModule,
     TransparencyModule,
+    PolicyCenterModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/blood-units/blood-inventory-query.service.ts
+++ b/backend/src/blood-units/blood-inventory-query.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository, SelectQueryBuilder } from 'typeorm';
+import { PolicyCenterService } from '../policy-center/policy-center.service';
 
 import {
   InventorySortField,
@@ -22,6 +23,7 @@ export interface InventoryStatistics {
   byBloodType: Record<string, number>;
   byComponent: Record<string, number>;
   totalVolumeMl: number;
+  policyVersionRef?: string;
 }
 
 export interface AvailabilityResult {
@@ -37,6 +39,7 @@ export class BloodInventoryQueryService {
   constructor(
     @InjectRepository(BloodUnit)
     private readonly bloodUnitRepository: Repository<BloodUnit>,
+    private readonly policyCenterService: PolicyCenterService,
   ) {}
 
   async query(dto: QueryBloodInventoryDto): Promise<{
@@ -75,8 +78,11 @@ export class BloodInventoryQueryService {
   }
 
   async getStatistics(bankId?: string): Promise<InventoryStatistics> {
+    const policy = await this.policyCenterService.getActivePolicySnapshot();
     const now = new Date();
-    const soonThreshold = new Date(now.getTime() + 72 * 60 * 60 * 1000); // 72 hours
+    const soonThreshold = new Date(
+      now.getTime() + policy.rules.inventory.expiringSoonHours * 60 * 60 * 1000,
+    );
 
     const qb = this.bloodUnitRepository.createQueryBuilder('u');
     if (bankId) {
@@ -123,6 +129,7 @@ export class BloodInventoryQueryService {
       byBloodType,
       byComponent,
       totalVolumeMl,
+      policyVersionRef: policy.policyVersionId,
     };
   }
 

--- a/backend/src/blood-units/blood-units.module.ts
+++ b/backend/src/blood-units/blood-units.module.ts
@@ -7,6 +7,7 @@ import { BlockchainEvent } from '../soroban/entities/blockchain-event.entity';
 import { BloodUnitTrail } from '../soroban/entities/blood-unit-trail.entity';
 import { SorobanModule } from '../soroban/soroban.module';
 import { DonorEligibilityModule } from '../donor-eligibility/donor-eligibility.module';
+import { PolicyCenterModule } from '../policy-center/policy-center.module';
 
 import { BloodInventoryQueryService } from './blood-inventory-query.service';
 import { BloodStatusService } from './blood-status.service';
@@ -39,6 +40,7 @@ import { DispositionService } from './services/disposition.service';
     SorobanModule,
     NotificationsModule,
     DonorEligibilityModule,
+    PolicyCenterModule,
   ],
   controllers: [BloodUnitsController, DispositionController, QuarantineController],
   providers: [

--- a/backend/src/dispatch/dispatch.module.ts
+++ b/backend/src/dispatch/dispatch.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 
 import { MapsModule } from '../maps/maps.module';
+import { PolicyCenterModule } from '../policy-center/policy-center.module';
 import { RidersModule } from '../riders/riders.module';
 
 import { DispatchController } from './dispatch.controller';
@@ -15,6 +16,7 @@ import { RiderAssignmentService } from './rider-assignment.service';
     EventEmitterModule.forRoot(),
     RidersModule,
     MapsModule,
+    PolicyCenterModule,
   ],
   controllers: [DispatchController],
   providers: [DispatchService, RiderAssignmentService],

--- a/backend/src/dispatch/rider-assignment.service.ts
+++ b/backend/src/dispatch/rider-assignment.service.ts
@@ -4,6 +4,7 @@ import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 
 import { OrderConfirmedEvent, OrderRiderAssignedEvent } from '../events';
 import { MapsService } from '../maps/maps.service';
+import { PolicyCenterService } from '../policy-center/policy-center.service';
 import { RiderRecord, RidersService } from '../riders/riders.service';
 
 @Injectable()
@@ -12,20 +13,21 @@ export class RiderAssignmentService {
   private readonly processedEvents = new Set<string>();
   private readonly assignmentLogs: AssignmentLog[] = [];
   private readonly activeAssignments = new Map<string, ActiveAssignmentState>();
-  private readonly acceptanceTimeoutMs: number;
-  private readonly weights: AssignmentWeights;
+  private readonly defaultAcceptanceTimeoutMs: number;
+  private readonly defaultWeights: AssignmentWeights;
 
   constructor(
     private readonly ridersService: RidersService,
     private readonly mapsService: MapsService,
     private readonly eventEmitter: EventEmitter2,
     private readonly configService: ConfigService,
+    private readonly policyCenterService: PolicyCenterService,
   ) {
-    this.acceptanceTimeoutMs = this.configService.get<number>(
+    this.defaultAcceptanceTimeoutMs = this.configService.get<number>(
       'ASSIGNMENT_ACCEPTANCE_TIMEOUT_MS',
       180000,
     );
-    this.weights = this.resolveWeights();
+    this.defaultWeights = this.resolveWeights();
   }
 
   @OnEvent('order.confirmed')
@@ -98,6 +100,7 @@ export class RiderAssignmentService {
         status: 'accepted',
         attemptNumber: assignment.currentIndex + 1,
         candidates: assignment.candidates.map((item) => item.score),
+        weights: assignment.weights,
         reason: 'rider_accepted',
       });
       this.activeAssignments.delete(orderId);
@@ -118,6 +121,7 @@ export class RiderAssignmentService {
       status: 'rejected',
       attemptNumber: assignment.currentIndex + 1,
       candidates: assignment.candidates.map((item) => item.score),
+      weights: assignment.weights,
       reason: 'rider_rejected',
     });
 
@@ -217,13 +221,15 @@ export class RiderAssignmentService {
         status: 'exhausted',
         attemptNumber: 0,
         candidates: [],
+        weights: this.defaultWeights,
         reason: 'no_available_riders',
       });
       return;
     }
 
     const pickupPoint = event.deliveryAddress;
-    const scored = await this.scoreRiders(riders, pickupPoint);
+    const policyConfig = await this.getRuntimeAssignmentConfig();
+    const scored = await this.scoreRiders(riders, pickupPoint, policyConfig.weights);
     const ranked = scored.sort(
       (a, b) => b.score.totalScore - a.score.totalScore,
     );
@@ -232,7 +238,8 @@ export class RiderAssignmentService {
       orderId: event.orderId,
       candidates: ranked,
       currentIndex: 0,
-      timeoutMs: this.acceptanceTimeoutMs,
+      timeoutMs: policyConfig.acceptanceTimeoutMs,
+      weights: policyConfig.weights,
       timer: null,
     };
     this.activeAssignments.set(event.orderId, state);
@@ -243,6 +250,7 @@ export class RiderAssignmentService {
   private async scoreRiders(
     riders: RiderRecord[],
     pickupPoint: string,
+    weights: AssignmentWeights,
   ): Promise<Array<{ rider: RiderRecord; score: AssignmentCandidateScore }>> {
     const raw = await Promise.all(
       riders.map(async (rider) => {
@@ -292,9 +300,9 @@ export class RiderAssignmentService {
       );
 
       const totalScore =
-        distanceScore * this.weights.distance +
-        workloadScore * this.weights.workload +
-        ratingScore * this.weights.rating;
+        distanceScore * weights.distance +
+        workloadScore * weights.workload +
+        ratingScore * weights.rating;
 
       return {
         rider: item.rider,
@@ -346,6 +354,7 @@ export class RiderAssignmentService {
         status: 'exhausted',
         attemptNumber: assignment.currentIndex,
         candidates: assignment.candidates.map((item) => item.score),
+        weights: assignment.weights,
         reason: 'all_candidates_exhausted',
       });
       this.activeAssignments.delete(assignment.orderId);
@@ -358,6 +367,7 @@ export class RiderAssignmentService {
       status: 'pending',
       attemptNumber: assignment.currentIndex + 1,
       candidates: assignment.candidates.map((item) => item.score),
+      weights: assignment.weights,
       reason,
     });
 
@@ -389,6 +399,7 @@ export class RiderAssignmentService {
       status: reason === 'timeout' ? 'timeout' : 'escalated',
       attemptNumber: assignment.currentIndex + 1,
       candidates: assignment.candidates.map((item) => item.score),
+      weights: assignment.weights,
       reason,
     });
 
@@ -400,6 +411,7 @@ export class RiderAssignmentService {
         status: 'exhausted',
         attemptNumber: assignment.currentIndex,
         candidates: assignment.candidates.map((item) => item.score),
+        weights: assignment.weights,
         reason: 'all_candidates_exhausted',
       });
       this.activeAssignments.delete(orderId);
@@ -417,14 +429,47 @@ export class RiderAssignmentService {
   }
 
   private appendAssignmentLog(
-    log: Omit<AssignmentLog, 'id' | 'createdAt' | 'weights'>,
+    log: Omit<AssignmentLog, 'id' | 'createdAt'>,
   ): void {
     this.assignmentLogs.push({
       id: `assignment-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
       createdAt: new Date(),
-      weights: this.weights,
       ...log,
     });
+  }
+
+  private async getRuntimeAssignmentConfig(): Promise<{
+    acceptanceTimeoutMs: number;
+    weights: AssignmentWeights;
+  }> {
+    try {
+      const policy = await this.policyCenterService.getActivePolicySnapshot();
+      const totalWeight =
+        policy.rules.dispatch.distanceWeight +
+        policy.rules.dispatch.workloadWeight +
+        policy.rules.dispatch.ratingWeight;
+
+      if (totalWeight <= 0) {
+        return {
+          acceptanceTimeoutMs: this.defaultAcceptanceTimeoutMs,
+          weights: this.defaultWeights,
+        };
+      }
+
+      return {
+        acceptanceTimeoutMs: policy.rules.dispatch.acceptanceTimeoutMs,
+        weights: {
+          distance: policy.rules.dispatch.distanceWeight / totalWeight,
+          workload: policy.rules.dispatch.workloadWeight / totalWeight,
+          rating: policy.rules.dispatch.ratingWeight / totalWeight,
+        },
+      };
+    } catch {
+      return {
+        acceptanceTimeoutMs: this.defaultAcceptanceTimeoutMs,
+        weights: this.defaultWeights,
+      };
+    }
   }
 }
 
@@ -479,5 +524,6 @@ interface ActiveAssignmentState {
   candidates: Array<{ rider: RiderRecord; score: AssignmentCandidateScore }>;
   currentIndex: number;
   timeoutMs: number;
+  weights: AssignmentWeights;
   timer: NodeJS.Timeout | null;
 }

--- a/backend/src/notifications/entities/notification-delivery-log.entity.ts
+++ b/backend/src/notifications/entities/notification-delivery-log.entity.ts
@@ -50,6 +50,9 @@ export class NotificationDeliveryLog {
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, any>;
 
+  @Column({ name: 'policy_version_ref', nullable: true })
+  policyVersionRef: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -3,6 +3,8 @@ import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { PolicyCenterModule } from '../policy-center/policy-center.module';
+
 import { NotificationTemplateEntity } from './entities/notification-template.entity';
 import { NotificationEntity } from './entities/notification.entity';
 import { NotificationPreference } from './entities/notification-preference.entity';
@@ -31,6 +33,7 @@ import { SmsProvider } from './providers/sms.provider';
       name: 'notifications',
     }),
     EventEmitterModule.forRoot(),
+    PolicyCenterModule,
   ],
   controllers: [NotificationsController, NotificationPreferenceController],
   providers: [

--- a/backend/src/notifications/services/notification-preference.service.ts
+++ b/backend/src/notifications/services/notification-preference.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { PolicyCenterService } from '../../policy-center/policy-center.service';
 import {
   NotificationPreference,
   NotificationChannel,
@@ -19,6 +20,7 @@ export class NotificationPreferenceService {
     private preferenceRepo: Repository<NotificationPreference>,
     @InjectRepository(NotificationDeliveryLog)
     private deliveryLogRepo: Repository<NotificationDeliveryLog>,
+    private readonly policyCenterService: PolicyCenterService,
   ) {}
 
   async getUserPreferences(userId: string): Promise<NotificationPreference[]> {
@@ -39,30 +41,42 @@ export class NotificationPreferenceService {
     userId: string,
     category: NotificationCategory,
     channels: NotificationChannel[],
-    quietHoursEnabled: boolean = false,
+    quietHoursEnabled?: boolean,
     quietHoursStart?: string,
     quietHoursEnd?: string,
-    emergencyBypassTier: EmergencyTier = EmergencyTier.NORMAL,
+    emergencyBypassTier?: EmergencyTier,
   ): Promise<NotificationPreference> {
+    const policy = await this.policyCenterService.getActivePolicySnapshot();
+    const defaults = policy.rules.notification;
+
     let preference = await this.preferenceRepo.findOne({
       where: { userId, category },
     });
 
+    const resolvedQuietHoursEnabled =
+      quietHoursEnabled ?? defaults.defaultQuietHoursEnabled;
+    const resolvedQuietHoursStart =
+      quietHoursStart ?? defaults.defaultQuietHoursStart;
+    const resolvedQuietHoursEnd =
+      quietHoursEnd ?? defaults.defaultQuietHoursEnd;
+    const resolvedEmergencyBypassTier =
+      emergencyBypassTier ?? (defaults.defaultEmergencyBypassTier as EmergencyTier);
+
     if (preference) {
       preference.channels = channels;
-      preference.quietHoursEnabled = quietHoursEnabled;
-      preference.quietHoursStart = quietHoursStart;
-      preference.quietHoursEnd = quietHoursEnd;
-      preference.emergencyBypassTier = emergencyBypassTier;
+      preference.quietHoursEnabled = resolvedQuietHoursEnabled;
+      preference.quietHoursStart = resolvedQuietHoursStart;
+      preference.quietHoursEnd = resolvedQuietHoursEnd;
+      preference.emergencyBypassTier = resolvedEmergencyBypassTier;
     } else {
       preference = this.preferenceRepo.create({
         userId,
         category,
         channels,
-        quietHoursEnabled,
-        quietHoursStart,
-        quietHoursEnd,
-        emergencyBypassTier,
+        quietHoursEnabled: resolvedQuietHoursEnabled,
+        quietHoursStart: resolvedQuietHoursStart,
+        quietHoursEnd: resolvedQuietHoursEnd,
+        emergencyBypassTier: resolvedEmergencyBypassTier,
       });
     }
 
@@ -74,7 +88,13 @@ export class NotificationPreferenceService {
     category: NotificationCategory,
     channel: NotificationChannel,
     emergencyTier: EmergencyTier = EmergencyTier.NORMAL,
-  ): Promise<{ shouldSend: boolean; reason?: string; emergencyBypass: boolean }> {
+  ): Promise<{
+    shouldSend: boolean;
+    reason?: string;
+    emergencyBypass: boolean;
+    policyVersionRef?: string;
+  }> {
+    const policy = await this.policyCenterService.getActivePolicySnapshot();
     const preference = await this.preferenceRepo.findOne({
       where: { userId, category },
     });
@@ -84,6 +104,7 @@ export class NotificationPreferenceService {
         shouldSend: false,
         reason: 'Category disabled or no preference set',
         emergencyBypass: false,
+        policyVersionRef: policy.policyVersionId,
       };
     }
 
@@ -92,6 +113,7 @@ export class NotificationPreferenceService {
         shouldSend: false,
         reason: 'Channel not enabled for this category',
         emergencyBypass: false,
+        policyVersionRef: policy.policyVersionId,
       };
     }
 
@@ -103,6 +125,7 @@ export class NotificationPreferenceService {
           shouldSend: true,
           reason: 'Emergency bypass of quiet hours',
           emergencyBypass: true,
+          policyVersionRef: policy.policyVersionId,
         };
       }
 
@@ -110,10 +133,15 @@ export class NotificationPreferenceService {
         shouldSend: false,
         reason: 'Within quiet hours',
         emergencyBypass: false,
+        policyVersionRef: policy.policyVersionId,
       };
     }
 
-    return { shouldSend: true, emergencyBypass: false };
+    return {
+      shouldSend: true,
+      emergencyBypass: false,
+      policyVersionRef: policy.policyVersionId,
+    };
   }
 
   private isInQuietHours(preference: NotificationPreference): boolean {
@@ -156,6 +184,7 @@ export class NotificationPreferenceService {
     reason?: string,
     emergencyBypass: boolean = false,
     metadata?: Record<string, any>,
+    policyVersionRef?: string,
   ): Promise<NotificationDeliveryLog> {
     const log = this.deliveryLogRepo.create({
       userId,
@@ -165,6 +194,7 @@ export class NotificationPreferenceService {
       reason,
       emergencyBypass,
       metadata,
+      policyVersionRef: policyVersionRef ?? null,
     });
 
     return this.deliveryLogRepo.save(log);

--- a/backend/src/policy-center/dto/create-policy-version.dto.ts
+++ b/backend/src/policy-center/dto/create-policy-version.dto.ts
@@ -1,0 +1,22 @@
+import { IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class CreatePolicyVersionDto {
+  @IsOptional()
+  @IsString()
+  policyName?: string;
+
+  @IsOptional()
+  @IsDateString()
+  effectiveFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  effectiveTo?: string;
+
+  @IsOptional()
+  @IsString()
+  changeSummary?: string;
+
+  @IsObject()
+  rules: Record<string, unknown>;
+}

--- a/backend/src/policy-center/dto/list-policy-versions.dto.ts
+++ b/backend/src/policy-center/dto/list-policy-versions.dto.ts
@@ -1,0 +1,13 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+import { PolicyVersionStatus } from '../enums/policy-version-status.enum';
+
+export class ListPolicyVersionsDto {
+  @IsOptional()
+  @IsString()
+  policyName?: string;
+
+  @IsOptional()
+  @IsEnum(PolicyVersionStatus)
+  status?: PolicyVersionStatus;
+}

--- a/backend/src/policy-center/dto/update-policy-version.dto.ts
+++ b/backend/src/policy-center/dto/update-policy-version.dto.ts
@@ -1,0 +1,19 @@
+import { IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class UpdatePolicyVersionDto {
+  @IsOptional()
+  @IsDateString()
+  effectiveFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  effectiveTo?: string;
+
+  @IsOptional()
+  @IsString()
+  changeSummary?: string;
+
+  @IsOptional()
+  @IsObject()
+  rules?: Record<string, unknown>;
+}

--- a/backend/src/policy-center/entities/policy-version.entity.ts
+++ b/backend/src/policy-center/entities/policy-version.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+import { PolicyVersionStatus } from '../enums/policy-version-status.enum';
+import { OperationalPolicyRules } from '../policy-config.types';
+
+@Entity('policy_versions')
+@Index(['policyName', 'version'], { unique: true })
+export class PolicyVersionEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'policy_name', default: 'operational-core' })
+  policyName: string;
+
+  @Column({ type: 'int' })
+  version: number;
+
+  @Column({
+    type: 'enum',
+    enum: PolicyVersionStatus,
+    default: PolicyVersionStatus.DRAFT,
+  })
+  status: PolicyVersionStatus;
+
+  @Column({ type: 'jsonb' })
+  rules: OperationalPolicyRules;
+
+  @Column({ name: 'change_summary', type: 'text', nullable: true })
+  changeSummary: string | null;
+
+  @Column({ name: 'effective_from', type: 'timestamptz', nullable: true })
+  effectiveFrom: Date | null;
+
+  @Column({ name: 'effective_to', type: 'timestamptz', nullable: true })
+  effectiveTo: Date | null;
+
+  @Column({ name: 'created_by', nullable: true })
+  createdBy: string | null;
+
+  @Column({ name: 'activated_by', nullable: true })
+  activatedBy: string | null;
+
+  @Column({ name: 'activated_at', type: 'timestamptz', nullable: true })
+  activatedAt: Date | null;
+
+  @Column({ name: 'rollback_from_version_id', nullable: true })
+  rollbackFromVersionId: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/policy-center/enums/policy-version-status.enum.ts
+++ b/backend/src/policy-center/enums/policy-version-status.enum.ts
@@ -1,0 +1,6 @@
+export enum PolicyVersionStatus {
+  DRAFT = 'draft',
+  ACTIVE = 'active',
+  SUPERSEDED = 'superseded',
+  ROLLED_BACK = 'rolled_back',
+}

--- a/backend/src/policy-center/policy-center.controller.ts
+++ b/backend/src/policy-center/policy-center.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
+
+import { CreatePolicyVersionDto } from './dto/create-policy-version.dto';
+import { ListPolicyVersionsDto } from './dto/list-policy-versions.dto';
+import { UpdatePolicyVersionDto } from './dto/update-policy-version.dto';
+import { PolicyCenterService } from './policy-center.service';
+
+@Controller('policy-center')
+export class PolicyCenterController {
+  constructor(private readonly policyCenterService: PolicyCenterService) {}
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get('versions')
+  listVersions(@Query() query: ListPolicyVersionsDto) {
+    return this.policyCenterService.listVersions(query);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get('versions/:id')
+  getVersion(@Param('id') id: string) {
+    return this.policyCenterService.getVersion(id);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post('versions')
+  createVersion(@Body() dto: CreatePolicyVersionDto, @Req() req: { user?: { id?: string } }) {
+    return this.policyCenterService.createVersion(dto, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Patch('versions/:id')
+  updateVersion(@Param('id') id: string, @Body() dto: UpdatePolicyVersionDto) {
+    return this.policyCenterService.updateVersion(id, dto);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post('versions/:id/activate')
+  activateVersion(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
+    return this.policyCenterService.activateVersion(id, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post('versions/:id/rollback')
+  rollbackVersion(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
+    return this.policyCenterService.rollbackToVersion(id, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get('active')
+  getActiveVersion(@Query('policyName') policyName?: string) {
+    return this.policyCenterService.getActivePolicySnapshot(policyName);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get('compare')
+  compareVersions(
+    @Query('fromVersionId') fromVersionId: string,
+    @Query('toVersionId') toVersionId: string,
+  ) {
+    return this.policyCenterService.compareVersions(fromVersionId, toVersionId);
+  }
+}

--- a/backend/src/policy-center/policy-center.module.ts
+++ b/backend/src/policy-center/policy-center.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { PolicyVersionEntity } from './entities/policy-version.entity';
+import { PolicyCenterController } from './policy-center.controller';
+import { PolicyCenterService } from './policy-center.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PolicyVersionEntity])],
+  controllers: [PolicyCenterController],
+  providers: [PolicyCenterService],
+  exports: [PolicyCenterService],
+})
+export class PolicyCenterModule {}

--- a/backend/src/policy-center/policy-center.service.ts
+++ b/backend/src/policy-center/policy-center.service.ts
@@ -1,0 +1,419 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreatePolicyVersionDto } from './dto/create-policy-version.dto';
+import { ListPolicyVersionsDto } from './dto/list-policy-versions.dto';
+import { UpdatePolicyVersionDto } from './dto/update-policy-version.dto';
+import { PolicyVersionEntity } from './entities/policy-version.entity';
+import { PolicyVersionStatus } from './enums/policy-version-status.enum';
+import { ActivePolicySnapshot, OperationalPolicyRules } from './policy-config.types';
+
+@Injectable()
+export class PolicyCenterService {
+  private readonly defaultPolicyName = 'operational-core';
+
+  constructor(
+    @InjectRepository(PolicyVersionEntity)
+    private readonly repo: Repository<PolicyVersionEntity>,
+  ) {}
+
+  getDefaultRules(): OperationalPolicyRules {
+    return {
+      anomaly: {
+        duplicateEmergencyMinCount: 3,
+        riderMinOrders: 5,
+        riderCancellationRatioThreshold: 0.4,
+        disputeCountThreshold: 3,
+        stockSwingWindowMinutes: 60,
+        stockSwingMinOrders: 10,
+      },
+      dispatch: {
+        acceptanceTimeoutMs: 180000,
+        distanceWeight: 0.5,
+        workloadWeight: 0.3,
+        ratingWeight: 0.2,
+      },
+      inventory: {
+        expiringSoonHours: 72,
+      },
+      notification: {
+        defaultQuietHoursEnabled: false,
+        defaultQuietHoursStart: '22:00',
+        defaultQuietHoursEnd: '06:00',
+        defaultEmergencyBypassTier: 'normal',
+      },
+    };
+  }
+
+  async listVersions(query: ListPolicyVersionsDto): Promise<PolicyVersionEntity[]> {
+    await this.ensureBaselinePolicy(query.policyName ?? this.defaultPolicyName);
+
+    const qb = this.repo.createQueryBuilder('p').orderBy('p.version', 'DESC');
+    qb.andWhere('p.policy_name = :policyName', {
+      policyName: query.policyName ?? this.defaultPolicyName,
+    });
+
+    if (query.status) {
+      qb.andWhere('p.status = :status', { status: query.status });
+    }
+
+    return qb.getMany();
+  }
+
+  async getVersion(id: string): Promise<PolicyVersionEntity> {
+    const found = await this.repo.findOne({ where: { id } });
+    if (!found) {
+      throw new NotFoundException(`Policy version ${id} not found`);
+    }
+    return found;
+  }
+
+  async createVersion(
+    dto: CreatePolicyVersionDto,
+    actor: string,
+  ): Promise<PolicyVersionEntity> {
+    const policyName = dto.policyName ?? this.defaultPolicyName;
+    await this.ensureBaselinePolicy(policyName);
+
+    const currentMaxVersion = await this.repo
+      .createQueryBuilder('p')
+      .select('COALESCE(MAX(p.version), 0)', 'max')
+      .where('p.policy_name = :policyName', { policyName })
+      .getRawOne<{ max: string }>();
+
+    const active = await this.getActivePolicySnapshot(policyName);
+    const baseRules = active.rules;
+    const mergedRules = this.mergeRules(baseRules, dto.rules);
+
+    this.validateRules(mergedRules);
+    this.validateEffectiveDates(dto.effectiveFrom, dto.effectiveTo);
+
+    const entity = this.repo.create({
+      policyName,
+      version: Number(currentMaxVersion?.max ?? 0) + 1,
+      status: PolicyVersionStatus.DRAFT,
+      rules: mergedRules,
+      effectiveFrom: dto.effectiveFrom ? new Date(dto.effectiveFrom) : null,
+      effectiveTo: dto.effectiveTo ? new Date(dto.effectiveTo) : null,
+      changeSummary: dto.changeSummary ?? null,
+      createdBy: actor,
+    });
+
+    return this.repo.save(entity);
+  }
+
+  async updateVersion(
+    id: string,
+    dto: UpdatePolicyVersionDto,
+  ): Promise<PolicyVersionEntity> {
+    const existing = await this.getVersion(id);
+
+    if (existing.status !== PolicyVersionStatus.DRAFT) {
+      throw new BadRequestException('Only draft versions can be edited');
+    }
+
+    if (dto.rules) {
+      existing.rules = this.mergeRules(existing.rules, dto.rules);
+      this.validateRules(existing.rules);
+    }
+
+    if (dto.effectiveFrom !== undefined) {
+      existing.effectiveFrom = dto.effectiveFrom ? new Date(dto.effectiveFrom) : null;
+    }
+
+    if (dto.effectiveTo !== undefined) {
+      existing.effectiveTo = dto.effectiveTo ? new Date(dto.effectiveTo) : null;
+    }
+
+    this.validateEffectiveDates(
+      existing.effectiveFrom?.toISOString(),
+      existing.effectiveTo?.toISOString(),
+    );
+
+    if (dto.changeSummary !== undefined) {
+      existing.changeSummary = dto.changeSummary ?? null;
+    }
+
+    return this.repo.save(existing);
+  }
+
+  async activateVersion(id: string, actor: string): Promise<PolicyVersionEntity> {
+    const target = await this.getVersion(id);
+    this.validateRules(target.rules);
+
+    const now = new Date();
+    if (target.effectiveFrom && target.effectiveFrom > now) {
+      throw new BadRequestException('Cannot activate a version before effectiveFrom');
+    }
+
+    if (target.effectiveTo && target.effectiveTo <= now) {
+      throw new BadRequestException('Cannot activate an already-expired version');
+    }
+
+    const currentlyActive = await this.repo.findOne({
+      where: {
+        policyName: target.policyName,
+        status: PolicyVersionStatus.ACTIVE,
+      },
+      order: { version: 'DESC' },
+    });
+
+    if (currentlyActive && currentlyActive.id !== target.id) {
+      currentlyActive.status = PolicyVersionStatus.SUPERSEDED;
+      currentlyActive.effectiveTo = now;
+      await this.repo.save(currentlyActive);
+    }
+
+    target.status = PolicyVersionStatus.ACTIVE;
+    target.activatedAt = now;
+    target.activatedBy = actor;
+
+    return this.repo.save(target);
+  }
+
+  async rollbackToVersion(id: string, actor: string): Promise<PolicyVersionEntity> {
+    const target = await this.getVersion(id);
+
+    const currentlyActive = await this.repo.findOne({
+      where: {
+        policyName: target.policyName,
+        status: PolicyVersionStatus.ACTIVE,
+      },
+      order: { version: 'DESC' },
+    });
+
+    if (currentlyActive && currentlyActive.id !== target.id) {
+      currentlyActive.status = PolicyVersionStatus.ROLLED_BACK;
+      currentlyActive.effectiveTo = new Date();
+      currentlyActive.rollbackFromVersionId = target.id;
+      await this.repo.save(currentlyActive);
+    }
+
+    return this.activateVersion(id, actor);
+  }
+
+  async getActivePolicySnapshot(
+    policyName: string = this.defaultPolicyName,
+  ): Promise<ActivePolicySnapshot> {
+    await this.ensureBaselinePolicy(policyName);
+
+    const now = new Date();
+
+    const active = await this.repo
+      .createQueryBuilder('p')
+      .where('p.policy_name = :policyName', { policyName })
+      .andWhere('p.status = :status', { status: PolicyVersionStatus.ACTIVE })
+      .andWhere('(p.effective_from IS NULL OR p.effective_from <= :now)', { now })
+      .andWhere('(p.effective_to IS NULL OR p.effective_to > :now)', { now })
+      .orderBy('p.version', 'DESC')
+      .getOne();
+
+    if (!active) {
+      throw new NotFoundException('No active policy version found');
+    }
+
+    return {
+      policyVersionId: active.id,
+      version: active.version,
+      policyName: active.policyName,
+      rules: active.rules,
+    };
+  }
+
+  async compareVersions(fromVersionId: string, toVersionId: string): Promise<{
+    fromVersionId: string;
+    toVersionId: string;
+    changedKeys: string[];
+  }> {
+    const from = await this.getVersion(fromVersionId);
+    const to = await this.getVersion(toVersionId);
+
+    const changedKeys = this.diffRules(from.rules, to.rules);
+
+    return {
+      fromVersionId,
+      toVersionId,
+      changedKeys,
+    };
+  }
+
+  private async ensureBaselinePolicy(policyName: string): Promise<void> {
+    const activeExists = await this.repo.findOne({
+      where: {
+        policyName,
+        status: PolicyVersionStatus.ACTIVE,
+      },
+    });
+
+    if (activeExists) {
+      return;
+    }
+
+    const currentMaxVersion = await this.repo
+      .createQueryBuilder('p')
+      .select('COALESCE(MAX(p.version), 0)', 'max')
+      .where('p.policy_name = :policyName', { policyName })
+      .getRawOne<{ max: string }>();
+
+    const baseline = this.repo.create({
+      policyName,
+      version: Number(currentMaxVersion?.max ?? 0) + 1,
+      status: PolicyVersionStatus.ACTIVE,
+      rules: this.getDefaultRules(),
+      effectiveFrom: new Date(),
+      createdBy: 'system',
+      activatedBy: 'system',
+      activatedAt: new Date(),
+      changeSummary: 'System baseline policy',
+    });
+
+    await this.repo.save(baseline);
+  }
+
+  private validateEffectiveDates(
+    effectiveFrom?: string,
+    effectiveTo?: string,
+  ): void {
+    if (!effectiveFrom || !effectiveTo) {
+      return;
+    }
+
+    if (new Date(effectiveTo) <= new Date(effectiveFrom)) {
+      throw new BadRequestException('effectiveTo must be later than effectiveFrom');
+    }
+  }
+
+  private validateRules(rules: OperationalPolicyRules): void {
+    const positiveFields: Array<{ name: string; value: number }> = [
+      {
+        name: 'anomaly.duplicateEmergencyMinCount',
+        value: rules.anomaly.duplicateEmergencyMinCount,
+      },
+      {
+        name: 'anomaly.riderMinOrders',
+        value: rules.anomaly.riderMinOrders,
+      },
+      {
+        name: 'anomaly.disputeCountThreshold',
+        value: rules.anomaly.disputeCountThreshold,
+      },
+      {
+        name: 'anomaly.stockSwingWindowMinutes',
+        value: rules.anomaly.stockSwingWindowMinutes,
+      },
+      {
+        name: 'anomaly.stockSwingMinOrders',
+        value: rules.anomaly.stockSwingMinOrders,
+      },
+      {
+        name: 'dispatch.acceptanceTimeoutMs',
+        value: rules.dispatch.acceptanceTimeoutMs,
+      },
+      {
+        name: 'inventory.expiringSoonHours',
+        value: rules.inventory.expiringSoonHours,
+      },
+    ];
+
+    for (const field of positiveFields) {
+      if (!Number.isFinite(field.value) || field.value <= 0) {
+        throw new BadRequestException(`${field.name} must be greater than 0`);
+      }
+    }
+
+    if (
+      rules.anomaly.riderCancellationRatioThreshold < 0 ||
+      rules.anomaly.riderCancellationRatioThreshold > 1
+    ) {
+      throw new BadRequestException(
+        'anomaly.riderCancellationRatioThreshold must be between 0 and 1',
+      );
+    }
+
+    const weightSum =
+      rules.dispatch.distanceWeight +
+      rules.dispatch.workloadWeight +
+      rules.dispatch.ratingWeight;
+
+    if (weightSum <= 0) {
+      throw new BadRequestException('dispatch weights must sum to a positive number');
+    }
+
+    const quietHoursPattern = /^\d{2}:\d{2}$/;
+    if (
+      !quietHoursPattern.test(rules.notification.defaultQuietHoursStart) ||
+      !quietHoursPattern.test(rules.notification.defaultQuietHoursEnd)
+    ) {
+      throw new BadRequestException('notification quiet-hours must use HH:MM format');
+    }
+  }
+
+  private mergeRules(
+    base: OperationalPolicyRules,
+    patch: Record<string, unknown>,
+  ): OperationalPolicyRules {
+    const next = JSON.parse(JSON.stringify(base)) as Record<string, any>;
+
+    const deepMerge = (target: Record<string, any>, source: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(source)) {
+        if (
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value) &&
+          typeof target[key] === 'object' &&
+          target[key] !== null
+        ) {
+          deepMerge(target[key], value as Record<string, unknown>);
+          continue;
+        }
+        target[key] = value;
+      }
+    };
+
+    deepMerge(next, patch);
+    return next as OperationalPolicyRules;
+  }
+
+  private diffRules(
+    fromRules: OperationalPolicyRules,
+    toRules: OperationalPolicyRules,
+  ): string[] {
+    const changes: string[] = [];
+
+    const walk = (fromValue: unknown, toValue: unknown, path: string) => {
+      if (
+        fromValue !== null &&
+        typeof fromValue === 'object' &&
+        toValue !== null &&
+        typeof toValue === 'object'
+      ) {
+        const keys = new Set([
+          ...Object.keys(fromValue as Record<string, unknown>),
+          ...Object.keys(toValue as Record<string, unknown>),
+        ]);
+
+        for (const key of keys) {
+          const nextPath = path ? `${path}.${key}` : key;
+          walk(
+            (fromValue as Record<string, unknown>)[key],
+            (toValue as Record<string, unknown>)[key],
+            nextPath,
+          );
+        }
+        return;
+      }
+
+      if (fromValue !== toValue) {
+        changes.push(path);
+      }
+    };
+
+    walk(fromRules, toRules, '');
+    return changes.filter(Boolean).sort();
+  }
+}

--- a/backend/src/policy-center/policy-config.types.ts
+++ b/backend/src/policy-center/policy-config.types.ts
@@ -1,0 +1,32 @@
+export interface OperationalPolicyRules {
+  anomaly: {
+    duplicateEmergencyMinCount: number;
+    riderMinOrders: number;
+    riderCancellationRatioThreshold: number;
+    disputeCountThreshold: number;
+    stockSwingWindowMinutes: number;
+    stockSwingMinOrders: number;
+  };
+  dispatch: {
+    acceptanceTimeoutMs: number;
+    distanceWeight: number;
+    workloadWeight: number;
+    ratingWeight: number;
+  };
+  inventory: {
+    expiringSoonHours: number;
+  };
+  notification: {
+    defaultQuietHoursEnabled: boolean;
+    defaultQuietHoursStart: string;
+    defaultQuietHoursEnd: string;
+    defaultEmergencyBypassTier: 'normal' | 'urgent' | 'critical';
+  };
+}
+
+export interface ActivePolicySnapshot {
+  policyVersionId: string;
+  version: number;
+  policyName: string;
+  rules: OperationalPolicyRules;
+}

--- a/backend/src/riders/entities/assignment-decision.entity.ts
+++ b/backend/src/riders/entities/assignment-decision.entity.ts
@@ -15,4 +15,7 @@ export class AssignmentDecisionEntity extends BaseEntity {
 
   @Column({ name: 'candidates', type: 'jsonb' })
   candidates: Array<{ riderId: string; totalScore: number; breakdown: Record<string, number> }>;
+
+  @Column({ name: 'policy_version_ref', nullable: true })
+  policyVersionRef: string | null;
 }

--- a/backend/src/riders/riders.module.ts
+++ b/backend/src/riders/riders.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ReputationEntity } from '../reputation/entities/reputation.entity';
 import { ReputationModule } from '../reputation/reputation.module';
+import { PolicyCenterModule } from '../policy-center/policy-center.module';
 
 import { AssignmentDecisionEntity } from './entities/assignment-decision.entity';
 import { AssignmentWeightsEntity } from './entities/assignment-weights.entity';
@@ -16,6 +17,7 @@ import { ReputationAwareAssignmentService } from './services/reputation-aware-as
   imports: [
     TypeOrmModule.forFeature([RiderEntity, AssignmentWeightsEntity, AssignmentDecisionEntity, ReputationEntity]),
     ReputationModule,
+    PolicyCenterModule,
   ],
   controllers: [RidersController, AssignmentController],
   providers: [RidersService, ReputationAwareAssignmentService],

--- a/backend/src/riders/services/reputation-aware-assignment.service.ts
+++ b/backend/src/riders/services/reputation-aware-assignment.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { PolicyCenterService } from '../../policy-center/policy-center.service';
 import { ReputationEntity } from '../../reputation/entities/reputation.entity';
 import { RiderEntity } from '../entities/rider.entity';
 import { AssignmentWeightsEntity } from '../entities/assignment-weights.entity';
@@ -26,6 +27,7 @@ export class ReputationAwareAssignmentService {
     private readonly weightsRepo: Repository<AssignmentWeightsEntity>,
     @InjectRepository(AssignmentDecisionEntity)
     private readonly decisionRepo: Repository<AssignmentDecisionEntity>,
+    private readonly policyCenterService: PolicyCenterService,
   ) {}
 
   async assignRider(params: {
@@ -34,6 +36,7 @@ export class ReputationAwareAssignmentService {
     pickupLon: number;
     maxCandidates?: number;
   }): Promise<{ selectedRiderId: string; explanation: ScoredCandidate[] }> {
+    const policy = await this.policyCenterService.getActivePolicySnapshot();
     const weights = await this.getActiveWeights();
     const riders = await this.riderRepo.find({
       where: { status: RiderStatus.AVAILABLE, isVerified: true },
@@ -97,6 +100,7 @@ export class ReputationAwareAssignmentService {
           coldChainWeight: weights.coldChainWeight,
         },
         candidates: scored.map((c) => ({ riderId: c.riderId, totalScore: c.totalScore, breakdown: c.breakdown })),
+        policyVersionRef: policy.policyVersionId,
       }),
     );
 
@@ -110,9 +114,10 @@ export class ReputationAwareAssignmentService {
   async getActiveWeights(): Promise<AssignmentWeightsEntity> {
     let w = await this.weightsRepo.findOne({ where: { name: 'default', isActive: true } });
     if (!w) {
+      const policy = await this.policyCenterService.getActivePolicySnapshot();
       w = this.weightsRepo.create({
         name: 'default',
-        distanceWeight: 0.3,
+        distanceWeight: policy.rules.dispatch.distanceWeight,
         reputationWeight: 0.25,
         rejectionRateWeight: 0.2,
         completionRateWeight: 0.15,

--- a/frontend/health-chain/app/admin/policy-center/page.tsx
+++ b/frontend/health-chain/app/admin/policy-center/page.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+import {
+  useActivatePolicyVersion,
+  useComparePolicies,
+  useCreatePolicyVersion,
+  usePolicyVersions,
+  useRollbackPolicyVersion,
+} from "@/lib/hooks/usePolicyCenter";
+import type { PolicyVersion } from "@/lib/types/policy-center";
+
+const DEFAULT_CREATE_RULES = {
+  anomaly: {
+    duplicateEmergencyMinCount: 3,
+    riderMinOrders: 5,
+    riderCancellationRatioThreshold: 0.4,
+    disputeCountThreshold: 3,
+    stockSwingWindowMinutes: 60,
+    stockSwingMinOrders: 10,
+  },
+  dispatch: {
+    acceptanceTimeoutMs: 180000,
+    distanceWeight: 0.5,
+    workloadWeight: 0.3,
+    ratingWeight: 0.2,
+  },
+  inventory: {
+    expiringSoonHours: 72,
+  },
+  notification: {
+    defaultQuietHoursEnabled: false,
+    defaultQuietHoursStart: "22:00",
+    defaultQuietHoursEnd: "06:00",
+    defaultEmergencyBypassTier: "normal",
+  },
+};
+
+function StatusBadge({ status }: { status: PolicyVersion["status"] }) {
+  const style =
+    status === "active"
+      ? "bg-green-100 text-green-700"
+      : status === "draft"
+        ? "bg-blue-100 text-blue-700"
+        : status === "rolled_back"
+          ? "bg-amber-100 text-amber-700"
+          : "bg-gray-100 text-gray-700";
+
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${style}`}>
+      {status}
+    </span>
+  );
+}
+
+export default function PolicyCenterPage() {
+  const [summary, setSummary] = useState("");
+  const [rulesJson, setRulesJson] = useState(
+    JSON.stringify(DEFAULT_CREATE_RULES, null, 2),
+  );
+
+  const { data: versions, isLoading, isError } = usePolicyVersions();
+  const activate = useActivatePolicyVersion();
+  const rollback = useRollbackPolicyVersion();
+  const create = useCreatePolicyVersion();
+
+  const [compareFrom, setCompareFrom] = useState<string | undefined>();
+  const [compareTo, setCompareTo] = useState<string | undefined>();
+  const compare = useComparePolicies(compareFrom, compareTo);
+
+  const activeVersion = useMemo(
+    () => versions?.find((v) => v.status === "active") ?? null,
+    [versions],
+  );
+
+  const drafts = useMemo(
+    () => (versions ?? []).filter((v) => v.status === "draft"),
+    [versions],
+  );
+
+  function handleCreateVersion(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const parsed = JSON.parse(rulesJson) as Record<string, unknown>;
+      create.mutate({
+        changeSummary: summary || "Policy revision",
+        rules: parsed,
+      });
+      setSummary("");
+    } catch {
+      window.alert("Rules JSON is invalid. Please fix and retry.");
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-white p-6 lg:p-10 space-y-8">
+      <header className="border-b border-gray-100 pb-5">
+        <h1 className="text-3xl font-manrope font-bold text-brand-black">Policy Center</h1>
+        <p className="text-gray-500 mt-1">
+          Manage operational thresholds by version, activate safely, and rollback when needed.
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <article className="rounded-xl border border-gray-200 p-5 xl:col-span-2">
+          <h2 className="text-lg font-semibold text-brand-black mb-3">Versions</h2>
+          {isLoading ? (
+            <p className="text-sm text-gray-400">Loading versions...</p>
+          ) : isError ? (
+            <p className="text-sm text-red-500">Failed to load versions.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
+                  <tr>
+                    <th className="text-left px-3 py-2">Version</th>
+                    <th className="text-left px-3 py-2">Status</th>
+                    <th className="text-left px-3 py-2">Summary</th>
+                    <th className="text-left px-3 py-2">Activated</th>
+                    <th className="text-left px-3 py-2">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {(versions ?? []).map((v) => (
+                    <tr key={v.id}>
+                      <td className="px-3 py-2 font-semibold">v{v.version}</td>
+                      <td className="px-3 py-2">
+                        <StatusBadge status={v.status} />
+                      </td>
+                      <td className="px-3 py-2 text-gray-600">{v.changeSummary || "-"}</td>
+                      <td className="px-3 py-2 text-gray-500">
+                        {v.activatedAt ? new Date(v.activatedAt).toLocaleString() : "-"}
+                      </td>
+                      <td className="px-3 py-2 flex gap-2">
+                        <button
+                          className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-40"
+                          disabled={v.status === "active" || activate.isPending}
+                          onClick={() => activate.mutate(v.id)}
+                        >
+                          Activate
+                        </button>
+                        <button
+                          className="rounded border border-amber-300 text-amber-700 px-2 py-1 text-xs hover:bg-amber-50 disabled:opacity-40"
+                          disabled={rollback.isPending || v.status === "active"}
+                          onClick={() => rollback.mutate(v.id)}
+                        >
+                          Rollback To
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </article>
+
+        <article className="rounded-xl border border-gray-200 p-5">
+          <h2 className="text-lg font-semibold text-brand-black mb-3">Active Policy</h2>
+          {!activeVersion ? (
+            <p className="text-sm text-gray-500">No active version found.</p>
+          ) : (
+            <div className="space-y-2 text-sm text-gray-700">
+              <p>
+                <span className="font-semibold">Current:</span> v{activeVersion.version}
+              </p>
+              <p>
+                <span className="font-semibold">Summary:</span> {activeVersion.changeSummary || "-"}
+              </p>
+              <p>
+                <span className="font-semibold">Activated by:</span> {activeVersion.activatedBy || "system"}
+              </p>
+            </div>
+          )}
+
+          <hr className="my-4" />
+
+          <h3 className="font-semibold text-sm mb-2">Compare Versions</h3>
+          <div className="space-y-2">
+            <select
+              className="w-full border rounded px-2 py-1 text-sm"
+              value={compareFrom ?? ""}
+              onChange={(e) => setCompareFrom(e.target.value || undefined)}
+            >
+              <option value="">From Version</option>
+              {(versions ?? []).map((v) => (
+                <option key={`from-${v.id}`} value={v.id}>
+                  v{v.version}
+                </option>
+              ))}
+            </select>
+
+            <select
+              className="w-full border rounded px-2 py-1 text-sm"
+              value={compareTo ?? ""}
+              onChange={(e) => setCompareTo(e.target.value || undefined)}
+            >
+              <option value="">To Version</option>
+              {(versions ?? []).map((v) => (
+                <option key={`to-${v.id}`} value={v.id}>
+                  v{v.version}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {compare.data && (
+            <div className="mt-3 rounded border border-gray-200 p-3 bg-gray-50">
+              <p className="text-xs font-semibold text-gray-600 mb-1">Changed Keys</p>
+              <ul className="text-xs text-gray-700 space-y-1 max-h-32 overflow-auto">
+                {compare.data.changedKeys.map((key) => (
+                  <li key={key}>{key}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </article>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 p-5">
+        <h2 className="text-lg font-semibold text-brand-black mb-3">Create Draft Version</h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Start from existing rules and adjust only what changed. Activation validates ranges and effective dates.
+        </p>
+
+        <form onSubmit={handleCreateVersion} className="space-y-3">
+          <input
+            className="w-full border rounded px-3 py-2 text-sm"
+            placeholder="Change summary"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+          />
+          <textarea
+            className="w-full h-56 border rounded px-3 py-2 text-xs font-mono"
+            value={rulesJson}
+            onChange={(e) => setRulesJson(e.target.value)}
+          />
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={create.isPending}
+              className="rounded bg-brand-black text-white px-4 py-2 text-sm disabled:opacity-40"
+            >
+              {create.isPending ? "Creating..." : "Create Draft"}
+            </button>
+            <span className="text-xs text-gray-500">
+              {drafts.length} draft version{drafts.length === 1 ? "" : "s"} ready for review
+            </span>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/frontend/health-chain/app/dashboard/layout.tsx
+++ b/frontend/health-chain/app/dashboard/layout.tsx
@@ -34,6 +34,7 @@ const sidebarLinks = [
   { name: "Track Riders", href: "/dashboard/track-riders", icon: Bike },
   { name: "Anomaly Queue", href: "/admin/anomalies", icon: ShieldAlert },
   { name: "Quarantine Review", href: "/admin/quarantine", icon: FlaskConical },
+  { name: "Policy Center", href: "/admin/policy-center", icon: Settings },
   { name: "Batch Import", href: "/admin/batch-import", icon: Upload },
   { name: "Expiration Forecast", href: "/admin/expiration-forecast", icon: Droplets },
 ];

--- a/frontend/health-chain/lib/api/policy-center.api.ts
+++ b/frontend/health-chain/lib/api/policy-center.api.ts
@@ -1,0 +1,55 @@
+import { api } from "./http-client";
+import type {
+  CreatePolicyVersionPayload,
+  PolicyCompareResult,
+  PolicySnapshot,
+  PolicyVersion,
+  UpdatePolicyVersionPayload,
+} from "@/lib/types/policy-center";
+
+const PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "api/v1";
+
+export async function fetchPolicyVersions(policyName?: string): Promise<PolicyVersion[]> {
+  const q = new URLSearchParams();
+  if (policyName) {
+    q.set("policyName", policyName);
+  }
+  return api.get<PolicyVersion[]>(`/${PREFIX}/policy-center/versions?${q.toString()}`);
+}
+
+export async function fetchActivePolicy(policyName?: string): Promise<PolicySnapshot> {
+  const q = new URLSearchParams();
+  if (policyName) {
+    q.set("policyName", policyName);
+  }
+  return api.get<PolicySnapshot>(`/${PREFIX}/policy-center/active?${q.toString()}`);
+}
+
+export async function createPolicyVersion(
+  payload: CreatePolicyVersionPayload,
+): Promise<PolicyVersion> {
+  return api.post<PolicyVersion>(`/${PREFIX}/policy-center/versions`, payload);
+}
+
+export async function updatePolicyVersion(
+  id: string,
+  payload: UpdatePolicyVersionPayload,
+): Promise<PolicyVersion> {
+  return api.patch<PolicyVersion>(`/${PREFIX}/policy-center/versions/${id}`, payload);
+}
+
+export async function activatePolicyVersion(id: string): Promise<PolicyVersion> {
+  return api.post<PolicyVersion>(`/${PREFIX}/policy-center/versions/${id}/activate`);
+}
+
+export async function rollbackToPolicyVersion(id: string): Promise<PolicyVersion> {
+  return api.post<PolicyVersion>(`/${PREFIX}/policy-center/versions/${id}/rollback`);
+}
+
+export async function comparePolicyVersions(
+  fromVersionId: string,
+  toVersionId: string,
+): Promise<PolicyCompareResult> {
+  const q = new URLSearchParams({ fromVersionId, toVersionId });
+  return api.get<PolicyCompareResult>(`/${PREFIX}/policy-center/compare?${q.toString()}`);
+}

--- a/frontend/health-chain/lib/api/queryKeys.ts
+++ b/frontend/health-chain/lib/api/queryKeys.ts
@@ -52,4 +52,14 @@ export const queryKeys = {
       ["quarantine", "list", params] as const,
     detail: (id: string) => ["quarantine", "detail", id] as const,
   },
+
+  policyCenter: {
+    all: ["policyCenter"] as const,
+    versions: (policyName?: string) =>
+      ["policyCenter", "versions", policyName ?? "operational-core"] as const,
+    active: (policyName?: string) =>
+      ["policyCenter", "active", policyName ?? "operational-core"] as const,
+    compare: (fromVersionId: string, toVersionId: string) =>
+      ["policyCenter", "compare", fromVersionId, toVersionId] as const,
+  },
 } as const;

--- a/frontend/health-chain/lib/hooks/usePolicyCenter.ts
+++ b/frontend/health-chain/lib/hooks/usePolicyCenter.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  activatePolicyVersion,
+  comparePolicyVersions,
+  createPolicyVersion,
+  fetchActivePolicy,
+  fetchPolicyVersions,
+  rollbackToPolicyVersion,
+  updatePolicyVersion,
+} from "@/lib/api/policy-center.api";
+import { queryKeys } from "@/lib/api/queryKeys";
+import type {
+  CreatePolicyVersionPayload,
+  UpdatePolicyVersionPayload,
+} from "@/lib/types/policy-center";
+
+export function usePolicyVersions(policyName?: string) {
+  return useQuery({
+    queryKey: queryKeys.policyCenter.versions(policyName),
+    queryFn: () => fetchPolicyVersions(policyName),
+  });
+}
+
+export function useActivePolicy(policyName?: string) {
+  return useQuery({
+    queryKey: queryKeys.policyCenter.active(policyName),
+    queryFn: () => fetchActivePolicy(policyName),
+  });
+}
+
+export function useComparePolicies(fromVersionId?: string, toVersionId?: string) {
+  return useQuery({
+    queryKey:
+      fromVersionId && toVersionId
+        ? queryKeys.policyCenter.compare(fromVersionId, toVersionId)
+        : ["policyCenter", "compare", "empty"],
+    queryFn: () => comparePolicyVersions(fromVersionId!, toVersionId!),
+    enabled: Boolean(fromVersionId && toVersionId),
+  });
+}
+
+export function useCreatePolicyVersion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreatePolicyVersionPayload) => createPolicyVersion(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.policyCenter.all }),
+  });
+}
+
+export function useUpdatePolicyVersion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdatePolicyVersionPayload }) =>
+      updatePolicyVersion(id, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.policyCenter.all }),
+  });
+}
+
+export function useActivatePolicyVersion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => activatePolicyVersion(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.policyCenter.all }),
+  });
+}
+
+export function useRollbackPolicyVersion() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => rollbackToPolicyVersion(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.policyCenter.all }),
+  });
+}

--- a/frontend/health-chain/lib/types/policy-center.ts
+++ b/frontend/health-chain/lib/types/policy-center.ts
@@ -1,0 +1,76 @@
+export type PolicyVersionStatus =
+  | "draft"
+  | "active"
+  | "superseded"
+  | "rolled_back";
+
+export interface OperationalPolicyRules {
+  anomaly: {
+    duplicateEmergencyMinCount: number;
+    riderMinOrders: number;
+    riderCancellationRatioThreshold: number;
+    disputeCountThreshold: number;
+    stockSwingWindowMinutes: number;
+    stockSwingMinOrders: number;
+  };
+  dispatch: {
+    acceptanceTimeoutMs: number;
+    distanceWeight: number;
+    workloadWeight: number;
+    ratingWeight: number;
+  };
+  inventory: {
+    expiringSoonHours: number;
+  };
+  notification: {
+    defaultQuietHoursEnabled: boolean;
+    defaultQuietHoursStart: string;
+    defaultQuietHoursEnd: string;
+    defaultEmergencyBypassTier: "normal" | "urgent" | "critical";
+  };
+}
+
+export interface PolicyVersion {
+  id: string;
+  policyName: string;
+  version: number;
+  status: PolicyVersionStatus;
+  rules: OperationalPolicyRules;
+  changeSummary?: string | null;
+  effectiveFrom?: string | null;
+  effectiveTo?: string | null;
+  createdBy?: string | null;
+  activatedBy?: string | null;
+  activatedAt?: string | null;
+  rollbackFromVersionId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PolicySnapshot {
+  policyVersionId: string;
+  version: number;
+  policyName: string;
+  rules: OperationalPolicyRules;
+}
+
+export interface PolicyCompareResult {
+  fromVersionId: string;
+  toVersionId: string;
+  changedKeys: string[];
+}
+
+export interface CreatePolicyVersionPayload {
+  policyName?: string;
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  changeSummary?: string;
+  rules: Record<string, unknown>;
+}
+
+export interface UpdatePolicyVersionPayload {
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  changeSummary?: string;
+  rules?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
Adds a unified Policy Center so core operational thresholds and rules can be versioned, activated with validation, compared, and rolled back without code edits.

## What Changed
- Added backend Policy Center module with version lifecycle endpoints: create, update, activate, rollback, compare, and active snapshot.
- Migrated key hard-coded rules to active policy reads (anomaly thresholds, dispatch assignment timeout/weights, inventory expiring-soon window, notification defaults).
- Added policy version audit references on affected records for traceability.
- Added admin UI page to manage policy versions and compare changes.

## Issue Link
- Closes #408 
