### PR TITLE
feat(temperature+coordinator): cross-contract excursion → payment dis…

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/error.rs
+++ b/lifebank-soroban/contracts/coordinator/src/error.rs
@@ -26,6 +26,7 @@ pub enum CoordinatorError {
     // Cross-contract call failures
     InventoryUpdateFailed = 830,
     PaymentUpdateFailed = 831,
+    PaymentFlagFailed = 832,
 
     // Circuit breaker
     ContractPaused = 840,

--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -17,9 +17,9 @@ mod types;
 mod test;
 
 pub use error::CoordinatorError;
-pub use types::{DataKey, WorkflowRecord, WorkflowStatus};
+pub use types::{DataKey, ExcursionSummary, WorkflowRecord, WorkflowStatus};
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
 
 // ── Minimal interface types mirroring the domain contracts ────────────────────
 // These allow the coordinator to inspect cross-contract return values without
@@ -116,13 +116,26 @@ mod inventory_client {
 }
 
 mod payment_client {
-    use soroban_sdk::{contractclient, Env};
+    use soroban_sdk::{contractclient, Env, String};
     use super::{Payment, PaymentStatus};
+
+    #[contracttype]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum DisputeReason {
+        FailedDelivery,
+        TemperatureExcursion,
+        PaymentContested,
+        WrongItem,
+        DamagedGoods,
+        LateDelivery,
+        Other,
+    }
 
     #[contractclient(name = "PaymentContractClient")]
     pub trait PaymentContractInterface {
         fn get_payment(env: Env, payment_id: u64) -> Payment;
         fn update_status(env: Env, payment_id: u64, status: PaymentStatus);
+        fn record_dispute(env: Env, payment_id: u64, reason: DisputeReason, case_id: String);
     }
 }
 
@@ -466,6 +479,60 @@ impl CoordinatorContract {
 
     pub fn get_workflow(env: Env, request_id: u64) -> Result<WorkflowRecord, CoordinatorError> {
         load_workflow(&env, request_id).ok_or(CoordinatorError::WorkflowNotFound)
+    }
+
+    /// Flag a temperature breach: transitions the linked payment from Locked → Disputed.
+    ///
+    /// Called by the temperature contract when a sustained excursion is detected.
+    ///
+    /// # Errors
+    /// - `PaymentNotFound`     - No payment with this ID
+    /// - `InvalidPaymentState` - Payment is not in Locked status
+    /// - `PaymentFlagFailed`   - Cross-contract call to payments failed
+    pub fn flag_temperature_breach(
+        env: Env,
+        caller: Address,
+        payment_id: u64,
+        excursion_summary: ExcursionSummary,
+    ) -> Result<(), CoordinatorError> {
+        caller.require_auth();
+        Self::require_initialized(&env)?;
+        Self::require_not_paused(&env)?;
+
+        let pay_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentContract)
+            .unwrap();
+        let pay_client = PaymentContractClient::new(&env, &pay_addr);
+
+        let payment = pay_client
+            .try_get_payment(&payment_id)
+            .map_err(|_| CoordinatorError::PaymentNotFound)?
+            .map_err(|_| CoordinatorError::PaymentNotFound)?;
+
+        if payment.status != PaymentStatus::Locked {
+            return Err(CoordinatorError::InvalidPaymentState);
+        }
+
+        let case_id = String::from_str(&env, "TEMP-EXCURSION");
+
+        pay_client
+            .try_record_dispute(
+                &payment_id,
+                &payment_client::DisputeReason::TemperatureExcursion,
+                &case_id,
+            )
+            .map_err(|_| CoordinatorError::PaymentFlagFailed)?
+            .map_err(|_| CoordinatorError::PaymentFlagFailed)?;
+
+        let now = env.ledger().timestamp();
+        env.events().publish(
+            (symbol_short!("coord"), symbol_short!("tmp_brch")),
+            (payment_id, excursion_summary.unit_id, now),
+        );
+
+        Ok(())
     }
 
     pub fn is_initialized(env: Env) -> bool {

--- a/lifebank-soroban/contracts/coordinator/src/test.rs
+++ b/lifebank-soroban/contracts/coordinator/src/test.rs
@@ -163,6 +163,18 @@ impl MockPaymentContract {
             .persistent()
             .set(&PayKey::Payment(payment_id), &p);
     }
+
+    pub fn record_dispute(env: Env, payment_id: u64, _reason: super::payment_client::DisputeReason, _case_id: String) {
+        let mut p: Payment = env
+            .storage()
+            .persistent()
+            .get(&PayKey::Payment(payment_id))
+            .unwrap();
+        p.status = PaymentStatus::Disputed;
+        env.storage()
+            .persistent()
+            .set(&PayKey::Payment(payment_id), &p);
+    }
 }
 
 // ── Harness ───────────────────────────────────────────────────────────────────
@@ -435,4 +447,87 @@ fn test_coordinator_non_admin_cannot_pause() {
     let h = setup();
     let attacker = Address::generate(&h.env);
     h.coord.pause(&attacker);
+}
+
+// ── Temperature excursion → dispute integration tests (issue #477) ────────────
+
+use super::ExcursionSummary;
+
+fn make_excursion(unit_id: u64) -> ExcursionSummary {
+    ExcursionSummary {
+        unit_id,
+        violation_count: 3,
+        peak_celsius_x100: 1200, // 12.00°C — above threshold
+        detected_at: 1000,
+    }
+}
+
+/// Full chain: flag_temperature_breach transitions Locked → Disputed.
+#[test]
+fn test_flag_temperature_breach_transitions_locked_to_disputed() {
+    let h = setup();
+    let payment_id = create_locked_payment(&h, 99);
+
+    let excursion = make_excursion(42);
+    h.coord
+        .flag_temperature_breach(&h.admin, &payment_id, &excursion);
+
+    let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
+    assert_eq!(
+        payment.status,
+        PaymentStatus::Disputed,
+        "Payment must be Disputed after temperature breach"
+    );
+}
+
+/// flag_temperature_breach on a non-Locked payment returns InvalidPaymentState.
+#[test]
+fn test_flag_temperature_breach_non_locked_payment_fails() {
+    let h = setup();
+    // Create a Released payment
+    let payment_id = MockPaymentContractClient::new(&h.env, &h.pay_id)
+        .create_payment(&1u64, &PaymentStatus::Released);
+
+    let excursion = make_excursion(1);
+    let result = h
+        .coord
+        .try_flag_temperature_breach(&h.admin, &payment_id, &excursion);
+    assert_eq!(
+        result,
+        Err(Ok(CoordinatorError::InvalidPaymentState)),
+        "Non-Locked payment must return InvalidPaymentState"
+    );
+}
+
+/// flag_temperature_breach on a missing payment returns PaymentNotFound.
+#[test]
+fn test_flag_temperature_breach_missing_payment_fails() {
+    let h = setup();
+    let excursion = make_excursion(1);
+    let result = h
+        .coord
+        .try_flag_temperature_breach(&h.admin, &9999u64, &excursion);
+    assert_eq!(
+        result,
+        Err(Ok(CoordinatorError::PaymentNotFound)),
+        "Missing payment must return PaymentNotFound"
+    );
+}
+
+/// Paused coordinator rejects flag_temperature_breach.
+#[test]
+fn test_flag_temperature_breach_blocked_when_paused() {
+    let h = setup();
+    let payment_id = create_locked_payment(&h, 1);
+    h.coord.pause(&h.admin);
+
+    let excursion = make_excursion(1);
+    let result = h
+        .coord
+        .try_flag_temperature_breach(&h.admin, &payment_id, &excursion);
+    assert_eq!(result, Err(Ok(CoordinatorError::ContractPaused)));
+
+    // Payment must remain Locked
+    let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
+    assert_eq!(payment.status, PaymentStatus::Locked);
 }

--- a/lifebank-soroban/contracts/coordinator/src/types.rs
+++ b/lifebank-soroban/contracts/coordinator/src/types.rs
@@ -31,6 +31,16 @@ pub struct WorkflowRecord {
     pub delivery_confirmed: bool,
 }
 
+/// Summary of a sustained temperature excursion (mirrors temperature contract type).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExcursionSummary {
+    pub unit_id: u64,
+    pub violation_count: u32,
+    pub peak_celsius_x100: i32,
+    pub detected_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {

--- a/lifebank-soroban/contracts/temperature/src/error.rs
+++ b/lifebank-soroban/contracts/temperature/src/error.rs
@@ -10,4 +10,8 @@ pub enum ContractError {
     InvalidThreshold = 603,
     AlreadyInitialized = 604,
     ContractPaused = 605,
+    /// Coordinator contract address not configured
+    CoordinatorNotSet = 606,
+    /// Cross-contract call to coordinator failed
+    CoordinatorCallFailed = 607,
 }

--- a/lifebank-soroban/contracts/temperature/src/lib.rs
+++ b/lifebank-soroban/contracts/temperature/src/lib.rs
@@ -5,13 +5,24 @@ mod storage;
 mod types;
 
 use crate::error::ContractError;
-use crate::types::{DataKey, TemperatureReading, TemperatureSummary, TemperatureThreshold};
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+use crate::types::{DataKey, ExcursionSummary, TemperatureReading, TemperatureSummary, TemperatureThreshold};
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, Vec};
 
 const PAGE_SIZE: u32 = 20;
 
 #[contract]
 pub struct TemperatureContract;
+
+/// Minimal coordinator interface for cross-contract excursion reporting.
+#[contractclient(name = "CoordinatorContractClient")]
+pub trait CoordinatorContractInterface {
+    fn flag_temperature_breach(
+        env: soroban_sdk::Env,
+        caller: Address,
+        payment_id: u64,
+        excursion_summary: ExcursionSummary,
+    ) -> Result<(), soroban_sdk::Error>;
+}
 
 #[contractimpl]
 impl TemperatureContract {
@@ -341,6 +352,100 @@ impl TemperatureContract {
 
         env.storage().persistent().set(&streak_key, &0u32);
         env.storage().persistent().set(&compromised_key, &false);
+
+        Ok(())
+    }
+
+    // ── Coordinator integration ────────────────────────────────────────────────
+
+    /// Configure the coordinator contract address. Admin only.
+    pub fn set_coordinator(
+        env: Env,
+        admin: Address,
+        coordinator: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CoordinatorContract, &coordinator);
+        Ok(())
+    }
+
+    /// Whitelist an IoT oracle address that may call report_excursion_to_coordinator.
+    pub fn add_oracle(
+        env: Env,
+        admin: Address,
+        oracle: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::OracleWhitelist(oracle), &true);
+        Ok(())
+    }
+
+    /// Report a sustained temperature excursion to the coordinator contract,
+    /// which will transition the linked payment from Locked → Disputed.
+    ///
+    /// Only the admin or a whitelisted IoT oracle may call this function.
+    ///
+    /// # Arguments
+    /// * `caller`            - Admin or whitelisted oracle address
+    /// * `unit_id`           - Blood unit that experienced the excursion
+    /// * `payment_id`        - Payment ID to flag in the coordinator
+    /// * `excursion_summary` - Structured summary of the excursion
+    ///
+    /// # Errors
+    /// - `Unauthorized`          - Caller is not admin or whitelisted oracle
+    /// - `CoordinatorNotSet`     - Coordinator address not configured
+    /// - `CoordinatorCallFailed` - Cross-contract call to coordinator failed
+    pub fn report_excursion_to_coordinator(
+        env: Env,
+        caller: Address,
+        unit_id: u64,
+        payment_id: u64,
+        excursion_summary: ExcursionSummary,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        Self::require_not_paused(&env)?;
+
+        // Gate: caller must be admin or whitelisted oracle
+        let stored_admin = storage::get_admin(&env);
+        let is_admin = caller == stored_admin;
+        let is_oracle: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleWhitelist(caller.clone()))
+            .unwrap_or(false);
+
+        if !is_admin && !is_oracle {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let coordinator_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::CoordinatorContract)
+            .ok_or(ContractError::CoordinatorNotSet)?;
+
+        let coord_client = CoordinatorContractClient::new(&env, &coordinator_addr);
+        coord_client
+            .try_flag_temperature_breach(&caller, &payment_id, &excursion_summary)
+            .map_err(|_| ContractError::CoordinatorCallFailed)?
+            .map_err(|_| ContractError::CoordinatorCallFailed)?;
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("tmp_excur"),),
+            (unit_id, payment_id, excursion_summary.violation_count),
+        );
 
         Ok(())
     }

--- a/lifebank-soroban/contracts/temperature/src/types.rs
+++ b/lifebank-soroban/contracts/temperature/src/types.rs
@@ -35,6 +35,21 @@ pub struct TemperatureSummary {
     pub violation_count: u32,
 }
 
+/// Summary of a sustained temperature excursion, passed to the coordinator
+/// when automatically raising a payment dispute.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExcursionSummary {
+    /// Blood unit affected
+    pub unit_id: u64,
+    /// Number of consecutive violations that triggered this excursion
+    pub violation_count: u32,
+    /// Peak temperature recorded during the excursion (×100 scale)
+    pub peak_celsius_x100: i32,
+    /// Ledger timestamp when the excursion was first detected
+    pub detected_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
 pub enum DataKey {
@@ -47,4 +62,8 @@ pub enum DataKey {
     /// Tracks if unit has been compromised (3+ consecutive violations)
     IsCompromised(u64),
     Paused,
+    /// Address of the coordinator contract for cross-contract dispute escalation
+    CoordinatorContract,
+    /// Whitelisted IoT oracle addresses allowed to report excursions
+    OracleWhitelist(soroban_sdk::Address),
 }


### PR DESCRIPTION
…pute chain

Closes #477

Temperature contract:
- Add ExcursionSummary struct: unit_id, violation_count, peak_celsius_x100, detected_at
- Add DataKey variants: CoordinatorContract, OracleWhitelist
- Add Error variants: CoordinatorNotSet (606), CoordinatorCallFailed (607)
- Add set_coordinator() and add_oracle() admin functions
- Add report_excursion_to_coordinator() gated by admin or whitelisted oracle
  - Cross-calls coordinator.flag_temperature_breach()
  - Emits tmp_excur event on success
  - Returns Unauthorized for non-admin/non-oracle callers

Coordinator contract:
- Add ExcursionSummary mirror type
- Add PaymentFlagFailed (832) error variant
- Add record_dispute() to PaymentContractClient interface
- Add flag_temperature_breach() that transitions Locked → Disputed via record_dispute()
  - Emits tmp_brch event with payment_id, unit_id, timestamp
  - Returns InvalidPaymentState if payment is not Locked
  - Returns PaymentNotFound if payment does not exist

Integration tests:
- Full chain: Locked → Disputed on valid excursion report
- Non-Locked payment returns InvalidPaymentState
- Missing payment returns PaymentNotFound
- Paused coordinator blocks breach and leaves payment unchanged