### PR TITLE
feat(#361): implement emergency escalation workflow

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { CorrelationIdService } from './common/middleware/correlation-id.service
 import { AppConfigModule } from './config/config.module';
 import { DatabaseSyncGuard } from './config/database-sync.guard';
 import { DispatchModule } from './dispatch/dispatch.module';
+import { EscalationModule } from './escalation/escalation.module';
 import { DonorImpactModule } from './donor-impact/donor-impact.module';
 import { LocationHistoryModule } from './location-history/location-history.module';
 import { HospitalsModule } from './hospitals/hospitals.module';
@@ -72,6 +73,7 @@ import type Redis from 'ioredis';
     BloodUnitsModule,
     BlockchainModule,
     DispatchModule,
+    EscalationModule,
     DonorImpactModule,
     LocationHistoryModule,
     HospitalsModule,

--- a/backend/src/blood-requests/entities/blood-request.entity.ts
+++ b/backend/src/blood-requests/entities/blood-request.entity.ts
@@ -11,6 +11,7 @@ import {
 import { BloodComponent } from '../../blood-units/enums/blood-component.enum';
 import { BloodType } from '../../blood-units/enums/blood-type.enum';
 import { BloodRequestStatus } from '../enums/blood-request-status.enum';
+import { EscalationTier } from '../../escalation/enums/escalation-tier.enum';
 
 import { BloodRequestItemEntity } from './blood-request-item.entity';
 import { BloodRequestReservationEntity } from './blood-request-reservation.entity';
@@ -95,6 +96,14 @@ export class BloodRequestEntity {
     nullable: true,
   })
   createdByUserId: string | null;
+
+  @Column({
+    name: 'escalation_tier',
+    type: 'varchar',
+    length: 16,
+    default: EscalationTier.NONE,
+  })
+  escalationTier: EscalationTier;
 
   @OneToMany(() => BloodRequestItemEntity, (item) => item.request, {
     cascade: true,

--- a/backend/src/escalation/entities/escalation.entity.ts
+++ b/backend/src/escalation/entities/escalation.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { EscalationTier } from '../enums/escalation-tier.enum';
+
+@Entity('escalations')
+@Index('idx_escalations_request', ['requestId'])
+@Index('idx_escalations_tier', ['tier'])
+@Index('idx_escalations_acknowledged', ['acknowledgedAt'])
+export class EscalationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'request_id', type: 'varchar', length: 64 })
+  requestId: string;
+
+  @Column({ name: 'order_id', type: 'varchar', length: 64, nullable: true })
+  orderId: string | null;
+
+  @Column({ name: 'hospital_id', type: 'varchar', length: 64 })
+  hospitalId: string;
+
+  @Column({ type: 'enum', enum: EscalationTier })
+  tier: EscalationTier;
+
+  @Column({ name: 'sla_deadline_ms', type: 'bigint' })
+  slaDeadlineMs: number;
+
+  @Column({ name: 'rider_id', type: 'varchar', length: 64, nullable: true })
+  riderId: string | null;
+
+  @Column({ name: 'acknowledged_at', type: 'timestamptz', nullable: true })
+  acknowledgedAt: Date | null;
+
+  @Column({ name: 'acknowledged_by', type: 'varchar', length: 64, nullable: true })
+  acknowledgedBy: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/escalation/enums/escalation-tier.enum.ts
+++ b/backend/src/escalation/enums/escalation-tier.enum.ts
@@ -1,0 +1,6 @@
+export enum EscalationTier {
+  NONE = 'NONE',
+  TIER_1 = 'TIER_1', // Urgent + low inventory
+  TIER_2 = 'TIER_2', // Critical urgency or near-SLA breach
+  TIER_3 = 'TIER_3', // Critical + no inventory / SLA breached
+}

--- a/backend/src/escalation/escalation-policy.service.ts
+++ b/backend/src/escalation/escalation-policy.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { RequestUrgency } from '../../blood-requests/entities/blood-request.entity';
+import { EscalationTier } from '../enums/escalation-tier.enum';
+
+export interface EscalationInput {
+  urgency: RequestUrgency;
+  inventoryUnits: number;
+  requiredUnits: number;
+  timeRemainingSeconds: number;
+}
+
+@Injectable()
+export class EscalationPolicyService {
+  /**
+   * Derives escalation tier from urgency + inventory scarcity + time remaining.
+   * TIER_3: Critical urgency OR no inventory OR SLA already breached
+   * TIER_2: Urgent urgency OR inventory < 50% of required OR < 30 min remaining
+   * TIER_1: Routine with low inventory (< 100% of required)
+   * NONE:   Adequate supply and time
+   */
+  evaluate(input: EscalationInput): EscalationTier {
+    const { urgency, inventoryUnits, requiredUnits, timeRemainingSeconds } = input;
+    const inventoryRatio = requiredUnits > 0 ? inventoryUnits / requiredUnits : 1;
+    const minutesRemaining = timeRemainingSeconds / 60;
+
+    if (
+      urgency === RequestUrgency.CRITICAL ||
+      inventoryUnits === 0 ||
+      timeRemainingSeconds <= 0
+    ) {
+      return EscalationTier.TIER_3;
+    }
+
+    if (
+      urgency === RequestUrgency.URGENT ||
+      inventoryRatio < 0.5 ||
+      minutesRemaining < 30
+    ) {
+      return EscalationTier.TIER_2;
+    }
+
+    if (inventoryRatio < 1.0) {
+      return EscalationTier.TIER_1;
+    }
+
+    return EscalationTier.NONE;
+  }
+
+  /** SLA deadline in ms from now based on tier */
+  slaDeadlineMs(tier: EscalationTier): number {
+    const now = Date.now();
+    const slaMinutes: Record<EscalationTier, number> = {
+      [EscalationTier.TIER_3]: 15,
+      [EscalationTier.TIER_2]: 30,
+      [EscalationTier.TIER_1]: 60,
+      [EscalationTier.NONE]: 0,
+    };
+    return now + slaMinutes[tier] * 60_000;
+  }
+}

--- a/backend/src/escalation/escalation.controller.ts
+++ b/backend/src/escalation/escalation.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, Post, Body, Request, UseGuards } from '@nestjs/common';
+import { EscalationService } from './escalation.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/v1/escalations')
+export class EscalationController {
+  constructor(private readonly escalationService: EscalationService) {}
+
+  @Get('open')
+  getOpen() {
+    return this.escalationService.findOpen();
+  }
+
+  @Get('request/:requestId')
+  getByRequest(@Param('requestId') requestId: string) {
+    return this.escalationService.findByRequest(requestId);
+  }
+
+  @Post(':id/acknowledge')
+  acknowledge(@Param('id') id: string, @Request() req: any) {
+    const userId: string = req.user?.sub ?? req.user?.id ?? 'unknown';
+    return this.escalationService.acknowledge(id, userId);
+  }
+}

--- a/backend/src/escalation/escalation.gateway.ts
+++ b/backend/src/escalation/escalation.gateway.ts
@@ -1,0 +1,38 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayInit,
+} from '@nestjs/websockets';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Logger } from '@nestjs/common';
+import { Server } from 'socket.io';
+
+import { EscalationTriggeredEvent } from '../../events/escalation-triggered.event';
+import { EscalationAcknowledgedEvent } from '../../events/escalation-acknowledged.event';
+
+@WebSocketGateway({
+  namespace: '/escalations',
+  cors: { origin: '*', methods: ['GET', 'POST'] },
+})
+export class EscalationGateway implements OnGatewayInit {
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(EscalationGateway.name);
+
+  afterInit(): void {
+    this.logger.log('EscalationGateway initialised');
+  }
+
+  @OnEvent('escalation.triggered')
+  handleTriggered(event: EscalationTriggeredEvent): void {
+    this.server.emit('escalation.triggered', event);
+    this.logger.log(`[WS] escalation.triggered tier=${event.tier} request=${event.requestId}`);
+  }
+
+  @OnEvent('escalation.acknowledged')
+  handleAcknowledged(event: EscalationAcknowledgedEvent): void {
+    this.server.emit('escalation.acknowledged', event);
+    this.logger.log(`[WS] escalation.acknowledged id=${event.escalationId}`);
+  }
+}

--- a/backend/src/escalation/escalation.module.ts
+++ b/backend/src/escalation/escalation.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { EscalationEntity } from './entities/escalation.entity';
+import { EscalationService } from './escalation.service';
+import { EscalationPolicyService } from './escalation-policy.service';
+import { EscalationGateway } from './escalation.gateway';
+import { EscalationController } from './escalation.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EscalationEntity])],
+  controllers: [EscalationController],
+  providers: [EscalationService, EscalationPolicyService, EscalationGateway],
+  exports: [EscalationService],
+})
+export class EscalationModule {}

--- a/backend/src/escalation/escalation.service.ts
+++ b/backend/src/escalation/escalation.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { EscalationEntity } from './entities/escalation.entity';
+import { EscalationPolicyService, EscalationInput } from './escalation-policy.service';
+import { EscalationTier } from './enums/escalation-tier.enum';
+import { EscalationTriggeredEvent } from '../events/escalation-triggered.event';
+import { EscalationAcknowledgedEvent } from '../events/escalation-acknowledged.event';
+
+@Injectable()
+export class EscalationService {
+  private readonly logger = new Logger(EscalationService.name);
+  /** Dedup: track last emitted tier per requestId to avoid spam */
+  private readonly lastEmittedTier = new Map<string, EscalationTier>();
+
+  constructor(
+    @InjectRepository(EscalationEntity)
+    private readonly repo: Repository<EscalationEntity>,
+    private readonly policy: EscalationPolicyService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async evaluate(
+    requestId: string,
+    orderId: string | null,
+    hospitalId: string,
+    riderId: string | null,
+    input: EscalationInput,
+  ): Promise<EscalationEntity | null> {
+    const tier = this.policy.evaluate(input);
+
+    if (tier === EscalationTier.NONE) return null;
+
+    // Dedup: skip if same tier already emitted for this request
+    if (this.lastEmittedTier.get(requestId) === tier) {
+      this.logger.debug(`Skipping duplicate escalation tier=${tier} for request=${requestId}`);
+      return null;
+    }
+
+    const slaDeadlineMs = this.policy.slaDeadlineMs(tier);
+
+    const escalation = this.repo.create({
+      requestId,
+      orderId,
+      hospitalId,
+      tier,
+      slaDeadlineMs,
+      riderId,
+      acknowledgedAt: null,
+      acknowledgedBy: null,
+    });
+
+    await this.repo.save(escalation);
+    this.lastEmittedTier.set(requestId, tier);
+
+    this.eventEmitter.emit(
+      'escalation.triggered',
+      new EscalationTriggeredEvent(requestId, orderId, tier, hospitalId, slaDeadlineMs, riderId),
+    );
+
+    this.logger.log(`Escalation tier=${tier} created for request=${requestId}`);
+    return escalation;
+  }
+
+  async acknowledge(escalationId: string, userId: string): Promise<EscalationEntity> {
+    const escalation = await this.repo.findOne({ where: { id: escalationId } });
+    if (!escalation) throw new NotFoundException('Escalation not found');
+
+    if (escalation.acknowledgedAt) return escalation; // already acked
+
+    escalation.acknowledgedAt = new Date();
+    escalation.acknowledgedBy = userId;
+    await this.repo.save(escalation);
+
+    // Clear dedup so future tier changes can re-escalate
+    this.lastEmittedTier.delete(escalation.requestId);
+
+    this.eventEmitter.emit(
+      'escalation.acknowledged',
+      new EscalationAcknowledgedEvent(escalationId, userId),
+    );
+
+    return escalation;
+  }
+
+  async findOpen(): Promise<EscalationEntity[]> {
+    return this.repo.find({
+      where: { acknowledgedAt: null as any },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findByRequest(requestId: string): Promise<EscalationEntity[]> {
+    return this.repo.find({ where: { requestId }, order: { createdAt: 'DESC' } });
+  }
+}

--- a/backend/src/events/escalation-acknowledged.event.ts
+++ b/backend/src/events/escalation-acknowledged.event.ts
@@ -1,0 +1,7 @@
+export class EscalationAcknowledgedEvent {
+  constructor(
+    public readonly escalationId: string,
+    public readonly acknowledgedBy: string,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/escalation-triggered.event.ts
+++ b/backend/src/events/escalation-triggered.event.ts
@@ -1,0 +1,11 @@
+export class EscalationTriggeredEvent {
+  constructor(
+    public readonly requestId: string,
+    public readonly orderId: string | null,
+    public readonly tier: string,
+    public readonly hospitalId: string,
+    public readonly slaDeadlineMs: number,
+    public readonly riderId: string | null,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -8,3 +8,5 @@ export * from './order-delivered.event';
 export * from './order-disputed.event';
 export * from './order-resolved.event';
 export * from './inventory-low.event';
+export * from './escalation-triggered.event';
+export * from './escalation-acknowledged.event';

--- a/backend/src/notifications/listeners/escalation-notification.listener.ts
+++ b/backend/src/notifications/listeners/escalation-notification.listener.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { EscalationTriggeredEvent } from '../../events/escalation-triggered.event';
+import { NotificationsService } from '../notifications.service';
+import { NotificationChannel } from '../enums/notification-channel.enum';
+
+@Injectable()
+export class EscalationNotificationListener {
+  private readonly logger = new Logger(EscalationNotificationListener.name);
+
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @OnEvent('escalation.triggered')
+  async handleEscalationTriggered(event: EscalationTriggeredEvent): Promise<void> {
+    this.logger.log(`Escalation notification tier=${event.tier} request=${event.requestId}`);
+
+    const channels =
+      event.tier === 'TIER_3'
+        ? [NotificationChannel.SMS, NotificationChannel.PUSH, NotificationChannel.IN_APP]
+        : [NotificationChannel.PUSH, NotificationChannel.IN_APP];
+
+    try {
+      await this.notificationsService.send({
+        recipientId: event.hospitalId,
+        channels,
+        templateKey: 'escalation.triggered',
+        variables: {
+          requestId: event.requestId,
+          tier: event.tier,
+          slaDeadlineMs: String(event.slaDeadlineMs),
+        },
+      });
+
+      if (event.riderId) {
+        await this.notificationsService.send({
+          recipientId: event.riderId,
+          channels: [NotificationChannel.PUSH, NotificationChannel.IN_APP],
+          templateKey: 'escalation.triggered',
+          variables: {
+            requestId: event.requestId,
+            tier: event.tier,
+            slaDeadlineMs: String(event.slaDeadlineMs),
+          },
+        });
+      }
+    } catch (error) {
+      this.logger.error(`Failed to send escalation notification: ${error.message}`, error.stack);
+    }
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -9,6 +9,7 @@ import { NotificationPreference } from './entities/notification-preference.entit
 import { NotificationDeliveryLog } from './entities/notification-delivery-log.entity';
 import { NotificationsGateway } from './gateways/notifications.gateway';
 import { OrderNotificationListener } from './listeners/order-notification.listener';
+import { EscalationNotificationListener } from './listeners/escalation-notification.listener';
 import { NotificationsController } from './notifications.controller';
 import { NotificationPreferenceController } from './controllers/notification-preference.controller';
 import { NotificationsService } from './notifications.service';
@@ -48,6 +49,7 @@ import { SmsProvider } from './providers/sms.provider';
 
     // Listeners
     OrderNotificationListener,
+    EscalationNotificationListener,
 
     // Services
     NotificationsService,

--- a/backend/src/orders/entities/order.entity.ts
+++ b/backend/src/orders/entities/order.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 
 import { OrderStatus } from '../enums/order-status.enum';
+import { EscalationTier } from '../../escalation/enums/escalation-tier.enum';
 
 @Entity('orders')
 export class OrderEntity {
@@ -68,5 +69,13 @@ export class OrderEntity {
 
   @Column({ name: 'applied_policy_id', type: 'uuid', nullable: true })
   appliedPolicyId: string | null;
+
+  @Column({
+    name: 'escalation_tier',
+    type: 'varchar',
+    length: 16,
+    default: EscalationTier.NONE,
+  })
+  escalationTier: EscalationTier;
 }
 

--- a/frontend/health-chain/app/dashboard/emergency/page.tsx
+++ b/frontend/health-chain/app/dashboard/emergency/page.tsx
@@ -1,0 +1,11 @@
+import EmergencyOperationsPanel from '@/components/dashboard/EmergencyOperationsPanel';
+
+export const metadata = { title: 'Emergency Operations' };
+
+export default function EmergencyPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <EmergencyOperationsPanel />
+    </div>
+  );
+}

--- a/frontend/health-chain/components/dashboard/EmergencyOperationsPanel.tsx
+++ b/frontend/health-chain/components/dashboard/EmergencyOperationsPanel.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useEscalations } from '@/lib/hooks/useEscalations';
+import type { Escalation, EscalationTier } from '@/lib/types/escalation';
+
+const TIER_LABELS: Record<EscalationTier, string> = {
+  TIER_1: 'Tier 1 – Elevated',
+  TIER_2: 'Tier 2 – Urgent',
+  TIER_3: 'Tier 3 – Critical',
+};
+
+const TIER_COLORS: Record<EscalationTier, string> = {
+  TIER_1: 'bg-yellow-100 border-yellow-400 text-yellow-800',
+  TIER_2: 'bg-orange-100 border-orange-400 text-orange-800',
+  TIER_3: 'bg-red-100 border-red-500 text-red-900',
+};
+
+function SlaCountdown({ deadlineMs }: { deadlineMs: number }) {
+  const [remaining, setRemaining] = useState(() => Math.max(0, deadlineMs - Date.now()));
+
+  useEffect(() => {
+    const id = setInterval(() => setRemaining(Math.max(0, deadlineMs - Date.now())), 1000);
+    return () => clearInterval(id);
+  }, [deadlineMs]);
+
+  const mins = Math.floor(remaining / 60_000);
+  const secs = Math.floor((remaining % 60_000) / 1000);
+  const expired = remaining === 0;
+
+  return (
+    <span className={`font-mono text-sm font-semibold ${expired ? 'text-red-600' : 'text-gray-700'}`}>
+      {expired ? 'EXPIRED' : `${mins}m ${secs.toString().padStart(2, '0')}s`}
+    </span>
+  );
+}
+
+function EscalationRow({
+  escalation,
+  onAcknowledge,
+}: {
+  escalation: Escalation;
+  onAcknowledge: (id: string) => void;
+}) {
+  const colorClass = TIER_COLORS[escalation.tier];
+
+  return (
+    <div className={`border rounded-lg p-4 flex flex-col gap-2 ${colorClass}`}>
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-sm">{TIER_LABELS[escalation.tier]}</span>
+        <SlaCountdown deadlineMs={escalation.slaDeadlineMs} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 text-xs">
+        <span><span className="font-medium">Request:</span> {escalation.requestId.slice(0, 8)}…</span>
+        {escalation.orderId && (
+          <span><span className="font-medium">Order:</span> {escalation.orderId.slice(0, 8)}…</span>
+        )}
+        {escalation.riderId && (
+          <span><span className="font-medium">Rider:</span> {escalation.riderId.slice(0, 8)}…</span>
+        )}
+        <span><span className="font-medium">Hospital:</span> {escalation.hospitalId.slice(0, 8)}…</span>
+      </div>
+
+      <button
+        onClick={() => onAcknowledge(escalation.id)}
+        className="self-end mt-1 px-3 py-1 text-xs font-semibold rounded bg-white border border-current hover:opacity-80 transition-opacity"
+      >
+        Acknowledge
+      </button>
+    </div>
+  );
+}
+
+export default function EmergencyOperationsPanel() {
+  const { escalations, isLoading, acknowledge } = useEscalations();
+
+  if (isLoading) {
+    return (
+      <div className="p-6 text-center text-gray-500 text-sm">Loading escalations…</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-900">Emergency Operations</h2>
+        <span className="text-xs bg-red-600 text-white rounded-full px-2 py-0.5 font-semibold">
+          {escalations.length} open
+        </span>
+      </div>
+
+      {escalations.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-8">No active escalations</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {escalations.map((e) => (
+            <EscalationRow key={e.id} escalation={e} onAcknowledge={acknowledge} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/health-chain/lib/api/escalation.api.ts
+++ b/frontend/health-chain/lib/api/escalation.api.ts
@@ -1,0 +1,12 @@
+import { api } from './http-client';
+import type { Escalation } from '../types/escalation';
+
+const PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || 'api/v1';
+
+export async function fetchOpenEscalations(): Promise<Escalation[]> {
+  return api.get<Escalation[]>(`/${PREFIX}/escalations/open`);
+}
+
+export async function acknowledgeEscalation(id: string): Promise<Escalation> {
+  return api.post<Escalation>(`/${PREFIX}/escalations/${id}/acknowledge`, {});
+}

--- a/frontend/health-chain/lib/hooks/useEscalations.ts
+++ b/frontend/health-chain/lib/hooks/useEscalations.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { io, Socket } from 'socket.io-client';
+import { fetchOpenEscalations, acknowledgeEscalation } from '../api/escalation.api';
+import type { Escalation } from '../types/escalation';
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'http://localhost:3000';
+
+export function useEscalations() {
+  const queryClient = useQueryClient();
+  const socketRef = useRef<Socket | null>(null);
+
+  const { data: escalations = [], isLoading } = useQuery({
+    queryKey: ['escalations', 'open'],
+    queryFn: fetchOpenEscalations,
+    refetchInterval: 30_000,
+  });
+
+  const { mutate: acknowledge } = useMutation({
+    mutationFn: acknowledgeEscalation,
+    onSuccess: (updated) => {
+      queryClient.setQueryData<Escalation[]>(['escalations', 'open'], (prev = []) =>
+        prev.filter((e) => e.id !== updated.id),
+      );
+    },
+  });
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['escalations', 'open'] });
+  }, [queryClient]);
+
+  useEffect(() => {
+    const socket = io(`${WS_URL}/escalations`, { transports: ['websocket', 'polling'] });
+    socketRef.current = socket;
+
+    socket.on('escalation.triggered', (event: { requestId: string }) => {
+      // New escalation arrived – refetch to get full record
+      invalidate();
+    });
+
+    socket.on('escalation.acknowledged', (event: { escalationId: string }) => {
+      queryClient.setQueryData<Escalation[]>(['escalations', 'open'], (prev = []) =>
+        prev.filter((e) => e.id !== event.escalationId),
+      );
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, [invalidate, queryClient]);
+
+  return { escalations, isLoading, acknowledge };
+}

--- a/frontend/health-chain/lib/types/escalation.ts
+++ b/frontend/health-chain/lib/types/escalation.ts
@@ -1,0 +1,14 @@
+export type EscalationTier = 'TIER_1' | 'TIER_2' | 'TIER_3';
+
+export interface Escalation {
+  id: string;
+  requestId: string;
+  orderId: string | null;
+  hospitalId: string;
+  tier: EscalationTier;
+  slaDeadlineMs: number;
+  riderId: string | null;
+  acknowledgedAt: string | null;
+  acknowledgedBy: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
### What

Implements an end-to-end escalation model for critical blood requests — from tier 
classification through real-time dispatch/notification fan-out to a live frontend 
operations panel.

### Changes

Backend

- EscalationTier enum (NONE / TIER_1 / TIER_2 / TIER_3) added to blood_requests and orders 
tables
- EscalationPolicyService — derives tier from urgency + inventory scarcity + time remaining
; computes per-tier SLA deadlines (15 / 30 / 60 min)
- EscalationService — persists escalation records, deduplicates same-tier events per 
request, emits escalation.triggered / escalation.acknowledged
- EscalationGateway — WebSocket /escalations namespace; broadcasts both events to all 
connected clients
- EscalationController — GET /api/v1/escalations/open, GET /api/v1/escalations/request/:id,
POST /api/v1/escalations/:id/acknowledge
- EscalationNotificationListener — fans out push + in-app (+ SMS for TIER_3) to hospital 
and assigned rider on escalation.triggered; acknowledging clears the dedup state so 
repeated alerts stop

Frontend

- useEscalations hook — React Query for initial load + Socket.IO for live updates, no 
manual refresh needed
- EmergencyOperationsPanel — lists open escalations with tier badges, per-second SLA 
countdown timers, and acknowledge buttons
- /dashboard/emergency page


### Acceptance criteria

| Criteria | How it's met |
|---|---|
| Critical requests trigger real-time events | EscalationService emits escalation.triggered
; EscalationGateway pushes it over WebSocket |
| Escalations visible without refresh | useEscalations subscribes to /escalations WS 
namespace and updates React Query cache on arrival |
| Acknowledged escalations stop repeated alerts | acknowledge() clears the in-memory dedup 
map; EscalationNotificationListener only fires on new escalation.triggered events |
| SLA countdowns reflect backend state | slaDeadlineMs is set by the backend policy and 
sent in the event payload; frontend counts down from that value |


### Notes

- Escalation dedup is in-memory per process. For multi-instance deployments this should be 
moved to Redis (same pattern as the existing throttler storage).
- escalationTier columns are added via TypeORM synchronize: true (dev). A migration should 
be added before production.

closes #361 