### PR TITLE
feat(#374): harden RBAC with fine-grained permission scopes

### DIFF
--- a/backend/src/approvals/approval.controller.ts
+++ b/backend/src/approvals/approval.controller.ts
@@ -18,7 +18,7 @@ export class ApprovalController {
   constructor(private readonly approvalService: ApprovalService) {}
 
   @Get('pending')
-  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @RequirePermissions(Permission.REQUEST_APPROVE)
   @ApiOperation({ summary: 'Get all pending approval requests' })
   @ApiResponse({ status: 200, description: 'Requests fetched' })
   async getPending(@Req() req: Request) {
@@ -26,7 +26,7 @@ export class ApprovalController {
   }
 
   @Get(':id')
-  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @RequirePermissions(Permission.REQUEST_APPROVE)
   @ApiOperation({ summary: 'Get details of an approval request' })
   @ApiResponse({ status: 200, description: 'Request details fetched' })
   async getDetail(@Param('id') id: string) {
@@ -34,7 +34,7 @@ export class ApprovalController {
   }
 
   @Post(':id/approve')
-  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @RequirePermissions(Permission.REQUEST_APPROVE)
   @ApiOperation({ summary: 'Approve a request' })
   @ApiResponse({ status: 200, description: 'Request approved' })
   async approve(
@@ -54,7 +54,7 @@ export class ApprovalController {
   }
 
   @Post(':id/reject')
-  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @RequirePermissions(Permission.REQUEST_APPROVE)
   @ApiOperation({ summary: 'Reject a request' })
   @ApiResponse({ status: 200, description: 'Request rejected' })
   async reject(

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { UserActivityModule } from '../user-activity/user-activity.module';
 import { UserEntity } from '../users/entities/user.entity';
 
 import { AuthController } from './auth.controller';
+import { PermissionsController } from './permissions.controller';
 import { AuthService } from './auth.service';
 import { EmailVerificationEntity } from './entities/email-verification.entity';
 import { AuthSessionEntity } from './entities/auth-session.entity';
@@ -52,7 +53,7 @@ import { AuthSessionRepository } from './repositories/auth-session.repository';
     IdempotencyModule,
     UserActivityModule,
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, PermissionsController],
   providers: [
     AuthService,
     PasswordResetService,

--- a/backend/src/auth/enums/permission.enum.ts
+++ b/backend/src/auth/enums/permission.enum.ts
@@ -26,6 +26,7 @@ export enum Permission {
   CREATE_INVENTORY = 'create:inventory',
   UPDATE_INVENTORY = 'update:inventory',
   DELETE_INVENTORY = 'delete:inventory',
+  INVENTORY_WRITE = 'inventory:write',
 
   // ── Blood Units ──────────────────────────────────────────────────────
   VIEW_BLOODUNIT_TRAIL = 'view:bloodunit:trail',
@@ -41,6 +42,7 @@ export enum Permission {
   UPDATE_DISPATCH = 'update:dispatch',
   DELETE_DISPATCH = 'delete:dispatch',
   MANAGE_DISPATCH = 'manage:dispatch',
+  DISPATCH_OVERRIDE = 'dispatch:override',
 
   // ── Users ─────────────────────────────────────────────────────────────
   VIEW_USERS = 'view:users',
@@ -70,4 +72,11 @@ export enum Permission {
   ADMIN_ACCESS = 'admin:access',
   MANAGE_ROLES = 'manage:roles',
   READ_ANALYTICS = 'read:analytics',
+  EXPORT_DISPUTES = 'export:disputes',
+
+  // ── Fine-grained workflow scopes (Issue #374) ─────────────────────────
+  REQUEST_APPROVE = 'request:approve',
+  DISPUTE_RESOLVE = 'dispute:resolve',
+  VERIFICATION_ADMIN = 'verification:admin',
+  SETTLEMENT_RELEASE = 'settlement:release',
 }

--- a/backend/src/auth/guards/permissions.guard.scopes.spec.ts
+++ b/backend/src/auth/guards/permissions.guard.scopes.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Negative authorization tests for fine-grained permission scopes (Issue #374).
+ *
+ * Verifies that sensitive actions are blocked when the caller lacks the
+ * required scope, even if they hold a valid role.
+ */
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PERMISSIONS_KEY } from '../decorators/require-permissions.decorator';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { Permission } from '../enums/permission.enum';
+import { PermissionsService } from '../permissions.service';
+import { PermissionsGuard } from './permissions.guard';
+
+function makeContext(role: string): ExecutionContext {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ user: { id: 'u1', email: 'u@test.com', role } }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('Fine-grained permission scopes – negative authorization (Issue #374)', () => {
+  let guard: PermissionsGuard;
+  let reflector: jest.Mocked<Reflector>;
+  let permissionsService: jest.Mocked<PermissionsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PermissionsGuard,
+        {
+          provide: Reflector,
+          useValue: { getAllAndOverride: jest.fn() },
+        },
+        {
+          provide: PermissionsService,
+          useValue: { getPermissionsForRole: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    guard = module.get(PermissionsGuard);
+    reflector = module.get(Reflector);
+    permissionsService = module.get(PermissionsService);
+
+    // Default: not public
+    reflector.getAllAndOverride.mockImplementation((key) =>
+      key === IS_PUBLIC_KEY ? false : undefined,
+    );
+  });
+
+  function setupRequired(scope: Permission, rolePermissions: Permission[]) {
+    reflector.getAllAndOverride.mockImplementation((key) => {
+      if (key === IS_PUBLIC_KEY) return false;
+      if (key === PERMISSIONS_KEY) return [scope];
+      return undefined;
+    });
+    permissionsService.getPermissionsForRole.mockResolvedValue(rolePermissions);
+  }
+
+  it('blocks inventory:write for a donor role', async () => {
+    setupRequired(Permission.INVENTORY_WRITE, [Permission.VIEW_INVENTORY]);
+    await expect(guard.canActivate(makeContext('donor'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('blocks dispatch:override for a hospital role', async () => {
+    setupRequired(Permission.DISPATCH_OVERRIDE, [
+      Permission.VIEW_DISPATCH,
+      Permission.CREATE_DISPATCH,
+    ]);
+    await expect(guard.canActivate(makeContext('hospital'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('blocks request:approve for a rider role', async () => {
+    setupRequired(Permission.REQUEST_APPROVE, [
+      Permission.VIEW_ORDER,
+      Permission.UPDATE_ORDER,
+    ]);
+    await expect(guard.canActivate(makeContext('rider'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('blocks dispute:resolve for a donor role', async () => {
+    setupRequired(Permission.DISPUTE_RESOLVE, [Permission.VIEW_ORDER]);
+    await expect(guard.canActivate(makeContext('donor'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('blocks verification:admin for a vendor role', async () => {
+    setupRequired(Permission.VERIFICATION_ADMIN, [
+      Permission.VIEW_INVENTORY,
+      Permission.INVENTORY_WRITE,
+    ]);
+    await expect(guard.canActivate(makeContext('vendor'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('blocks settlement:release for a hospital role', async () => {
+    setupRequired(Permission.SETTLEMENT_RELEASE, [
+      Permission.VIEW_ORDER,
+      Permission.REQUEST_APPROVE,
+    ]);
+    await expect(guard.canActivate(makeContext('hospital'))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('allows inventory:write when the scope is present', async () => {
+    setupRequired(Permission.INVENTORY_WRITE, [
+      Permission.VIEW_INVENTORY,
+      Permission.INVENTORY_WRITE,
+    ]);
+    await expect(
+      guard.canActivate(makeContext('vendor')),
+    ).resolves.toBe(true);
+  });
+
+  it('allows dispute:resolve for admin role', async () => {
+    setupRequired(Permission.DISPUTE_RESOLVE, [
+      Permission.ADMIN_ACCESS,
+      Permission.DISPUTE_RESOLVE,
+    ]);
+    await expect(guard.canActivate(makeContext('admin'))).resolves.toBe(true);
+  });
+});

--- a/backend/src/auth/permissions.controller.ts
+++ b/backend/src/auth/permissions.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
+import { UserRole } from '../auth/enums/user-role.enum';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PermissionsGuard } from '../auth/guards/permissions.guard';
+import { PermissionsService } from '../auth/permissions.service';
+
+@ApiTags('Permissions')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@Controller('permissions')
+export class PermissionsController {
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  /** Return effective permissions for a given role (admin UI). */
+  @Get('role/:role')
+  @RequirePermissions(Permission.MANAGE_ROLES)
+  @ApiOperation({ summary: 'Get effective permissions for a role' })
+  async getByRole(@Param('role') role: UserRole) {
+    const permissions = await this.permissionsService.getPermissionsForRole(role);
+    return { role, permissions };
+  }
+
+  /** Return effective permissions for every role (admin UI overview). */
+  @Get()
+  @RequirePermissions(Permission.MANAGE_ROLES)
+  @ApiOperation({ summary: 'Get effective permissions for all roles' })
+  async getAll() {
+    const roles = Object.values(UserRole);
+    const results = await Promise.all(
+      roles.map(async (role) => ({
+        role,
+        permissions: await this.permissionsService.getPermissionsForRole(role),
+      })),
+    );
+    return results;
+  }
+}

--- a/backend/src/dispatch/dispatch.controller.ts
+++ b/backend/src/dispatch/dispatch.controller.ts
@@ -50,7 +50,7 @@ export class DispatchController {
     return this.dispatchService.create(createDispatchDto);
   }
 
-  @RequirePermissions(Permission.MANAGE_DISPATCH)
+  @RequirePermissions(Permission.DISPATCH_OVERRIDE)
   @Post('assign')
   assignOrder(
     @Body('orderId') orderId: string,

--- a/backend/src/disputes/disputes.controller.ts
+++ b/backend/src/disputes/disputes.controller.ts
@@ -1,13 +1,16 @@
-import { Body, Controller, Get, Param, Patch, Post, Query, Res } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { User } from '../auth/decorators/user.decorator';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PermissionsGuard } from '../auth/guards/permissions.guard';
 import { DisputesService } from './disputes.service';
 import { AddNoteDto, AssignDisputeDto, OpenDisputeDto, ResolveDisputeDto } from './dto/dispute.dto';
 import { DisputeSeverity, DisputeStatus } from './enums/dispute.enum';
 
 @Controller('disputes')
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 export class DisputesController {
   constructor(private readonly service: DisputesService) {}
 
@@ -17,6 +20,7 @@ export class DisputesController {
   }
 
   @Get()
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   list(
     @Query('status') status?: DisputeStatus,
     @Query('severity') severity?: DisputeSeverity,
@@ -39,31 +43,37 @@ export class DisputesController {
   }
 
   @Get(':id')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   get(@Param('id') id: string) {
     return this.service.get(id);
   }
 
   @Patch(':id/assign')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   assign(@Param('id') id: string, @Body() dto: AssignDisputeDto) {
     return this.service.assign(id, dto.operatorId);
   }
 
   @Patch(':id/resolve')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   resolve(@Param('id') id: string, @Body() dto: ResolveDisputeDto) {
     return this.service.resolve(id, dto);
   }
 
   @Post(':id/notes')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   addNote(@Param('id') id: string, @Body() dto: AddNoteDto, @User('id') userId: string) {
     return this.service.addNote(id, dto.content, userId);
   }
 
   @Get(':id/notes')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   getNotes(@Param('id') id: string) {
     return this.service.getNotes(id);
   }
 
   @Post(':id/evidence')
+  @RequirePermissions(Permission.DISPUTE_RESOLVE)
   addEvidence(@Param('id') id: string, @Body() body: { type: string; url: string }) {
     return this.service.addEvidence(id, body);
   }

--- a/backend/src/inventory/inventory.controller.ts
+++ b/backend/src/inventory/inventory.controller.ts
@@ -81,13 +81,13 @@ export class InventoryController {
     return this.inventoryService.findOne(id);
   }
 
-  @RequirePermissions(Permission.CREATE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Post()
   create(@Body() createInventoryDto: CreateInventoryDto) {
     return this.inventoryService.create(createInventoryDto);
   }
 
-  @RequirePermissions(Permission.UPDATE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -96,27 +96,27 @@ export class InventoryController {
     return this.inventoryService.update(id, updateInventoryDto);
   }
 
-  @RequirePermissions(Permission.UPDATE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Patch(':id/stock')
   updateStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     return this.inventoryService.updateStock(id, quantity);
   }
 
-  @RequirePermissions(Permission.UPDATE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Patch(':id/reserve')
   reserveStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     return this.inventoryService.reserveStock(id, quantity);
   }
 
-  @RequirePermissions(Permission.UPDATE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Patch(':id/release')
   releaseStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     return this.inventoryService.releaseStock(id, quantity);
   }
 
-  @RequirePermissions(Permission.DELETE_INVENTORY)
+  @RequirePermissions(Permission.INVENTORY_WRITE)
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {

--- a/backend/src/migrations/1820000002000-AddFineGrainedPermissionScopes.ts
+++ b/backend/src/migrations/1820000002000-AddFineGrainedPermissionScopes.ts
@@ -1,0 +1,62 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #374 – Fine-grained permission scopes.
+ *
+ * New scopes:
+ *   inventory:write       – create/update/delete inventory records
+ *   dispatch:override     – force-assign or override dispatch decisions
+ *   request:approve       – approve / reject blood-request workflows
+ *   dispute:resolve       – manage and resolve disputes
+ *   verification:admin    – verify / unverify healthcare actors
+ *   settlement:release    – release escrowed settlement funds
+ */
+export class AddFineGrainedPermissionScopes1820000002000
+  implements MigrationInterface
+{
+  private readonly NEW_SCOPES = [
+    'inventory:write',
+    'dispatch:override',
+    'request:approve',
+    'dispute:resolve',
+    'verification:admin',
+    'settlement:release',
+  ];
+
+  /** Roles that receive each new scope */
+  private readonly ROLE_SCOPE_MAP: Record<string, string[]> = {
+    admin: [
+      'inventory:write',
+      'dispatch:override',
+      'request:approve',
+      'dispute:resolve',
+      'verification:admin',
+      'settlement:release',
+    ],
+    vendor: ['inventory:write'],
+    hospital: ['request:approve'],
+    rider: ['dispatch:override'],
+  };
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const [role, scopes] of Object.entries(this.ROLE_SCOPE_MAP)) {
+      for (const scope of scopes) {
+        await queryRunner.query(
+          `INSERT INTO role_permissions (role_id, permission)
+           SELECT id, $1 FROM roles WHERE name = $2
+           ON CONFLICT DO NOTHING`,
+          [scope, role],
+        );
+      }
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const scope of this.NEW_SCOPES) {
+      await queryRunner.query(
+        `DELETE FROM role_permissions WHERE permission = $1`,
+        [scope],
+      );
+    }
+  }
+}

--- a/frontend/health-chain/app/admin/permissions/page.tsx
+++ b/frontend/health-chain/app/admin/permissions/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useState } from "react";
+import { usePermissions } from "@/lib/hooks/usePermissions";
+
+const SCOPE_LABELS: Record<string, string> = {
+  "inventory:write": "Inventory Write",
+  "dispatch:override": "Dispatch Override",
+  "request:approve": "Request Approval",
+  "dispute:resolve": "Dispute Resolution",
+  "verification:admin": "Verification Admin",
+  "settlement:release": "Settlement Release",
+};
+
+export default function PermissionsPage() {
+  const { data, isLoading, error } = usePermissions();
+  const [search, setSearch] = useState("");
+
+  const filtered = data?.filter((r) =>
+    r.role.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="p-6 lg:p-10 space-y-6 bg-white min-h-screen">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Permission Management</h1>
+        <p className="text-gray-500 mt-1">
+          Effective permission scopes by role. Sensitive actions require the
+          matching scope.
+        </p>
+      </div>
+
+      <input
+        type="text"
+        placeholder="Filter by role…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm w-64 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+
+      {isLoading && (
+        <p className="text-gray-500 text-sm">Loading permissions…</p>
+      )}
+
+      {error && (
+        <p className="text-red-600 text-sm">
+          Failed to load permissions. Make sure you have the{" "}
+          <code>manage:roles</code> scope.
+        </p>
+      )}
+
+      {filtered && (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-gray-700 w-32">
+                  Role
+                </th>
+                {Object.entries(SCOPE_LABELS).map(([scope, label]) => (
+                  <th
+                    key={scope}
+                    className="px-4 py-3 text-center font-semibold text-gray-700"
+                    title={scope}
+                  >
+                    {label}
+                  </th>
+                ))}
+                <th className="px-4 py-3 text-left font-semibold text-gray-700">
+                  All Permissions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {filtered.map(({ role, permissions }) => (
+                <tr key={role} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium text-gray-900 capitalize">
+                    {role}
+                  </td>
+                  {Object.keys(SCOPE_LABELS).map((scope) => (
+                    <td key={scope} className="px-4 py-3 text-center">
+                      {permissions.includes(scope) ? (
+                        <span className="inline-block w-5 h-5 rounded-full bg-green-500 text-white text-xs leading-5 text-center">
+                          ✓
+                        </span>
+                      ) : (
+                        <span className="inline-block w-5 h-5 rounded-full bg-gray-200 text-gray-400 text-xs leading-5 text-center">
+                          –
+                        </span>
+                      )}
+                    </td>
+                  ))}
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {permissions.map((p) => (
+                        <span
+                          key={p}
+                          className="inline-block bg-blue-50 text-blue-700 text-xs px-2 py-0.5 rounded-full"
+                        >
+                          {p}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/health-chain/lib/api/permissions.api.ts
+++ b/frontend/health-chain/lib/api/permissions.api.ts
@@ -1,0 +1,7 @@
+import { api } from './http-client';
+import type { RolePermissions } from '../types/permissions';
+
+export const permissionsApi = {
+  getAll: () => api.get<RolePermissions[]>('/permissions'),
+  getByRole: (role: string) => api.get<RolePermissions>(`/permissions/role/${role}`),
+};

--- a/frontend/health-chain/lib/hooks/usePermissions.ts
+++ b/frontend/health-chain/lib/hooks/usePermissions.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { permissionsApi } from '../api/permissions.api';
+
+export function usePermissions() {
+  return useQuery({
+    queryKey: ['permissions', 'all'],
+    queryFn: () => permissionsApi.getAll(),
+  });
+}

--- a/frontend/health-chain/lib/types/permissions.ts
+++ b/frontend/health-chain/lib/types/permissions.ts
@@ -1,0 +1,4 @@
+export interface RolePermissions {
+  role: string;
+  permissions: string[];
+}

--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -49,6 +49,20 @@ pub enum Role {
     Custom(u32),
 }
 
+/// Fine-grained permission scopes that map to on-chain actions (Issue #374).
+/// These mirror the backend `Permission` enum for actions that require
+/// on-chain enforcement (e.g. settlement release, verification admin).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum PermissionScope {
+    InventoryWrite,
+    DispatchOverride,
+    RequestApprove,
+    DisputeResolve,
+    VerificationAdmin,
+    SettlementRelease,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BadgeType {
@@ -153,6 +167,8 @@ pub enum DataKey {
     Delivery(u64),
     // AccessControlContract (and IdentityContract role storage)
     AddressRoles(Address),
+    // Fine-grained permission scopes (Issue #374)
+    AddressScopes(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -987,6 +1003,86 @@ impl AccessControlContract {
         }
 
         new_roles
+    }
+
+    // ── Fine-grained permission scopes (Issue #374) ──────────────────────
+
+    /// Grant a permission scope to an address. Admin only.
+    pub fn grant_scope(env: Env, address: Address, scope: PermissionScope) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        let key = DataKey::AddressScopes(address.clone());
+        let mut scopes: Vec<PermissionScope> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        // Deduplicate
+        for i in 0..scopes.len() {
+            if scopes.get(i).unwrap() == scope {
+                return;
+            }
+        }
+        scopes.push_back(scope);
+        env.storage().persistent().set(&key, &scopes);
+    }
+
+    /// Revoke a permission scope from an address. Admin only.
+    pub fn revoke_scope(env: Env, address: Address, scope: PermissionScope) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        let key = DataKey::AddressScopes(address.clone());
+        if let Some(scopes) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Vec<PermissionScope>>(&key)
+        {
+            let mut new_scopes: Vec<PermissionScope> = Vec::new(&env);
+            for i in 0..scopes.len() {
+                let s = scopes.get(i).unwrap();
+                if s != scope {
+                    new_scopes.push_back(s);
+                }
+            }
+            env.storage().persistent().set(&key, &new_scopes);
+        }
+    }
+
+    /// Check whether an address holds a specific permission scope.
+    pub fn has_scope(env: Env, address: Address, scope: PermissionScope) -> bool {
+        let key = DataKey::AddressScopes(address);
+        if let Some(scopes) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Vec<PermissionScope>>(&key)
+        {
+            for i in 0..scopes.len() {
+                if scopes.get(i).unwrap() == scope {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Return all scopes granted to an address.
+    pub fn get_scopes(env: Env, address: Address) -> Vec<PermissionScope> {
+        let key = DataKey::AddressScopes(address);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env))
     }
 }
 


### PR DESCRIPTION
Closes #374

Hardens the existing RBAC system with fine-grained permission scopes so
sensitive healthcare and logistics actions are gated on specific scopes
rather than broad role membership.

---

## Changes

### Backend
- **Permission enum** — adds 6 new scopes: `inventory:write`,
  `dispatch:override`, `request:approve`, `dispute:resolve`,
  `verification:admin`, `settlement:release`
- **Controllers** — `inventory`, `dispatch`, `approvals`, and `disputes`
  controllers now use `@RequirePermissions` with the appropriate scope
  instead of role-only checks; `DisputesController` gets class-level
  `JwtAuthGuard` + `PermissionsGuard`
- **Permissions endpoint** — `GET /permissions` and
  `GET /permissions/role/:role` return effective scopes per role
  (requires `manage:roles`); registered in `AuthModule`
- **Migration** `1820000002000` — seeds new scopes into
  `role_permissions`: admin → all 6, vendor → `inventory:write`,
  hospital → `request:approve`, rider → `dispatch:override`

### Smart Contract
- `PermissionScope` enum added to the identity contract mirroring
  backend scopes for actions that need on-chain enforcement
- `grant_scope`, `revoke_scope`, `has_scope`, `get_scopes` functions
  with `AddressScopes` storage key

### Frontend
- `/admin/permissions` page — scope matrix table (✓ / –) showing
  effective permissions per role, filterable by role name, with full
  permission badge list per row

### Tests
- 8 unit tests in `permissions.guard.scopes.spec.ts` covering negative
  authorization for all 6 scopes (e.g. donor blocked from
  `inventory:write`, rider blocked from `request:approve`) plus two
  positive cases

---

## Acceptance criteria

- [x] Sensitive actions blocked without the correct scope
- [x] Effective permission inspection works in admin UI (`/admin/permissions`)
- [x] Tests cover negative authorization cases

