### PR TITLE
fix: consolidate EventEmitter bootstrap to AppModule

### DIFF
--- a/backend/src/cold-chain/cold-chain.module.ts
+++ b/backend/src/cold-chain/cold-chain.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ConfigModule } from '@nestjs/config';
 
 import { TemperatureSampleEntity } from './entities/temperature-sample.entity';
@@ -11,7 +10,6 @@ import { ColdChainController } from './cold-chain.controller';
 @Module({
   imports: [
     TypeOrmModule.forFeature([TemperatureSampleEntity, DeliveryComplianceEntity]),
-    EventEmitterModule.forRoot(),
     ConfigModule,
   ],
   controllers: [ColdChainController],

--- a/backend/src/dispatch/dispatch.module.ts
+++ b/backend/src/dispatch/dispatch.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MapsModule } from '../maps/maps.module';
@@ -17,7 +16,6 @@ import { RiderAssignmentService } from './rider-assignment.service';
 @Module({
   imports: [
     ConfigModule,
-    EventEmitterModule.forRoot(),
     TypeOrmModule.forFeature([BloodUnit, OrderEntity]),
     RidersModule,
     MapsModule,

--- a/backend/src/events/event-bus.bootstrap.spec.ts
+++ b/backend/src/events/event-bus.bootstrap.spec.ts
@@ -1,0 +1,30 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+function getModuleFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...getModuleFiles(fullPath));
+      continue;
+    }
+    if (entry.endsWith('.module.ts')) files.push(fullPath);
+  }
+  return files;
+}
+
+describe('Event bus bootstrap', () => {
+  it('initializes EventEmitterModule.forRoot only once in app modules', () => {
+    const srcRoot = join(process.cwd(), 'src');
+    const moduleFiles = getModuleFiles(srcRoot);
+    const withForRoot = moduleFiles.filter((filePath) =>
+      readFileSync(filePath, 'utf8').includes('EventEmitterModule.forRoot('),
+    );
+
+    expect(withForRoot.length).toBe(1);
+    expect(withForRoot[0]?.endsWith(join('src', 'app.module.ts'))).toBe(true);
+  });
+});

--- a/backend/src/events/events.module.ts
+++ b/backend/src/events/events.module.ts
@@ -1,6 +1,5 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { OutboxConsumer } from './outbox-consumer';
@@ -14,7 +13,6 @@ import { OutboxService } from './outbox.service';
     BullModule.registerQueue({
       name: 'outbox-events',
     }),
-    EventEmitterModule.forRoot(),
   ],
   providers: [OutboxService, OutboxProducer, OutboxConsumer],
   exports: [OutboxService],

--- a/backend/src/inventory/inventory.module.ts
+++ b/backend/src/inventory/inventory.module.ts
@@ -1,6 +1,5 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
@@ -52,7 +51,6 @@ import { RestockingCampaignController } from './controllers/restocking-campaign.
       name: 'donor-outreach',
     }),
     ScheduleModule.forRoot(),
-    EventEmitterModule.forRoot(),
     NotificationsModule,
     UsersModule,
   ],

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,6 +1,5 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { PolicyCenterModule } from '../policy-center/policy-center.module';
@@ -33,7 +32,6 @@ import { SmsProvider } from './providers/sms.provider';
     BullModule.registerQueue({
       name: 'notifications',
     }),
-    EventEmitterModule.forRoot(),
     PolicyCenterModule,
   ],
   controllers: [NotificationsController, NotificationPreferenceController],

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApprovalModule } from '../approvals/approval.module';
@@ -23,7 +22,6 @@ import { OrderStateMachine } from './state-machine/order-state-machine';
 @Module({
   imports: [
     TypeOrmModule.forFeature([OrderEntity, OrderEventEntity, BlockchainEvent]),
-    EventEmitterModule.forRoot(),
     InventoryModule,
     NotificationsModule,
     FeePolicyModule,


### PR DESCRIPTION
## Summary
- Remove `EventEmitterModule.forRoot()` from feature modules so only `AppModule` initializes the event bus.
- Keep notifications, outbox, and domain listeners wired through the shared emitter instance from the root graph.
- Add a regression spec that enforces a single `EventEmitterModule.forRoot()` occurrence across production module files.

## Validation
- Verified only `backend/src/app.module.ts` contains `EventEmitterModule.forRoot()`.
- Added test coverage in `backend/src/events/event-bus.bootstrap.spec.ts`.

Closes #587