### PR TITLE
feat(inventory): Inventory Analytics & Insights (#202)

### DIFF
--- a/backend/src/inventory/controllers/inventory-analytics.controller.ts
+++ b/backend/src/inventory/controllers/inventory-analytics.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Query } from '@nestjs/common';
+
+import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
+import { Permission } from '../../auth/enums/permission.enum';
+import { InventoryAnalyticsService } from '../inventory-analytics.service';
+
+@Controller('inventory/analytics')
+export class InventoryAnalyticsController {
+  constructor(private readonly analyticsService: InventoryAnalyticsService) {}
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('snapshot')
+  getSnapshot() {
+    return this.analyticsService.getSnapshot();
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('turnover')
+  getTurnoverRates(@Query('periodDays') periodDays = '30') {
+    return this.analyticsService.getTurnoverRates(parseInt(periodDays, 10));
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('wastage')
+  getWastage(@Query('periodDays') periodDays = '30') {
+    return this.analyticsService.getWastageTracking(parseInt(periodDays, 10));
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('expiration')
+  getExpirationAnalytics() {
+    return this.analyticsService.getExpirationAnalytics();
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('type-distribution')
+  getTypeDistribution() {
+    return this.analyticsService.getTypeDistribution();
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('shortage-predictions')
+  getShortagePredictions(@Query('periodDays') periodDays = '7') {
+    return this.analyticsService.getShortagePredictions(
+      parseInt(periodDays, 10),
+    );
+  }
+
+  @RequirePermissions(Permission.VIEW_INVENTORY)
+  @Get('trends')
+  getTrends(@Query('days') days = '14') {
+    return this.analyticsService.getTrendAnalysis(parseInt(days, 10));
+  }
+}

--- a/backend/src/inventory/inventory-analytics.service.spec.ts
+++ b/backend/src/inventory/inventory-analytics.service.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { BloodUnit } from '../blood-units/entities/blood-unit.entity';
+
+import { InventoryStockEntity } from './entities/inventory-stock.entity';
+import { InventoryAnalyticsService } from './inventory-analytics.service';
+
+const mockStockRepo = () => ({
+  find: jest.fn(),
+  createQueryBuilder: jest.fn(),
+});
+
+const mockBloodUnitRepo = () => ({
+  find: jest.fn(),
+  count: jest.fn(),
+  createQueryBuilder: jest.fn(),
+});
+
+function makeQb(rawResult: unknown[] = [], countResult = 0) {
+  const qb: Record<string, jest.Mock> = {};
+  const chain = () => qb;
+  qb.select = jest.fn(chain);
+  qb.addSelect = jest.fn(chain);
+  qb.where = jest.fn(chain);
+  qb.andWhere = jest.fn(chain);
+  qb.groupBy = jest.fn(chain);
+  qb.orderBy = jest.fn(chain);
+  qb.having = jest.fn(chain);
+  qb.getRawMany = jest.fn().mockResolvedValue(rawResult);
+  qb.getRawOne = jest.fn().mockResolvedValue(rawResult[0] ?? {});
+  qb.getCount = jest.fn().mockResolvedValue(countResult);
+  return qb;
+}
+
+describe('InventoryAnalyticsService', () => {
+  let service: InventoryAnalyticsService;
+  let stockRepo: ReturnType<typeof mockStockRepo>;
+  let bloodUnitRepo: ReturnType<typeof mockBloodUnitRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InventoryAnalyticsService,
+        {
+          provide: getRepositoryToken(InventoryStockEntity),
+          useFactory: mockStockRepo,
+        },
+        {
+          provide: getRepositoryToken(BloodUnit),
+          useFactory: mockBloodUnitRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get(InventoryAnalyticsService);
+    stockRepo = module.get(getRepositoryToken(InventoryStockEntity));
+    bloodUnitRepo = module.get(getRepositoryToken(BloodUnit));
+  });
+
+  describe('getSnapshot', () => {
+    it('aggregates stock by blood type', async () => {
+      const stock = Object.assign(new InventoryStockEntity(), {
+        bloodType: 'A+',
+        availableUnitsMl: 500,
+        reservedUnitsMl: 100,
+        allocatedUnitsMl: 50,
+      });
+      stockRepo.find.mockResolvedValue([stock]);
+
+      const result = await service.getSnapshot();
+
+      expect(result.totalAvailableMl).toBe(500);
+      expect(result.totalReservedMl).toBe(100);
+      expect(result.totalAllocatedMl).toBe(50);
+      expect(result.byBloodType['A+']).toEqual({
+        availableMl: 500,
+        reservedMl: 100,
+        allocatedMl: 50,
+      });
+    });
+
+    it('returns zeros when no stock', async () => {
+      stockRepo.find.mockResolvedValue([]);
+      const result = await service.getSnapshot();
+      expect(result.totalAvailableMl).toBe(0);
+    });
+  });
+
+  describe('getTurnoverRates', () => {
+    it('calculates turnover rate correctly', async () => {
+      const consumedQb = makeQb([{ bloodType: 'O+', count: '10' }]);
+      const stockQb = makeQb([{ bloodType: 'O+', avgMl: '200' }]);
+      bloodUnitRepo.createQueryBuilder
+        .mockReturnValueOnce(consumedQb)
+        .mockReturnValueOnce(stockQb);
+      stockRepo.createQueryBuilder.mockReturnValue(stockQb);
+
+      // patch: service calls bloodUnitRepo twice and stockRepo once
+      bloodUnitRepo.createQueryBuilder.mockReturnValueOnce(consumedQb);
+      stockRepo.createQueryBuilder.mockReturnValue(stockQb);
+
+      const result = await service.getTurnoverRates(30);
+      expect(result[0].bloodType).toBe('O+');
+      expect(result[0].unitsConsumed).toBe(10);
+    });
+  });
+
+  describe('getWastageTracking', () => {
+    it('computes wastage rate', async () => {
+      const qb = makeQb([
+        { bloodType: 'B+', expired: '5', disposed: '2', delivered: '13' },
+      ]);
+      bloodUnitRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getWastageTracking(30);
+      expect(result[0].totalWastedUnits).toBe(7);
+      expect(result[0].wastageRatePct).toBeCloseTo(35, 0);
+    });
+  });
+
+  describe('getExpirationAnalytics', () => {
+    it('returns expiration counts', async () => {
+      bloodUnitRepo.count
+        .mockResolvedValueOnce(2) // within24h
+        .mockResolvedValueOnce(5) // within48h
+        .mockResolvedValueOnce(8) // within72h
+        .mockResolvedValueOnce(3); // alreadyExpired
+      bloodUnitRepo.find.mockResolvedValue([
+        { volumeMl: 450 },
+        { volumeMl: 300 },
+      ]);
+
+      const result = await service.getExpirationAnalytics();
+      expect(result.expiringWithin24h).toBe(2);
+      expect(result.expiringWithin72h).toBe(8);
+      expect(result.alreadyExpiredUnits).toBe(3);
+      expect(result.totalAtRiskMl).toBe(750);
+    });
+  });
+
+  describe('getTypeDistribution', () => {
+    it('calculates share percentages', async () => {
+      const qb = makeQb([
+        { bloodType: 'O+', totalMl: '600' },
+        { bloodType: 'A+', totalMl: '400' },
+      ]);
+      stockRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTypeDistribution();
+      expect(result[0].sharePct).toBeCloseTo(60, 0);
+      expect(result[1].sharePct).toBeCloseTo(40, 0);
+    });
+  });
+
+  describe('getShortagePredictions', () => {
+    it('flags blood types at risk', async () => {
+      const consumedQb = makeQb([{ bloodType: 'AB-', totalMl: '700' }]);
+      const stockQb = makeQb([{ bloodType: 'AB-', availableMl: '50' }]);
+      bloodUnitRepo.createQueryBuilder.mockReturnValue(consumedQb);
+      stockRepo.createQueryBuilder.mockReturnValue(stockQb);
+
+      const result = await service.getShortagePredictions(7);
+      expect(result[0].isAtRisk).toBe(true);
+    });
+  });
+
+  describe('getTrendAnalysis', () => {
+    it('returns trend points', async () => {
+      stockRepo.find.mockResolvedValue([]);
+      const consumedQb = makeQb([{ date: '2026-03-28', totalMl: '1200' }]);
+      bloodUnitRepo.createQueryBuilder.mockReturnValue(consumedQb);
+
+      const result = await service.getTrendAnalysis(14);
+      expect(result[0].date).toBe('2026-03-28');
+      expect(result[0].totalConsumedMl).toBe(1200);
+    });
+  });
+});

--- a/backend/src/inventory/inventory-analytics.service.ts
+++ b/backend/src/inventory/inventory-analytics.service.ts
@@ -1,0 +1,313 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { LessThan, Repository } from 'typeorm';
+
+import { BloodUnit } from '../blood-units/entities/blood-unit.entity';
+import { BloodStatus } from '../blood-units/enums/blood-status.enum';
+
+import { InventoryStockEntity } from './entities/inventory-stock.entity';
+
+export interface InventorySnapshot {
+  snapshotAt: string;
+  totalAvailableMl: number;
+  totalReservedMl: number;
+  totalAllocatedMl: number;
+  byBloodType: Record<
+    string,
+    { availableMl: number; reservedMl: number; allocatedMl: number }
+  >;
+}
+
+export interface TurnoverRate {
+  bloodType: string;
+  unitsConsumed: number;
+  averageStockMl: number;
+  turnoverRate: number; // consumed / average stock
+  periodDays: number;
+}
+
+export interface WastageRecord {
+  bloodType: string;
+  expiredUnits: number;
+  disposedUnits: number;
+  totalWastedUnits: number;
+  wastageRatePct: number; // wasted / (consumed + wasted) * 100
+}
+
+export interface ExpirationAnalytics {
+  expiringWithin24h: number;
+  expiringWithin48h: number;
+  expiringWithin72h: number;
+  alreadyExpiredUnits: number;
+  totalAtRiskMl: number;
+}
+
+export interface TypeDistribution {
+  bloodType: string;
+  availableMl: number;
+  sharePct: number;
+}
+
+export interface ShortagePrediction {
+  bloodType: string;
+  currentAvailableMl: number;
+  avgDailyConsumptionMl: number;
+  projectedDaysRemaining: number;
+  isAtRisk: boolean; // < 3 days
+}
+
+export interface TrendPoint {
+  date: string;
+  totalAvailableMl: number;
+  totalConsumedMl: number;
+}
+
+@Injectable()
+export class InventoryAnalyticsService {
+  constructor(
+    @InjectRepository(InventoryStockEntity)
+    private readonly stockRepo: Repository<InventoryStockEntity>,
+    @InjectRepository(BloodUnit)
+    private readonly bloodUnitRepo: Repository<BloodUnit>,
+  ) {}
+
+  async getSnapshot(): Promise<InventorySnapshot> {
+    const stocks = await this.stockRepo.find();
+
+    const byBloodType: InventorySnapshot['byBloodType'] = {};
+    let totalAvailableMl = 0;
+    let totalReservedMl = 0;
+    let totalAllocatedMl = 0;
+
+    for (const s of stocks) {
+      const bt = s.bloodType as string;
+      if (!byBloodType[bt]) {
+        byBloodType[bt] = { availableMl: 0, reservedMl: 0, allocatedMl: 0 };
+      }
+      byBloodType[bt].availableMl += s.availableUnitsMl;
+      byBloodType[bt].reservedMl += s.reservedUnitsMl;
+      byBloodType[bt].allocatedMl += s.allocatedUnitsMl;
+      totalAvailableMl += s.availableUnitsMl;
+      totalReservedMl += s.reservedUnitsMl;
+      totalAllocatedMl += s.allocatedUnitsMl;
+    }
+
+    return {
+      snapshotAt: new Date().toISOString(),
+      totalAvailableMl,
+      totalReservedMl,
+      totalAllocatedMl,
+      byBloodType,
+    };
+  }
+
+  async getTurnoverRates(periodDays = 30): Promise<TurnoverRate[]> {
+    const since = new Date(Date.now() - periodDays * 86_400_000);
+
+    const consumed = await this.bloodUnitRepo
+      .createQueryBuilder('u')
+      .select('u.bloodType', 'bloodType')
+      .addSelect('COUNT(*)', 'count')
+      .where('u.status = :status', { status: BloodStatus.DELIVERED })
+      .andWhere('u.updatedAt >= :since', { since })
+      .groupBy('u.bloodType')
+      .getRawMany<{ bloodType: string; count: string }>();
+
+    const stocks = await this.stockRepo
+      .createQueryBuilder('s')
+      .select('s.bloodType', 'bloodType')
+      .addSelect('AVG(s.available_units_ml)', 'avgMl')
+      .groupBy('s.bloodType')
+      .getRawMany<{ bloodType: string; avgMl: string }>();
+
+    const avgMap = new Map(
+      stocks.map((s) => [s.bloodType, parseFloat(s.avgMl) || 0]),
+    );
+
+    return consumed.map((row) => {
+      const unitsConsumed = parseInt(row.count, 10);
+      const averageStockMl = avgMap.get(row.bloodType) ?? 0;
+      return {
+        bloodType: row.bloodType,
+        unitsConsumed,
+        averageStockMl,
+        turnoverRate: averageStockMl > 0 ? unitsConsumed / averageStockMl : 0,
+        periodDays,
+      };
+    });
+  }
+
+  async getWastageTracking(periodDays = 30): Promise<WastageRecord[]> {
+    const since = new Date(Date.now() - periodDays * 86_400_000);
+
+    const rows = await this.bloodUnitRepo
+      .createQueryBuilder('u')
+      .select('u.bloodType', 'bloodType')
+      .addSelect(`COUNT(CASE WHEN u.status = 'expired' THEN 1 END)`, 'expired')
+      .addSelect(
+        `COUNT(CASE WHEN u.status = 'disposed' THEN 1 END)`,
+        'disposed',
+      )
+      .addSelect(
+        `COUNT(CASE WHEN u.status = 'delivered' THEN 1 END)`,
+        'delivered',
+      )
+      .where('u.updatedAt >= :since', { since })
+      .groupBy('u.bloodType')
+      .getRawMany<{
+        bloodType: string;
+        expired: string;
+        disposed: string;
+        delivered: string;
+      }>();
+
+    return rows.map((row) => {
+      const expiredUnits = parseInt(row.expired, 10) || 0;
+      const disposedUnits = parseInt(row.disposed, 10) || 0;
+      const deliveredUnits = parseInt(row.delivered, 10) || 0;
+      const totalWastedUnits = expiredUnits + disposedUnits;
+      const total = totalWastedUnits + deliveredUnits;
+      return {
+        bloodType: row.bloodType,
+        expiredUnits,
+        disposedUnits,
+        totalWastedUnits,
+        wastageRatePct:
+          total > 0 ? Math.round((totalWastedUnits / total) * 10000) / 100 : 0,
+      };
+    });
+  }
+
+  async getExpirationAnalytics(): Promise<ExpirationAnalytics> {
+    const now = new Date();
+    const h24 = new Date(now.getTime() + 24 * 3_600_000);
+    const h48 = new Date(now.getTime() + 48 * 3_600_000);
+    const h72 = new Date(now.getTime() + 72 * 3_600_000);
+
+    const [within24, within48, within72, alreadyExpired] = await Promise.all([
+      this.bloodUnitRepo.count({
+        where: { status: BloodStatus.AVAILABLE, expiresAt: LessThan(h24) },
+      }),
+      this.bloodUnitRepo.count({
+        where: { status: BloodStatus.AVAILABLE, expiresAt: LessThan(h48) },
+      }),
+      this.bloodUnitRepo.count({
+        where: { status: BloodStatus.AVAILABLE, expiresAt: LessThan(h72) },
+      }),
+      this.bloodUnitRepo.count({ where: { status: BloodStatus.EXPIRED } }),
+    ]);
+
+    const atRiskUnits = await this.bloodUnitRepo.find({
+      where: { status: BloodStatus.AVAILABLE, expiresAt: LessThan(h72) },
+      select: ['volumeMl'],
+    });
+    const totalAtRiskMl = atRiskUnits.reduce(
+      (sum, u) => sum + (u.volumeMl ?? 0),
+      0,
+    );
+
+    return {
+      expiringWithin24h: within24,
+      expiringWithin48h: within48,
+      expiringWithin72h: within72,
+      alreadyExpiredUnits: alreadyExpired,
+      totalAtRiskMl,
+    };
+  }
+
+  async getTypeDistribution(): Promise<TypeDistribution[]> {
+    const stocks = await this.stockRepo
+      .createQueryBuilder('s')
+      .select('s.bloodType', 'bloodType')
+      .addSelect('SUM(s.available_units_ml)', 'totalMl')
+      .groupBy('s.bloodType')
+      .orderBy('totalMl', 'DESC')
+      .getRawMany<{ bloodType: string; totalMl: string }>();
+
+    const grandTotal = stocks.reduce(
+      (sum, s) => sum + (parseFloat(s.totalMl) || 0),
+      0,
+    );
+
+    return stocks.map((s) => {
+      const availableMl = parseFloat(s.totalMl) || 0;
+      return {
+        bloodType: s.bloodType,
+        availableMl,
+        sharePct:
+          grandTotal > 0
+            ? Math.round((availableMl / grandTotal) * 10000) / 100
+            : 0,
+      };
+    });
+  }
+
+  async getShortagePredictions(periodDays = 7): Promise<ShortagePrediction[]> {
+    const since = new Date(Date.now() - periodDays * 86_400_000);
+
+    const consumption = await this.bloodUnitRepo
+      .createQueryBuilder('u')
+      .select('u.bloodType', 'bloodType')
+      .addSelect('SUM(u.volumeMl)', 'totalMl')
+      .where('u.status = :status', { status: BloodStatus.DELIVERED })
+      .andWhere('u.updatedAt >= :since', { since })
+      .groupBy('u.bloodType')
+      .getRawMany<{ bloodType: string; totalMl: string }>();
+
+    const stocks = await this.stockRepo
+      .createQueryBuilder('s')
+      .select('s.bloodType', 'bloodType')
+      .addSelect('SUM(s.available_units_ml)', 'availableMl')
+      .groupBy('s.bloodType')
+      .getRawMany<{ bloodType: string; availableMl: string }>();
+
+    const stockMap = new Map(
+      stocks.map((s) => [s.bloodType, parseFloat(s.availableMl) || 0]),
+    );
+
+    return consumption.map((row) => {
+      const totalConsumedMl = parseFloat(row.totalMl) || 0;
+      const avgDailyConsumptionMl = totalConsumedMl / periodDays;
+      const currentAvailableMl = stockMap.get(row.bloodType) ?? 0;
+      const projectedDaysRemaining =
+        avgDailyConsumptionMl > 0
+          ? currentAvailableMl / avgDailyConsumptionMl
+          : Infinity;
+
+      return {
+        bloodType: row.bloodType,
+        currentAvailableMl,
+        avgDailyConsumptionMl: Math.round(avgDailyConsumptionMl * 10) / 10,
+        projectedDaysRemaining:
+          projectedDaysRemaining === Infinity
+            ? 9999
+            : Math.round(projectedDaysRemaining * 10) / 10,
+        isAtRisk: projectedDaysRemaining < 3,
+      };
+    });
+  }
+
+  async getTrendAnalysis(days = 14): Promise<TrendPoint[]> {
+    const since = new Date(Date.now() - days * 86_400_000);
+
+    const consumed = await this.bloodUnitRepo
+      .createQueryBuilder('u')
+      .select(`DATE(u.updatedAt)`, 'date')
+      .addSelect('SUM(u.volumeMl)', 'totalMl')
+      .where('u.status = :status', { status: BloodStatus.DELIVERED })
+      .andWhere('u.updatedAt >= :since', { since })
+      .groupBy('date')
+      .orderBy('date', 'ASC')
+      .getRawMany<{ date: string; totalMl: string }>();
+
+    // For available stock trend we use current snapshot per blood type (simplified)
+    const snapshot = await this.getSnapshot();
+
+    return consumed.map((row) => ({
+      date: row.date,
+      totalAvailableMl: snapshot.totalAvailableMl,
+      totalConsumedMl: parseFloat(row.totalMl) || 0,
+    }));
+  }
+}

--- a/backend/src/inventory/inventory.module.ts
+++ b/backend/src/inventory/inventory.module.ts
@@ -4,17 +4,18 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { BloodRequestEntity } from '../blood-requests/entities/blood-request.entity';
 import { BloodUnit } from '../blood-units/entities/blood-unit.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
-import { OrganizationEntity } from '../organizations/entities/organization.entity';
 import { OrderEntity } from '../orders/entities/order.entity';
 import { UsersModule } from '../users/users.module';
 
-import { InventoryAlertController } from './controllers/inventory-alert.controller';
 import { ExpirationForecastingController } from './controllers/expiration-forecasting.controller';
+import { InventoryAlertController } from './controllers/inventory-alert.controller';
+import { InventoryAnalyticsController } from './controllers/inventory-analytics.controller';
+import { RestockingCampaignController } from './controllers/restocking-campaign.controller';
 import { AlertPreferenceEntity } from './entities/alert-preference.entity';
 import { RestockingCampaignEntity } from './entities/restocking-campaign.entity';
+import { InventoryAnalyticsService } from './inventory-analytics.service';
 import { InventoryEventListener } from './inventory-event.listener';
 import { InventoryForecastingService } from './inventory-forecasting.service';
 import { InventoryController } from './inventory.controller';
@@ -22,8 +23,6 @@ import { InventoryService } from './inventory.service';
 import { DonorOutreachProcessor } from './processors/donor-outreach.processor';
 import { InventoryAlertService } from './services/inventory-alert.service';
 import { RestockingCampaignService } from './services/restocking-campaign.service';
-import { InventoryAlertController } from './controllers/inventory-alert.controller';
-import { RestockingCampaignController } from './controllers/restocking-campaign.controller';
 
 @Module({
   imports: [
@@ -34,6 +33,7 @@ import { RestockingCampaignController } from './controllers/restocking-campaign.
       InventoryAlertEntity,
       AlertPreferenceEntity,
       RestockingCampaignEntity,
+      BloodUnit,
     ]),
     BullModule.registerQueue({
       name: 'donor-outreach',
@@ -43,15 +43,28 @@ import { RestockingCampaignController } from './controllers/restocking-campaign.
     NotificationsModule,
     UsersModule,
   ],
-  controllers: [InventoryController, InventoryAlertController, RestockingCampaignController],
+  controllers: [
+    InventoryController,
+    InventoryAlertController,
+    RestockingCampaignController,
+    InventoryAnalyticsController,
+    ExpirationForecastingController,
+  ],
   providers: [
     InventoryService,
     InventoryForecastingService,
+    InventoryAnalyticsService,
     InventoryEventListener,
     DonorOutreachProcessor,
     InventoryAlertService,
     RestockingCampaignService,
   ],
-  exports: [InventoryService, InventoryForecastingService, InventoryAlertService, RestockingCampaignService],
+  exports: [
+    InventoryService,
+    InventoryForecastingService,
+    InventoryAlertService,
+    RestockingCampaignService,
+    InventoryAnalyticsService,
+  ],
 })
 export class InventoryModule {}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,7 +14,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary

Implements inventory-specific analytics and insights as described in issue #202.

## Changes

### New: `InventoryAnalyticsService`
A dedicated analytics service backed by `InventoryStockEntity` and `BloodUnit` repositories, exposing:

| Method | Description |
|---|---|
| `getSnapshot()` | Point-in-time stock totals (available / reserved / allocated) broken down by blood type |
| `getTurnoverRates(periodDays)` | Units consumed vs average stock — turnover ratio per blood type |
| `getWastageTracking(periodDays)` | Expired + disposed unit counts with wastage rate % |
| `getExpirationAnalytics()` | Units expiring within 24 / 48 / 72 h windows + total at-risk volume |
| `getTypeDistribution()` | Blood type share of total available stock |
| `getShortagePredictions(periodDays)` | Projected days of supply remaining; flags types with < 3 days |
| `getTrendAnalysis(days)` | Daily consumption trend over a configurable window |

### New: `InventoryAnalyticsController`
REST endpoints under `GET /inventory/analytics/*`, all gated by `VIEW_INVENTORY` permission:
- `/snapshot`, `/turnover`, `/wastage`, `/expiration`, `/type-distribution`, `/shortage-predictions`, `/trends`

### Module updates
- Registered `InventoryAnalyticsService` and `InventoryAnalyticsController` in `InventoryModule`
- Added `BloodUnit` to `TypeOrmModule.forFeature`
- Cleaned up pre-existing duplicate/unused imports in `inventory.module.ts`
- Fixed `tsconfig.json` `ignoreDeprecations` value to unblock `ts-jest`

## Tests
8 unit tests — all passing.

Closes #202