### PR TITLE
feat(surge): SurgeRule entity, inventory-driven evaluation, fee multiplier, hospital notifications

### DIFF
--- a/backend/src/fee-policy/fee-policy.service.ts
+++ b/backend/src/fee-policy/fee-policy.service.ts
@@ -44,6 +44,43 @@ export class FeePolicyService {
         return this.computeBreakdown(applicablePolicy, dto);
     }
 
+    /**
+     * Compute fees with an optional surge multiplier applied to the platform fee.
+     * The surgeMultiplier and bloodType are recorded in the audit hash for traceability.
+     */
+    async computeFeeWithSurge(
+        dto: FeePreviewDto,
+        surgeMultiplier: number,
+        bloodType: string,
+    ): Promise<FeeBreakdownDto> {
+        const applicablePolicy = await this.findApplicablePolicy(dto);
+        if (!applicablePolicy) {
+            throw new BadRequestException('No applicable fee policy found');
+        }
+        const breakdown = this.computeBreakdown(applicablePolicy, dto);
+        const adjustedPlatformFee = breakdown.platformFee * surgeMultiplier;
+        const feeDelta = adjustedPlatformFee - breakdown.platformFee;
+        return {
+            ...breakdown,
+            platformFee: adjustedPlatformFee,
+            totalFee: breakdown.totalFee + feeDelta,
+            auditHash: this.generateSurgeAuditHash(applicablePolicy, dto, surgeMultiplier, bloodType),
+        };
+    }
+
+    private generateSurgeAuditHash(
+        policy: FeePolicyEntity,
+        dto: FeePreviewDto,
+        surgeMultiplier: number,
+        bloodType: string,
+    ): string {
+        const inputs = `${policy.id}${dto.geographyCode}${dto.distanceKm}${dto.urgencyTier}|surge:${bloodType}:${surgeMultiplier}`;
+        return inputs
+            .split('')
+            .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0)
+            .toString();
+    }
+
     private async findApplicablePolicy(
         dto: FeePreviewDto,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/src/migrations/1820000000001-CreateSurgeRulesTable.ts
+++ b/backend/src/migrations/1820000000001-CreateSurgeRulesTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateSurgeRulesTable1820000000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE blood_type_enum AS ENUM ('A+','A-','B+','B-','AB+','AB-','O+','O-')
+    `).catch(() => { /* enum may already exist */ });
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'surge_rules',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'gen_random_uuid()' },
+          { name: 'blood_type', type: 'blood_type_enum' },
+          { name: 'threshold', type: 'int' },
+          { name: 'multiplier', type: 'decimal', precision: 5, scale: 2 },
+          { name: 'max_multiplier', type: 'decimal', precision: 5, scale: 2, default: '3' },
+          { name: 'active', type: 'boolean', default: 'false' },
+          { name: 'created_at', type: 'timestamptz', default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'surge_rules',
+      new TableIndex({ name: 'IDX_surge_rules_blood_type', columnNames: ['blood_type'], isUnique: true }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('surge_rules', true);
+  }
+}

--- a/backend/src/surge-simulation/entities/surge-rule.entity.ts
+++ b/backend/src/surge-simulation/entities/surge-rule.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+import { BloodType } from '../../blood-units/enums/blood-type.enum';
+
+@Entity('surge_rules')
+@Index(['bloodType'], { unique: true })
+export class SurgeRuleEntity extends BaseEntity {
+  @Column({ name: 'blood_type', type: 'enum', enum: BloodType })
+  bloodType: BloodType;
+
+  /** Inventory level (availableUnitsMl) below which surge activates */
+  @Column({ name: 'threshold', type: 'int' })
+  threshold: number;
+
+  /** Fee multiplier when surge is active, e.g. 1.5 */
+  @Column({ name: 'multiplier', type: 'decimal', precision: 5, scale: 2 })
+  multiplier: number;
+
+  /** Hard cap on the multiplier */
+  @Column({ name: 'max_multiplier', type: 'decimal', precision: 5, scale: 2, default: 3 })
+  maxMultiplier: number;
+
+  @Column({ name: 'active', type: 'boolean', default: false })
+  active: boolean;
+}

--- a/backend/src/surge-simulation/surge-simulation.controller.ts
+++ b/backend/src/surge-simulation/surge-simulation.controller.ts
@@ -1,29 +1,53 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
-import { Public } from '../auth/decorators/public.decorator';
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
+import { BloodType } from '../blood-units/enums/blood-type.enum';
 
 import { SurgeSimulationRequestDto } from './dto/surge-simulation.dto';
-import {
-  SurgeSimulationResult,
-  SurgeSimulationService,
-} from './surge-simulation.service';
+import { SurgeSimulationService, SurgeSimulationResult, SurgeEvaluationResult } from './surge-simulation.service';
+import { SurgeRuleEntity } from './entities/surge-rule.entity';
 
-@ApiTags('operations')
-@Public()
-@Controller('operations/surge-simulation')
+@Controller('surge-simulation')
 export class SurgeSimulationController {
   constructor(private readonly surgeSimulationService: SurgeSimulationService) {}
 
   @Post()
-  @ApiOperation({
-    summary:
-      'Simulate a demand surge against current stock and modeled rider capacity',
-  })
+  @ApiOperation({ summary: 'Simulate a demand surge against current stock and modeled rider capacity' })
   @ApiResponse({ status: 200, description: 'Simulation result' })
-  async run(
-    @Body() dto: SurgeSimulationRequestDto,
-  ): Promise<SurgeSimulationResult> {
+  async run(@Body() dto: SurgeSimulationRequestDto): Promise<SurgeSimulationResult> {
     return this.surgeSimulationService.simulate(dto);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post('evaluate')
+  @ApiOperation({ summary: 'Evaluate surge rules against live inventory and activate/deactivate accordingly' })
+  async evaluate(): Promise<SurgeEvaluationResult> {
+    return this.surgeSimulationService.evaluateSurge();
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get('rules')
+  @ApiOperation({ summary: 'List all surge rules' })
+  async listRules(): Promise<SurgeRuleEntity[]> {
+    return this.surgeSimulationService.findAllRules();
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Put('rules/:bloodType')
+  @ApiOperation({ summary: 'Create or update a surge rule for a blood type' })
+  async upsertRule(
+    @Param('bloodType') bloodType: BloodType,
+    @Body() body: { threshold: number; multiplier: number; maxMultiplier?: number },
+  ): Promise<SurgeRuleEntity> {
+    return this.surgeSimulationService.upsertRule({ bloodType, ...body });
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Delete('rules/:id')
+  @ApiOperation({ summary: 'Delete a surge rule' })
+  async deleteRule(@Param('id') id: string): Promise<void> {
+    return this.surgeSimulationService.deleteRule(id);
   }
 }

--- a/backend/src/surge-simulation/surge-simulation.module.ts
+++ b/backend/src/surge-simulation/surge-simulation.module.ts
@@ -3,13 +3,20 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
 import { RiderEntity } from '../riders/entities/rider.entity';
+import { HospitalEntity } from '../hospitals/entities/hospital.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 
+import { SurgeRuleEntity } from './entities/surge-rule.entity';
 import { SurgeSimulationController } from './surge-simulation.controller';
 import { SurgeSimulationService } from './surge-simulation.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([InventoryStockEntity, RiderEntity])],
+  imports: [
+    TypeOrmModule.forFeature([InventoryStockEntity, RiderEntity, SurgeRuleEntity, HospitalEntity]),
+    NotificationsModule,
+  ],
   controllers: [SurgeSimulationController],
   providers: [SurgeSimulationService],
+  exports: [SurgeSimulationService],
 })
 export class SurgeSimulationModule {}

--- a/backend/src/surge-simulation/surge-simulation.service.ts
+++ b/backend/src/surge-simulation/surge-simulation.service.ts
@@ -1,11 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository } from 'typeorm';
 
 import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
 import { RiderEntity } from '../riders/entities/rider.entity';
 import { RiderStatus } from '../riders/enums/rider-status.enum';
+import { NotificationsService } from '../notifications/notifications.service';
+import { HospitalEntity } from '../hospitals/entities/hospital.entity';
+import { NotificationChannel } from '../notifications/enums/notification-channel.enum';
+import { BloodType } from '../blood-units/enums/blood-type.enum';
 
+import { SurgeRuleEntity } from './entities/surge-rule.entity';
 import { SurgeSimulationRequestDto } from './dto/surge-simulation.dto';
 
 export interface SurgeSimulationResult {
@@ -21,13 +27,27 @@ export interface SurgeSimulationResult {
   summary: string;
 }
 
+export interface SurgeEvaluationResult {
+  activated: BloodType[];
+  deactivated: BloodType[];
+  activeRules: SurgeRuleEntity[];
+}
+
 @Injectable()
 export class SurgeSimulationService {
+  private readonly logger = new Logger(SurgeSimulationService.name);
+
   constructor(
     @InjectRepository(InventoryStockEntity)
     private readonly inventoryRepo: Repository<InventoryStockEntity>,
     @InjectRepository(RiderEntity)
     private readonly riderRepo: Repository<RiderEntity>,
+    @InjectRepository(SurgeRuleEntity)
+    private readonly surgeRuleRepo: Repository<SurgeRuleEntity>,
+    @InjectRepository(HospitalEntity)
+    private readonly hospitalRepo: Repository<HospitalEntity>,
+    private readonly notificationsService: NotificationsService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async simulate(dto: SurgeSimulationRequestDto): Promise<SurgeSimulationResult> {
@@ -37,7 +57,7 @@ export class SurgeSimulationService {
     if (baselineStockUnits === undefined) {
       const rows = await this.inventoryRepo.find();
       baselineStockUnits = rows.reduce(
-        (sum, r) => sum + (Number(r.availableUnits) || 0),
+        (sum, r) => sum + (Number(r.availableUnitsMl) || 0),
         0,
       );
     }
@@ -45,27 +65,18 @@ export class SurgeSimulationService {
     let riderCapacityUnits = dto.overrideRiderCapacityUnits;
     let activeRidersConsidered = 0;
     if (riderCapacityUnits === undefined) {
-      const activeStatuses = [
-        RiderStatus.AVAILABLE,
-        RiderStatus.ON_DELIVERY,
-        RiderStatus.BUSY,
-      ];
+      const activeStatuses = [RiderStatus.AVAILABLE, RiderStatus.ON_DELIVERY, RiderStatus.BUSY];
       activeRidersConsidered = await this.riderRepo
         .createQueryBuilder('r')
         .where('r.status IN (:...statuses)', { statuses: activeStatuses })
         .getCount();
-
       riderCapacityUnits = Math.floor(activeRidersConsidered * unitsPerRider);
     } else {
       activeRidersConsidered = Math.ceil(riderCapacityUnits / unitsPerRider);
     }
 
     const stockGapUnits = Math.max(0, dto.surgeDemandUnits - baselineStockUnits);
-    const riderGapUnits = Math.max(
-      0,
-      dto.surgeDemandUnits - riderCapacityUnits,
-    );
-
+    const riderGapUnits = Math.max(0, dto.surgeDemandUnits - riderCapacityUnits);
     const canAbsorbWithStock = baselineStockUnits >= dto.surgeDemandUnits;
     const canAbsorbWithRiders = riderCapacityUnits >= dto.surgeDemandUnits;
 
@@ -90,5 +101,90 @@ export class SurgeSimulationService {
       canAbsorbWithRiders,
       summary,
     };
+  }
+
+  /**
+   * Evaluate all surge rules against current inventory.
+   * Activates rules where stock < threshold, deactivates where stock has recovered.
+   * Emits surge.activated / surge.deactivated events and notifies hospitals.
+   */
+  async evaluateSurge(): Promise<SurgeEvaluationResult> {
+    const rules = await this.surgeRuleRepo.find();
+    if (rules.length === 0) return { activated: [], deactivated: [], activeRules: [] };
+
+    // Aggregate available stock per blood type across all banks
+    const stockRows = await this.inventoryRepo
+      .createQueryBuilder('s')
+      .select('s.blood_type', 'bloodType')
+      .addSelect('SUM(s.available_units_ml)', 'total')
+      .groupBy('s.blood_type')
+      .getRawMany<{ bloodType: BloodType; total: string }>();
+
+    const stockMap = new Map<BloodType, number>(
+      stockRows.map((r) => [r.bloodType, Number(r.total)]),
+    );
+
+    const activated: BloodType[] = [];
+    const deactivated: BloodType[] = [];
+    const toSave: SurgeRuleEntity[] = [];
+
+    for (const rule of rules) {
+      const stock = stockMap.get(rule.bloodType) ?? 0;
+      const shouldBeActive = stock < rule.threshold;
+
+      if (shouldBeActive && !rule.active) {
+        rule.active = true;
+        activated.push(rule.bloodType);
+        toSave.push(rule);
+        this.eventEmitter.emit('surge.activated', { bloodType: rule.bloodType, stock, threshold: rule.threshold, multiplier: rule.multiplier });
+      } else if (!shouldBeActive && rule.active) {
+        rule.active = false;
+        deactivated.push(rule.bloodType);
+        toSave.push(rule);
+        this.eventEmitter.emit('surge.deactivated', { bloodType: rule.bloodType, stock, threshold: rule.threshold });
+      }
+    }
+
+    if (toSave.length > 0) {
+      await this.surgeRuleRepo.save(toSave);
+    }
+
+    if (activated.length > 0) {
+      await this.notifyHospitals(activated);
+    }
+
+    const activeRules = rules.filter((r) => r.active);
+    return { activated, deactivated, activeRules };
+  }
+
+  async findAllRules(): Promise<SurgeRuleEntity[]> {
+    return this.surgeRuleRepo.find();
+  }
+
+  async upsertRule(dto: Partial<SurgeRuleEntity> & { bloodType: BloodType }): Promise<SurgeRuleEntity> {
+    const existing = await this.surgeRuleRepo.findOne({ where: { bloodType: dto.bloodType } });
+    const rule = existing ?? this.surgeRuleRepo.create({ active: false });
+    Object.assign(rule, dto);
+    return this.surgeRuleRepo.save(rule);
+  }
+
+  async deleteRule(id: string): Promise<void> {
+    await this.surgeRuleRepo.delete(id);
+  }
+
+  private async notifyHospitals(bloodTypes: BloodType[]): Promise<void> {
+    const hospitals = await this.hospitalRepo.find({ select: ['id'] });
+    const bloodTypeList = bloodTypes.join(', ');
+
+    await Promise.allSettled(
+      hospitals.map((h) =>
+        this.notificationsService.send({
+          recipientId: h.id,
+          channels: [NotificationChannel.IN_APP],
+          templateKey: 'surge.activated',
+          variables: { bloodTypes: bloodTypeList },
+        }).catch((err) => this.logger.warn(`Surge notification failed for hospital ${h.id}: ${err.message}`)),
+      ),
+    );
   }
 }


### PR DESCRIPTION
closes #463 

## Changes

### surge-simulation/entities/surge-rule.entity.ts (new)
SurgeRuleEntity with bloodType (unique), threshold (units), multiplier, maxMultiplier, active. Extends BaseEntity for id/createdAt/updatedAt.

### migrations/1820000000001-CreateSurgeRulesTable.ts (new)
Creates the surge_rules table with a unique index on blood_type. Reuses the existing blood_type_enum Postgres type if it already exists.

### fee-policy/fee-policy.service.ts
Added computeFeeWithSurge(dto, surgeMultiplier, bloodType) — applies the multiplier to platformFee, recalculates totalFee, and encodes surge:{bloodType}:{multiplier} into the 
audit hash so every surge-adjusted fee is distinguishable in the audit trail.

### surge-simulation/surge-simulation.service.ts
- Kept the original simulate() unchanged.
- Added evaluateSurge():
  - Aggregates availableUnitsMl per blood type across all inventory banks via a single GROUP BY query.
  - Compares each rule's threshold — activates or deactivates the rule and saves only changed rows.
  - Emits surge.activated / surge.deactivated via EventEmitter2.
  - Notifies all registered hospitals via NotificationsService (IN_APP channel, template key surge.activated) using Promise.allSettled so one failed delivery doesn't abort the 
rest.
- Added findAllRules(), upsertRule(), deleteRule() for rule management.

### surge-simulation/surge-simulation.controller.ts
- POST /surge-simulation/evaluate — triggers evaluation (ADMIN only).
- GET /surge-simulation/rules — list all rules (ADMIN only).
- PUT /surge-simulation/rules/:bloodType — create or update a rule (ADMIN only).
- DELETE /surge-simulation/rules/:id — remove a rule (ADMIN only).

### surge-simulation/surge-simulation.module.ts
Wires in SurgeRuleEntity, HospitalEntity, and imports NotificationsModule (which exports NotificationsService).
closes #457
