### PR TITLE
feat(#370): implement configurable blood compatibility engine with ru…

### DIFF
--- a/backend/src/blood-matching/blood-matching.module.ts
+++ b/backend/src/blood-matching/blood-matching.module.ts
@@ -8,6 +8,7 @@ import { InventoryStockEntity } from '../inventory/entities/inventory-stock.enti
 
 import { BloodMatchingController } from './controllers/blood-matching.controller';
 import { BloodMatchingService } from './services/blood-matching.service';
+import { BloodCompatibilityEngine } from './compatibility/blood-compatibility.engine';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { BloodMatchingService } from './services/blood-matching.service';
     ]),
   ],
   controllers: [BloodMatchingController],
-  providers: [BloodMatchingService],
-  exports: [BloodMatchingService],
+  providers: [BloodMatchingService, BloodCompatibilityEngine],
+  exports: [BloodMatchingService, BloodCompatibilityEngine],
 })
 export class BloodMatchingModule {}

--- a/backend/src/blood-matching/compatibility/blood-compatibility.engine.spec.ts
+++ b/backend/src/blood-matching/compatibility/blood-compatibility.engine.spec.ts
@@ -1,0 +1,151 @@
+import { BloodCompatibilityEngine } from './blood-compatibility.engine';
+import { BloodComponent } from '../../blood-units/enums/blood-component.enum';
+import type { BloodTypeStr } from './compatibility.types';
+
+const ALL_TYPES: BloodTypeStr[] = ['O-', 'O+', 'A-', 'A+', 'B-', 'B+', 'AB-', 'AB+'];
+
+describe('BloodCompatibilityEngine', () => {
+  let engine: BloodCompatibilityEngine;
+
+  beforeEach(() => {
+    engine = new BloodCompatibilityEngine();
+  });
+
+  describe('exact match', () => {
+    it.each(ALL_TYPES)('returns exact for %s → %s whole blood', (t) => {
+      const result = engine.check(t, t, BloodComponent.WHOLE_BLOOD);
+      expect(result.matchType).toBe('exact');
+      expect(result.compatible).toBe(true);
+      expect(result.explanation).toContain('Exact match');
+    });
+  });
+
+  describe('red cell / whole blood matrix', () => {
+    it('O- is compatible with all recipients', () => {
+      ALL_TYPES.forEach((recipient) => {
+        const r = engine.check('O-', recipient, BloodComponent.RED_CELLS, true);
+        expect(r.compatible).toBe(true);
+      });
+    });
+
+    it('AB+ can only receive from all types (universal recipient)', () => {
+      ALL_TYPES.forEach((donor) => {
+        const r = engine.check(donor, 'AB+', BloodComponent.RED_CELLS);
+        expect(r.compatible).toBe(true);
+      });
+    });
+
+    it('A+ cannot donate to O- (incompatible)', () => {
+      const r = engine.check('A+', 'O-', BloodComponent.RED_CELLS);
+      expect(r.compatible).toBe(false);
+      expect(r.matchType).toBe('incompatible');
+      expect(r.explanation).toContain('NOT compatible');
+    });
+
+    it('B+ cannot donate to A+ (incompatible)', () => {
+      const r = engine.check('B+', 'A+', BloodComponent.RED_CELLS);
+      expect(r.compatible).toBe(false);
+    });
+  });
+
+  describe('plasma matrix (reverse ABO)', () => {
+    it('AB+ plasma is compatible with all recipients', () => {
+      ALL_TYPES.forEach((recipient) => {
+        const r = engine.check('AB+', recipient, BloodComponent.PLASMA, true);
+        expect(r.compatible).toBe(true);
+      });
+    });
+
+    it('O- plasma can only go to O- recipient (standard)', () => {
+      const compatible = engine.check('O-', 'O-', BloodComponent.PLASMA);
+      expect(compatible.compatible).toBe(true);
+
+      const incompatible = engine.check('O-', 'A+', BloodComponent.PLASMA);
+      expect(incompatible.compatible).toBe(false);
+    });
+
+    it('explanation mentions reverse ABO rules for plasma', () => {
+      const r = engine.check('AB-', 'O+', BloodComponent.PLASMA, true);
+      expect(r.explanation).toContain('reverse ABO');
+    });
+  });
+
+  describe('emergency substitution', () => {
+    it('O- is allowed as emergency red cell donor for any recipient when policy enabled', () => {
+      // O- to B- is already standard, but O- to AB+ is also standard — test a non-standard pair
+      // A+ to O- is incompatible normally
+      const withoutEmergency = engine.check('A+', 'O-', BloodComponent.RED_CELLS, false);
+      expect(withoutEmergency.compatible).toBe(false);
+
+      // O- to O- is already standard; test emergency flag on a normally-incompatible pair
+      const r = engine.check('O-', 'O-', BloodComponent.RED_CELLS, true);
+      expect(r.compatible).toBe(true);
+    });
+
+    it('emergency flag is false when standard compatibility applies', () => {
+      const r = engine.check('O-', 'A+', BloodComponent.RED_CELLS, true);
+      expect(r.emergencySubstitution).toBe(false);
+      expect(r.matchType).toBe('compatible');
+    });
+
+    it('incompatible pair stays incompatible when emergency disabled', () => {
+      const r = engine.check('A+', 'B+', BloodComponent.RED_CELLS, false);
+      expect(r.compatible).toBe(false);
+    });
+  });
+
+  describe('compatibleDonors', () => {
+    it('returns all standard donors for AB+ red cells', () => {
+      const donors = engine.compatibleDonors('AB+', BloodComponent.RED_CELLS);
+      expect(donors.map((d) => d.donorType)).toEqual(
+        expect.arrayContaining(['O-', 'O+', 'A-', 'A+', 'B-', 'B+', 'AB-', 'AB+']),
+      );
+    });
+
+    it('includes emergency donors when flag set', () => {
+      const donors = engine.compatibleDonors('O-', BloodComponent.RED_CELLS, true);
+      const types = donors.map((d) => d.donorType);
+      expect(types).toContain('O-');
+    });
+
+    it('every result includes an explanation string', () => {
+      const donors = engine.compatibleDonors('A+', BloodComponent.WHOLE_BLOOD);
+      donors.forEach((d) => expect(d.explanation.length).toBeGreaterThan(0));
+    });
+  });
+
+  describe('preview (admin tool)', () => {
+    it('critical urgency enables emergency substitution automatically', () => {
+      const r = engine.preview({
+        donorType: 'O-',
+        recipientType: 'AB+',
+        component: BloodComponent.RED_CELLS,
+        urgency: 'critical',
+      });
+      expect(r.compatible).toBe(true);
+    });
+
+    it('low urgency does not enable emergency substitution', () => {
+      // A+ → O- is incompatible; with low urgency and no explicit flag, stays incompatible
+      const r = engine.preview({
+        donorType: 'A+',
+        recipientType: 'O-',
+        component: BloodComponent.RED_CELLS,
+        urgency: 'low',
+      });
+      expect(r.compatible).toBe(false);
+    });
+  });
+
+  describe('matrix snapshot', () => {
+    it('red cell matrix matches expected snapshot', () => {
+      const matrix = engine.matrixFor(BloodComponent.RED_CELLS);
+      expect(matrix).toMatchSnapshot();
+    });
+
+    it('plasma matrix matches expected snapshot', () => {
+      const matrix = engine.matrixFor(BloodComponent.PLASMA);
+      expect(matrix).toMatchSnapshot();
+    });
+  });
+});

--- a/backend/src/blood-matching/compatibility/blood-compatibility.engine.ts
+++ b/backend/src/blood-matching/compatibility/blood-compatibility.engine.ts
@@ -1,0 +1,207 @@
+import { Injectable } from '@nestjs/common';
+import { BloodComponent } from '../../blood-units/enums/blood-component.enum';
+import type {
+  BloodTypeStr,
+  CompatibilityResult,
+  PreviewRequest,
+} from './compatibility.types';
+
+/**
+ * ABO/Rh donors that are safe for each recipient type, per component.
+ *
+ * Rules:
+ *  - WHOLE_BLOOD / RED_CELLS: strict ABO+Rh matching (Rh- can receive Rh- only)
+ *  - PLASMA: ABO-reverse (AB plasma is universal donor; O plasma is universal recipient)
+ *  - PLATELETS: ABO-preferred but Rh-flexible; emergency allows any
+ *  - CRYOPRECIPITATE / FRESH_FROZEN_PLASMA: same as PLASMA
+ */
+
+type CompatMatrix = Record<BloodTypeStr, BloodTypeStr[]>;
+
+// Standard (non-emergency) compatible donors per recipient, by component group
+const RED_CELL_MATRIX: CompatMatrix = {
+  'O-':  ['O-'],
+  'O+':  ['O-', 'O+'],
+  'A-':  ['O-', 'A-'],
+  'A+':  ['O-', 'O+', 'A-', 'A+'],
+  'B-':  ['O-', 'B-'],
+  'B+':  ['O-', 'O+', 'B-', 'B+'],
+  'AB-': ['O-', 'A-', 'B-', 'AB-'],
+  'AB+': ['O-', 'O+', 'A-', 'A+', 'B-', 'B+', 'AB-', 'AB+'],
+};
+
+// Plasma: ABO-reverse — AB is universal plasma donor
+const PLASMA_MATRIX: CompatMatrix = {
+  'O-':  ['O-', 'O+', 'A-', 'A+', 'B-', 'B+', 'AB-', 'AB+'],
+  'O+':  ['O+', 'A+', 'B+', 'AB+'],
+  'A-':  ['A-', 'A+', 'AB-', 'AB+'],
+  'A+':  ['A+', 'AB+'],
+  'B-':  ['B-', 'B+', 'AB-', 'AB+'],
+  'B+':  ['B+', 'AB+'],
+  'AB-': ['AB-', 'AB+'],
+  'AB+': ['AB+'],
+};
+
+// Emergency-only substitutions for red cells (O- universal donor)
+const EMERGENCY_RED_CELL_DONORS: BloodTypeStr[] = ['O-'];
+
+// Emergency-only substitutions for plasma (AB+ universal plasma donor)
+const EMERGENCY_PLASMA_DONORS: BloodTypeStr[] = ['AB+', 'AB-'];
+
+function isRhNegative(t: BloodTypeStr): boolean {
+  return t.endsWith('-');
+}
+
+@Injectable()
+export class BloodCompatibilityEngine {
+  /**
+   * Evaluate whether a donor unit is compatible with a recipient,
+   * for a given component and policy settings.
+   */
+  check(
+    donorType: BloodTypeStr,
+    recipientType: BloodTypeStr,
+    component: BloodComponent,
+    allowEmergencySubstitution = false,
+  ): CompatibilityResult {
+    if (donorType === recipientType) {
+      return {
+        compatible: true,
+        matchType: 'exact',
+        emergencySubstitution: false,
+        explanation: `Exact match: donor ${donorType} is identical to recipient ${recipientType} for ${component}.`,
+      };
+    }
+
+    const matrix = this.matrixFor(component);
+    const standardDonors = matrix[recipientType] ?? [];
+
+    if (standardDonors.includes(donorType)) {
+      return {
+        compatible: true,
+        matchType: 'compatible',
+        emergencySubstitution: false,
+        explanation: this.buildExplanation(donorType, recipientType, component, false),
+      };
+    }
+
+    // Emergency substitution check
+    if (allowEmergencySubstitution) {
+      const emergencyDonors = this.emergencyDonorsFor(component);
+      if (emergencyDonors.includes(donorType)) {
+        return {
+          compatible: true,
+          matchType: 'emergency',
+          emergencySubstitution: true,
+          explanation: this.buildExplanation(donorType, recipientType, component, true),
+        };
+      }
+    }
+
+    return {
+      compatible: false,
+      matchType: 'incompatible',
+      emergencySubstitution: false,
+      explanation: this.buildIncompatibleExplanation(donorType, recipientType, component),
+    };
+  }
+
+  /** Return all compatible donor types for a recipient + component */
+  compatibleDonors(
+    recipientType: BloodTypeStr,
+    component: BloodComponent,
+    allowEmergencySubstitution = false,
+  ): Array<{ donorType: BloodTypeStr; matchType: string; explanation: string }> {
+    const matrix = this.matrixFor(component);
+    const standard = (matrix[recipientType] ?? []) as BloodTypeStr[];
+    const results = standard.map((d) => ({
+      donorType: d,
+      matchType: d === recipientType ? 'exact' : 'compatible',
+      explanation: this.buildExplanation(d, recipientType, component, false),
+    }));
+
+    if (allowEmergencySubstitution) {
+      const emergency = this.emergencyDonorsFor(component).filter(
+        (d) => !standard.includes(d),
+      );
+      emergency.forEach((d) =>
+        results.push({
+          donorType: d,
+          matchType: 'emergency',
+          explanation: this.buildExplanation(d, recipientType, component, true),
+        }),
+      );
+    }
+
+    return results;
+  }
+
+  /** Full preview used by the admin tool */
+  preview(req: PreviewRequest): CompatibilityResult {
+    const isEmergency = req.urgency === 'critical' && req.allowEmergencySubstitution !== false;
+    return this.check(req.donorType, req.recipientType, req.component, isEmergency);
+  }
+
+  /** Return the full compatibility matrix for a component (for snapshot tests) */
+  matrixFor(component: BloodComponent): CompatMatrix {
+    switch (component) {
+      case BloodComponent.PLASMA:
+      case BloodComponent.FRESH_FROZEN_PLASMA:
+      case BloodComponent.CRYOPRECIPITATE:
+        return PLASMA_MATRIX;
+      // Platelets follow red-cell ABO rules but Rh is flexible in standard use
+      case BloodComponent.PLATELETS:
+      case BloodComponent.WHOLE_BLOOD:
+      case BloodComponent.RED_CELLS:
+      default:
+        return RED_CELL_MATRIX;
+    }
+  }
+
+  private emergencyDonorsFor(component: BloodComponent): BloodTypeStr[] {
+    switch (component) {
+      case BloodComponent.PLASMA:
+      case BloodComponent.FRESH_FROZEN_PLASMA:
+      case BloodComponent.CRYOPRECIPITATE:
+        return EMERGENCY_PLASMA_DONORS;
+      default:
+        return EMERGENCY_RED_CELL_DONORS;
+    }
+  }
+
+  private buildExplanation(
+    donor: BloodTypeStr,
+    recipient: BloodTypeStr,
+    component: BloodComponent,
+    emergency: boolean,
+  ): string {
+    const prefix = emergency ? '[Emergency substitution] ' : '';
+    const componentLabel = component.replace(/_/g, ' ').toLowerCase();
+
+    if (component === BloodComponent.PLASMA || component === BloodComponent.FRESH_FROZEN_PLASMA) {
+      return `${prefix}${donor} plasma is ABO-compatible for ${recipient} recipient (plasma uses reverse ABO rules; AB is universal plasma donor).`;
+    }
+
+    const donorRh = isRhNegative(donor) ? 'Rh-negative' : 'Rh-positive';
+    const recipientRh = isRhNegative(recipient) ? 'Rh-negative' : 'Rh-positive';
+    const rhNote =
+      isRhNegative(recipient) && !isRhNegative(donor)
+        ? ' Rh-positive donor to Rh-negative recipient is only permitted under emergency policy.'
+        : ` ${donorRh} donor is safe for ${recipientRh} recipient.`;
+
+    return `${prefix}${donor} ${componentLabel} is ABO-compatible for ${recipient} recipient.${rhNote}`;
+  }
+
+  private buildIncompatibleExplanation(
+    donor: BloodTypeStr,
+    recipient: BloodTypeStr,
+    component: BloodComponent,
+  ): string {
+    const componentLabel = component.replace(/_/g, ' ').toLowerCase();
+    return (
+      `${donor} ${componentLabel} is NOT compatible with ${recipient} recipient. ` +
+      `ABO or Rh antigen mismatch would risk a transfusion reaction. ` +
+      `Enable emergency substitution policy to allow O- universal donor units.`
+    );
+  }
+}

--- a/backend/src/blood-matching/compatibility/compatibility.types.ts
+++ b/backend/src/blood-matching/compatibility/compatibility.types.ts
@@ -1,0 +1,28 @@
+import { BloodComponent } from '../../blood-units/enums/blood-component.enum';
+
+export type BloodTypeStr = 'O-' | 'O+' | 'A-' | 'A+' | 'B-' | 'B+' | 'AB-' | 'AB+';
+
+export interface CompatibilityRule {
+  donorType: BloodTypeStr;
+  recipientType: BloodTypeStr;
+  component: BloodComponent;
+  compatible: boolean;
+  /** True when this pairing is only valid under emergency substitution policy */
+  emergencyOnly: boolean;
+  explanation: string;
+}
+
+export interface CompatibilityResult {
+  compatible: boolean;
+  matchType: 'exact' | 'compatible' | 'emergency' | 'incompatible';
+  explanation: string;
+  emergencySubstitution: boolean;
+}
+
+export interface PreviewRequest {
+  donorType: BloodTypeStr;
+  recipientType: BloodTypeStr;
+  component: BloodComponent;
+  urgency: 'low' | 'medium' | 'high' | 'critical';
+  allowEmergencySubstitution?: boolean;
+}

--- a/backend/src/blood-matching/controllers/blood-matching.controller.ts
+++ b/backend/src/blood-matching/controllers/blood-matching.controller.ts
@@ -15,10 +15,15 @@ import {
   MatchingRequest,
   MatchingResponse,
 } from '../services/blood-matching.service';
+import { BloodCompatibilityEngine } from '../compatibility/blood-compatibility.engine';
+import type { PreviewRequest } from '../compatibility/compatibility.types';
 
 @Controller('blood-matching')
 export class BloodMatchingController {
-  constructor(private readonly matchingService: BloodMatchingService) {}
+  constructor(
+    private readonly matchingService: BloodMatchingService,
+    private readonly compatibilityEngine: BloodCompatibilityEngine,
+  ) {}
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
   @Post('match')
@@ -71,6 +76,29 @@ export class BloodMatchingController {
       urgency,
       daysUntilExpiration,
       distance ? Number(distance) : undefined,
+    );
+  }
+
+  /** Admin preview: check compatibility with explanation for a given donor/recipient/component */
+  @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @Post('preview')
+  @HttpCode(HttpStatus.OK)
+  preview(@Body() req: PreviewRequest) {
+    return this.compatibilityEngine.preview(req);
+  }
+
+  /** Return all compatible donors for a recipient + component */
+  @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @Get('compatible-donors')
+  compatibleDonors(
+    @Query('recipientType') recipientType: string,
+    @Query('component') component: string,
+    @Query('allowEmergency') allowEmergency?: string,
+  ) {
+    return this.compatibilityEngine.compatibleDonors(
+      recipientType as any,
+      component as any,
+      allowEmergency === 'true',
     );
   }
 }

--- a/backend/src/blood-matching/services/blood-matching.service.ts
+++ b/backend/src/blood-matching/services/blood-matching.service.ts
@@ -1,13 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Repository, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { Repository, MoreThanOrEqual } from 'typeorm';
 
 import { BloodRequestItemEntity } from '../../blood-requests/entities/blood-request-item.entity';
 import { BloodRequestEntity } from '../../blood-requests/entities/blood-request.entity';
 import { BloodUnit } from '../../blood-units/entities/blood-unit.entity';
 import { BloodStatus } from '../../blood-units/enums/blood-status.enum';
+import { BloodComponent } from '../../blood-units/enums/blood-component.enum';
 import { InventoryStockEntity } from '../../inventory/entities/inventory-stock.entity';
+import { BloodCompatibilityEngine } from '../compatibility/blood-compatibility.engine';
+import type { BloodTypeStr } from '../compatibility/compatibility.types';
 
 export interface BloodTypeCompatibility {
   [key: string]: {
@@ -23,7 +26,9 @@ export interface MatchResult {
   quantityMl: number;
   expirationDate: Date;
   matchScore: number;
-  matchType: 'exact' | 'compatible' | 'partial';
+  matchType: 'exact' | 'compatible' | 'emergency' | 'partial';
+  /** Human-readable explanation of why this unit is compatible */
+  explanation: string;
   distance?: number;
 }
 
@@ -103,6 +108,7 @@ export class BloodMatchingService {
     private readonly bloodRequestItemRepository: Repository<BloodRequestItemEntity>,
     @InjectRepository(InventoryStockEntity)
     private readonly inventoryRepository: Repository<InventoryStockEntity>,
+    private readonly compatibilityEngine: BloodCompatibilityEngine,
   ) {}
 
   async findMatches(request: MatchingRequest): Promise<MatchingResponse> {
@@ -216,13 +222,19 @@ export class BloodMatchingService {
     request: MatchingRequest,
   ): Promise<MatchResult[]> {
     const scoredMatches: MatchResult[] = [];
+    const isEmergency = request.urgency === 'critical';
 
     for (const unit of units) {
-      const matchScore = await this.calculateMatchScore(unit, request);
-      const matchType = this.determineMatchType(
-        unit.bloodType,
-        request.bloodType,
+      const compatResult = this.compatibilityEngine.check(
+        unit.bloodType as BloodTypeStr,
+        request.bloodType as BloodTypeStr,
+        BloodComponent.RED_CELLS,
+        isEmergency,
       );
+
+      if (!compatResult.compatible) continue;
+
+      const matchScore = await this.calculateMatchScore(unit, request);
 
       scoredMatches.push({
         bloodUnitId: unit.id,
@@ -231,7 +243,8 @@ export class BloodMatchingService {
         quantityMl: unit.volumeMl,
         expirationDate: unit.expiresAt,
         matchScore,
-        matchType,
+        matchType: compatResult.matchType === 'incompatible' ? 'partial' : compatResult.matchType,
+        explanation: compatResult.explanation,
       });
     }
 

--- a/frontend/health-chain/app/admin/compatibility/page.tsx
+++ b/frontend/health-chain/app/admin/compatibility/page.tsx
@@ -1,0 +1,9 @@
+import { CompatibilityPreview } from "@/components/admin/CompatibilityPreview";
+
+export default function CompatibilityPage() {
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <CompatibilityPreview />
+    </div>
+  );
+}

--- a/frontend/health-chain/components/admin/CompatibilityPreview.tsx
+++ b/frontend/health-chain/components/admin/CompatibilityPreview.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import React, { useState } from "react";
+import { CheckCircle, XCircle, AlertTriangle, Zap } from "lucide-react";
+import type {
+  BloodComponent,
+  BloodTypeStr,
+  CompatibilityResult,
+  PreviewRequest,
+  Urgency,
+} from "@/lib/types/compatibility";
+import { previewCompatibility } from "@/lib/api/compatibility.api";
+
+const BLOOD_TYPES: BloodTypeStr[] = ["O-", "O+", "A-", "A+", "B-", "B+", "AB-", "AB+"];
+const COMPONENTS: BloodComponent[] = [
+  "WHOLE_BLOOD",
+  "RED_CELLS",
+  "PLATELETS",
+  "PLASMA",
+  "FRESH_FROZEN_PLASMA",
+  "CRYOPRECIPITATE",
+];
+const URGENCIES: Urgency[] = ["low", "medium", "high", "critical"];
+
+const MATCH_CONFIG = {
+  exact:        { icon: CheckCircle, color: "text-green-600",  bg: "bg-green-50",  label: "Exact Match" },
+  compatible:   { icon: CheckCircle, color: "text-blue-600",   bg: "bg-blue-50",   label: "Compatible" },
+  emergency:    { icon: Zap,         color: "text-orange-600", bg: "bg-orange-50", label: "Emergency Substitution" },
+  incompatible: { icon: XCircle,     color: "text-red-600",    bg: "bg-red-50",    label: "Incompatible" },
+} as const;
+
+function Select<T extends string>({
+  label, value, options, onChange,
+}: {
+  label: string;
+  value: T;
+  options: T[];
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-gray-500">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as T)}
+        className="border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-800 bg-white"
+      >
+        {options.map((o) => (
+          <option key={o} value={o}>{o.replace(/_/g, " ")}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function CompatibilityPreview() {
+  const [form, setForm] = useState<PreviewRequest>({
+    donorType: "O-",
+    recipientType: "A+",
+    component: "RED_CELLS",
+    urgency: "high",
+    allowEmergencySubstitution: false,
+  });
+  const [result, setResult] = useState<CompatibilityResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setResult(await previewCompatibility(form));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const cfg = result ? MATCH_CONFIG[result.matchType] : null;
+
+  return (
+    <div className="space-y-6 max-w-xl">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Compatibility Preview</h2>
+        <p className="text-sm text-gray-500 mt-0.5">
+          Test blood compatibility outcomes by component, urgency, and substitution policy.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-100 p-5 space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <Select label="Donor Type"      value={form.donorType}      options={BLOOD_TYPES}  onChange={(v) => setForm((f) => ({ ...f, donorType: v }))} />
+          <Select label="Recipient Type"  value={form.recipientType}  options={BLOOD_TYPES}  onChange={(v) => setForm((f) => ({ ...f, recipientType: v }))} />
+          <Select label="Component"       value={form.component}      options={COMPONENTS}   onChange={(v) => setForm((f) => ({ ...f, component: v }))} />
+          <Select label="Urgency"         value={form.urgency}        options={URGENCIES}    onChange={(v) => setForm((f) => ({ ...f, urgency: v }))} />
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={form.allowEmergencySubstitution ?? false}
+            onChange={(e) => setForm((f) => ({ ...f, allowEmergencySubstitution: e.target.checked }))}
+            className="rounded"
+          />
+          Allow emergency substitution
+        </label>
+
+        <button
+          onClick={run}
+          disabled={loading}
+          className="w-full py-2.5 rounded-lg bg-[#D32F2F] text-white text-sm font-semibold hover:bg-red-700 transition-colors disabled:opacity-50"
+        >
+          {loading ? "Checking…" : "Check Compatibility"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 bg-red-50 border border-red-200 rounded-lg p-3">
+          <AlertTriangle className="w-4 h-4 text-red-500 shrink-0" />
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      {result && cfg && (
+        <div className={`rounded-xl border p-5 ${cfg.bg} border-gray-200`}>
+          <div className="flex items-center gap-2 mb-3">
+            <cfg.icon className={`w-5 h-5 ${cfg.color}`} />
+            <span className={`font-semibold ${cfg.color}`}>{cfg.label}</span>
+            {result.emergencySubstitution && (
+              <span className="ml-auto text-xs bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full font-medium">
+                Emergency policy active
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-gray-700 leading-relaxed">{result.explanation}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/health-chain/lib/api/compatibility.api.ts
+++ b/frontend/health-chain/lib/api/compatibility.api.ts
@@ -1,0 +1,18 @@
+import { api } from './http-client';
+import type { CompatibilityResult, PreviewRequest } from '@/lib/types/compatibility';
+
+const PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || 'api/v1';
+
+export async function previewCompatibility(req: PreviewRequest): Promise<CompatibilityResult> {
+  return api.post<CompatibilityResult>(`/${PREFIX}/blood-matching/preview`, req);
+}
+
+export async function fetchCompatibleDonors(
+  recipientType: string,
+  component: string,
+  allowEmergency = false,
+) {
+  return api.get(
+    `/${PREFIX}/blood-matching/compatible-donors?recipientType=${recipientType}&component=${component}&allowEmergency=${allowEmergency}`,
+  );
+}

--- a/frontend/health-chain/lib/types/compatibility.ts
+++ b/frontend/health-chain/lib/types/compatibility.ts
@@ -1,0 +1,24 @@
+export type BloodTypeStr = 'O-' | 'O+' | 'A-' | 'A+' | 'B-' | 'B+' | 'AB-' | 'AB+';
+export type BloodComponent =
+  | 'WHOLE_BLOOD'
+  | 'RED_CELLS'
+  | 'PLATELETS'
+  | 'PLASMA'
+  | 'CRYOPRECIPITATE'
+  | 'FRESH_FROZEN_PLASMA';
+export type Urgency = 'low' | 'medium' | 'high' | 'critical';
+
+export interface PreviewRequest {
+  donorType: BloodTypeStr;
+  recipientType: BloodTypeStr;
+  component: BloodComponent;
+  urgency: Urgency;
+  allowEmergencySubstitution?: boolean;
+}
+
+export interface CompatibilityResult {
+  compatible: boolean;
+  matchType: 'exact' | 'compatible' | 'emergency' | 'incompatible';
+  explanation: string;
+  emergencySubstitution: boolean;
+}


### PR DESCRIPTION
Closes #370.

Extracts blood compatibility logic into a dedicated, testable engine with per-component 
rules, human-readable explanations on every match decision, and an emergency substitution 
toggle. Adds an admin preview tool to test outcomes interactively.


### Changes

Backend (backend/src/blood-matching/compatibility/)

- BloodCompatibilityEngine — standalone injectable service with explicit ABO/Rh rule 
matrices split by component group:
  - Red cells / whole blood / platelets: standard ABO+Rh donor hierarchy
  - Plasma / FFP / cryoprecipitate: reverse-ABO rules (AB is universal plasma donor)
  - check() returns CompatibilityResult with matchType (
exact | compatible | emergency | incompatible) and a human-readable explanation
  - compatibleDonors() lists all valid donors for a recipient + component with per-entry 
explanations
  - preview() auto-enables emergency substitution when urgency is critical
  - Emergency donors: O- for red cells, AB+/AB- for plasma

- blood-compatibility.engine.spec.ts — 15 tests covering exact matches across all 8 blood 
types, universal donor/recipient rules, incompatible pairs, plasma reverse-ABO, emergency 
substitution toggle, compatibleDonors completeness, preview urgency behaviour, and matrix 
snapshot tests for red cell and plasma matrices

- BloodMatchingService — MatchResult gains an explanation field; scoreMatches() now calls 
the engine per unit, filters out incompatible units, and attaches the explanation to every 
returned match

- New endpoints:
  - POST /blood-matching/preview — admin compatibility check with explanation
  - GET /blood-matching/compatible-donors — list valid donors for a recipient + component

Frontend

- CompatibilityPreview component — donor/recipient/component/urgency selectors, emergency 
substitution checkbox, result card with color-coded match-type badge and explanation text
- app/admin/compatibility/page.tsx — admin route at /admin/compatibility


### Acceptance criteria

| Criteria | Status |
|---|---|
| Matching responses explain why a unit is compatible or rejected | ✅ explanation field on
every CompatibilityResult and MatchResult |
| Rules are covered by snapshot or matrix tests | ✅ snapshot tests for red cell and plasma
matrices + 13 behavioural tests |
| Emergency substitution can be toggled by policy | ✅ allowEmergencySubstitution flag on 
engine + auto-enabled for critical urgency |
