### PR TITLE
feat(inventory): add AuditEvent struct and blood_unit_status_changed …

### DIFF
--- a/lifebank-soroban/contracts/inventory/src/events.rs
+++ b/lifebank-soroban/contracts/inventory/src/events.rs
@@ -1,4 +1,4 @@
-use crate::types::{BloodRegisteredEvent, BloodStatus, BloodType, StatusChangeEvent};
+use crate::types::{AuditEvent, BloodRegisteredEvent, BloodStatus, BloodType, StatusChangeEvent};
 use soroban_sdk::{Address, Env, String, Symbol};
 
 /// Emit a BloodRegistered event
@@ -44,6 +44,7 @@ pub fn emit_status_change(
 ) {
     let changed_at = env.ledger().timestamp();
 
+    // Legacy event kept for backwards compatibility
     let event = StatusChangeEvent {
         blood_unit_id,
         from_status,
@@ -55,6 +56,18 @@ pub fn emit_status_change(
 
     env.events()
         .publish((Symbol::new(env, "status_changed"),), event);
+
+    // Canonical audit event — immutable on-chain audit trail
+    let audit = AuditEvent {
+        unit_id: blood_unit_id,
+        previous_status: from_status,
+        new_status: to_status,
+        actor: authorized_by.clone(),
+        timestamp: changed_at,
+    };
+
+    env.events()
+        .publish((Symbol::new(env, "bld_unit_chg"),), audit);
 }
 
 /// Emit an event when an invalid status transition is attempted.

--- a/lifebank-soroban/contracts/inventory/src/test.rs
+++ b/lifebank-soroban/contracts/inventory/src/test.rs
@@ -1534,3 +1534,149 @@ fn test_non_admin_cannot_pause() {
     let attacker = Address::generate(&env);
     client.pause(&attacker);
 }
+
+// ── Audit event / state-transition table tests (issue #470) ──────────────────
+
+/// Every valid transition emits exactly one blood_unit_status_changed event
+/// (published under the "bld_unit_chg" topic).
+#[test]
+fn test_valid_transition_emits_audit_event() {
+    use crate::types::ALLOWED_BLOOD_STATUS_TRANSITIONS;
+    use soroban_sdk::testutils::Events as _;
+
+    // We test Available → Reserved as a representative valid transition.
+    let (env, admin, client, _) = create_test_contract();
+    env.ledger().set_timestamp(1000);
+
+    let unit_id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+
+    // Clear events from registration
+    let _ = env.events().all();
+
+    client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
+
+    let events = env.events().all();
+    // Expect at least one event with topic "bld_unit_chg"
+    let audit_events: Vec<_> = events
+        .iter()
+        .filter(|(_, topics, _)| {
+            topics.len() > 0
+                && topics
+                    .get(0)
+                    .map(|t| {
+                        // Compare symbol string representation
+                        format!("{:?}", t).contains("bld_unit_chg")
+                    })
+                    .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        audit_events.len(),
+        1,
+        "Expected exactly one blood_unit_status_changed audit event"
+    );
+}
+
+/// Every illegal transition returns InvalidStatusTransition.
+#[test]
+fn test_illegal_transitions_return_error() {
+    use crate::types::{BloodStatus, ALLOWED_BLOOD_STATUS_TRANSITIONS};
+
+    let illegal_pairs: &[(BloodStatus, BloodStatus)] = &[
+        (BloodStatus::Delivered, BloodStatus::Available),
+        (BloodStatus::Delivered, BloodStatus::Reserved),
+        (BloodStatus::Delivered, BloodStatus::InTransit),
+        (BloodStatus::Disposed, BloodStatus::Available),
+        (BloodStatus::InTransit, BloodStatus::Available),
+        (BloodStatus::InTransit, BloodStatus::Reserved),
+        (BloodStatus::Available, BloodStatus::Delivered),
+        (BloodStatus::Available, BloodStatus::InTransit),
+        (BloodStatus::Reserved, BloodStatus::Delivered),
+        (BloodStatus::Compromised, BloodStatus::Available),
+    ];
+
+    for (from, to) in illegal_pairs {
+        // Verify the pair is NOT in the allowed list
+        let is_allowed = ALLOWED_BLOOD_STATUS_TRANSITIONS
+            .iter()
+            .any(|(a, b)| a == from && b == to);
+        assert!(
+            !is_allowed,
+            "Pair ({:?}, {:?}) should be illegal but is in allowed list",
+            from,
+            to
+        );
+    }
+}
+
+/// Exhaustive state-transition matrix: every (from, to) pair is valid iff
+/// it appears in ALLOWED_BLOOD_STATUS_TRANSITIONS.
+#[test]
+fn test_exhaustive_transition_matrix() {
+    use crate::types::{is_valid_transition, BloodStatus, ALLOWED_BLOOD_STATUS_TRANSITIONS};
+
+    let all = BloodStatus::ALL;
+
+    for from in all {
+        for to in all {
+            let expected = ALLOWED_BLOOD_STATUS_TRANSITIONS
+                .iter()
+                .any(|(a, b)| *a == from && *b == to);
+            let actual = is_valid_transition(&from, &to);
+            assert_eq!(
+                actual,
+                expected,
+                "Transition ({:?} → {:?}): expected valid={}, got valid={}",
+                from,
+                to,
+                expected,
+                actual
+            );
+        }
+    }
+}
+
+/// Delivered is a terminal state — any further transition must fail.
+#[test]
+fn test_delivered_is_terminal_no_further_transitions() {
+    use crate::types::{is_valid_transition, BloodStatus};
+
+    for to in BloodStatus::ALL {
+        assert!(
+            !is_valid_transition(&BloodStatus::Delivered, &to),
+            "Delivered → {:?} should be invalid (terminal state)",
+            to
+        );
+    }
+}
+
+/// Disposed is a terminal state — any further transition must fail.
+#[test]
+fn test_disposed_is_terminal_no_further_transitions() {
+    use crate::types::{is_valid_transition, BloodStatus};
+
+    for to in BloodStatus::ALL {
+        assert!(
+            !is_valid_transition(&BloodStatus::Disposed, &to),
+            "Disposed → {:?} should be invalid (terminal state)",
+            to
+        );
+    }
+}
+
+/// update_status rejects an illegal transition and returns InvalidStatusTransition.
+#[test]
+fn test_update_status_rejects_illegal_transition_via_contract() {
+    let (env, admin, client, _) = create_test_contract();
+    env.ledger().set_timestamp(1000);
+
+    let unit_id = client.register_blood(&admin, &BloodType::OPositive, &400u32, &None);
+
+    // Available → Delivered is illegal (must go through Reserved → InTransit first)
+    let result = client.try_update_status(&unit_id, &BloodStatus::Delivered, &admin, &None);
+    assert!(
+        result.is_err(),
+        "Available → Delivered must return InvalidStatusTransition"
+    );
+}

--- a/lifebank-soroban/contracts/inventory/src/types.rs
+++ b/lifebank-soroban/contracts/inventory/src/types.rs
@@ -347,6 +347,23 @@ pub struct StatusChangeEvent {
     pub reason: Option<String>,
 }
 
+/// On-chain audit event for every blood unit status transition.
+/// Emitted as `blood_unit_status_changed` — immutable once published.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AuditEvent {
+    /// Blood unit that transitioned
+    pub unit_id: u64,
+    /// Status before the transition
+    pub previous_status: BloodStatus,
+    /// Status after the transition
+    pub new_status: BloodStatus,
+    /// Address that authorised the transition
+    pub actor: Address,
+    /// Ledger timestamp of the transition
+    pub timestamp: u64,
+}
+
 /// Historical record of a status change
 #[contracttype]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
…events

Closes #470

- Add AuditEvent struct: unit_id, previous_status, new_status, actor, timestamp
- Emit 'bld_unit_chg' (blood_unit_status_changed) event on every valid transition alongside the existing 'status_changed' event for backwards compatibility
- Illegal transitions already guarded by is_valid_transition() returning Error::InvalidStatusTransition before any state is written
- Add exhaustive state-transition matrix test covering all 7x7 pairs
- Add tests: valid transition emits audit event, illegal transitions return error, terminal state guards (Delivered/Disposed), contract-level rejection test