### PR TITLE
Add invariant and property testing for protocol transitions

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -14,6 +14,8 @@ pub mod storage_lifecycle;
 #[cfg(test)]
 mod test_payments;
 #[cfg(test)]
+mod test_protocol_invariants;
+#[cfg(test)]
 mod test_storage_layout;
 
 /// Error types for blood registration and transfer
@@ -62,6 +64,7 @@ pub enum Error {
     NotCurrentCustodian = 29,
     InvalidMultiSigConfig = 30,
     DuplicateApproval = 31,
+    EscrowNotReleasable = 32,
 }
 
 // Alias for issue/docs terminology.
@@ -1328,8 +1331,10 @@ impl HealthChainContract {
             timestamp: current_time,
         };
 
-        env.events()
-            .publish((symbol_short!("quar"), symbol_short!("place")), quarantine_event);
+        env.events().publish(
+            (symbol_short!("quar"), symbol_short!("place")),
+            quarantine_event,
+        );
 
         Ok(())
     }
@@ -1386,8 +1391,10 @@ impl HealthChainContract {
             timestamp: env.ledger().timestamp(),
         };
 
-        env.events()
-            .publish((symbol_short!("quar"), symbol_short!("final")), quarantine_event);
+        env.events().publish(
+            (symbol_short!("quar"), symbol_short!("final")),
+            quarantine_event,
+        );
 
         Ok(())
     }
@@ -1952,7 +1959,9 @@ impl HealthChainContract {
             .get(&ESCROW_ACCOUNTS)
             .unwrap_or(Map::new(&env));
         escrow_accounts.set(payment_id, escrow);
-        env.storage().persistent().set(&ESCROW_ACCOUNTS, &escrow_accounts);
+        env.storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrow_accounts);
 
         payments.set(payment_id, payment);
         env.storage().persistent().set(&PAYMENTS, &payments);
@@ -1984,14 +1993,18 @@ impl HealthChainContract {
             .get(&ESCROW_ACCOUNTS)
             .ok_or(Error::PaymentNotFound)?;
 
-        let mut escrow = escrow_accounts.get(payment_id).ok_or(Error::PaymentNotFound)?;
+        let mut escrow = escrow_accounts
+            .get(payment_id)
+            .ok_or(Error::PaymentNotFound)?;
         escrow.release_conditions = ReleaseConditions {
             medical_records_verified,
             min_timestamp,
             authorized_approver,
         };
         escrow_accounts.set(payment_id, escrow);
-        env.storage().persistent().set(&ESCROW_ACCOUNTS, &escrow_accounts);
+        env.storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrow_accounts);
         Ok(())
     }
 
@@ -2074,7 +2087,9 @@ impl HealthChainContract {
             .persistent()
             .get(&ESCROW_ACCOUNTS)
             .unwrap_or(Map::new(&env));
-        let escrow = escrow_accounts.get(payment_id).ok_or(Error::PaymentNotFound)?;
+        let escrow = escrow_accounts
+            .get(payment_id)
+            .ok_or(Error::PaymentNotFound)?;
         let current_timestamp = env.ledger().timestamp();
         if !escrow.can_release(current_timestamp, Some(&approver)) {
             return Err(Error::EscrowNotReleasable);
@@ -3172,20 +3187,14 @@ impl HealthChainContract {
     ///
     /// Returns `None` if the history has not been archived yet (full history
     /// is still available via `get_transfer_history`).
-    pub fn get_history_summary(
-        env: Env,
-        unit_id: u64,
-    ) -> Option<ArchivedHistorySummary> {
+    pub fn get_history_summary(env: Env, unit_id: u64) -> Option<ArchivedHistorySummary> {
         storage_lifecycle::get_archived_history_summary(&env, unit_id)
     }
 
     /// Retrieve the archived custody summary for a unit.
     ///
     /// Returns `None` if custody events have not been archived yet.
-    pub fn get_custody_summary(
-        env: Env,
-        unit_id: u64,
-    ) -> Option<ArchivedCustodySummary> {
+    pub fn get_custody_summary(env: Env, unit_id: u64) -> Option<ArchivedCustodySummary> {
         storage_lifecycle::get_archived_custody_summary(&env, unit_id)
     }
 }
@@ -3243,7 +3252,14 @@ mod test {
         let expiration = current_time + (7 * 86400);
 
         env.mock_all_auths();
-        client.register_blood(&hospital, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        client.register_blood(
+            &hospital,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
     }
 
     #[test]
@@ -3356,7 +3372,14 @@ mod test {
 
         // Attempt to register blood using revoked bank (should fail Unauthorized)
         env.mock_all_auths();
-        client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &100, &expiration, &None);
+        client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &100,
+            &expiration,
+            &None,
+        );
 
         // Attempt to allocate using revoked bank (should also fail Unauthorized)
         env.mock_all_auths();
@@ -5262,7 +5285,6 @@ mod test {
         client.fulfill_request(&bank, &999u64, &unit_ids);
     }
 
-
     // ======================================================
     // Custodian Check Tests (#101)
     // ======================================================
@@ -5278,15 +5300,14 @@ mod test {
 
         let current_time = env.ledger().timestamp();
         let expiration = current_time + (7 * 86400);
-        let unit_id =
-            client.register_blood(
-                &bank,
-                &BloodType::OPositive,
-                &BloodComponent::WholeBlood,
-                &450,
-                &expiration,
-                &None,
-            );
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
         client.allocate_blood(&bank, &unit_id, &hospital);
 
         // Current custodian (bank) can initiate transfer
@@ -5309,15 +5330,14 @@ mod test {
         let current_time = env.ledger().timestamp();
         let expiration = current_time + (7 * 86400);
         // bank_a registers and allocates the unit — bank_a is the custodian
-        let unit_id =
-            client.register_blood(
-                &bank_a,
-                &BloodType::OPositive,
-                &BloodComponent::WholeBlood,
-                &450,
-                &expiration,
-                &None,
-            );
+        let unit_id = client.register_blood(
+            &bank_a,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
         client.allocate_blood(&bank_a, &unit_id, &hospital);
 
         // bank_b is authorized but is NOT the custodian — must fail
@@ -5337,15 +5357,14 @@ mod test {
 
         let current_time = env.ledger().timestamp();
         let expiration = current_time + (7 * 86400);
-        let unit_id =
-            client.register_blood(
-                &bank,
-                &BloodType::OPositive,
-                &BloodComponent::WholeBlood,
-                &450,
-                &expiration,
-                &None,
-            );
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
         client.allocate_blood(&bank, &unit_id, &hospital);
 
         // Completely unregistered address — must fail with Unauthorized, not NotCurrentCustodian
@@ -5671,7 +5690,14 @@ mod test {
 
         // Register blood without donor_id (anonymous)
         env.mock_all_auths();
-        client.register_blood(&bank, &BloodType::ABPositive, &BloodComponent::WholeBlood, &300, &expiration, &None);
+        client.register_blood(
+            &bank,
+            &BloodType::ABPositive,
+            &BloodComponent::WholeBlood,
+            &300,
+            &expiration,
+            &None,
+        );
 
         // Anonymous donors are stored as "ANON"
         let units = client.get_units_by_donor(&symbol_short!("ANON"));
@@ -5696,7 +5722,14 @@ mod test {
 
         // Register and allocate blood
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         env.mock_all_auths();
         client.allocate_blood(&bank, &unit_id, &hospital);
@@ -5733,7 +5766,14 @@ mod test {
         let expiration = current_time + (7 * 86400);
 
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         let mut event_ids = vec![&env];
 
@@ -5788,7 +5828,14 @@ mod test {
 
         // Register blood
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         let mut all_event_ids = vec![&env];
 
@@ -5855,7 +5902,14 @@ mod test {
         let expiration = current_time + (30 * 86400);
 
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         for i in 0..100 {
             env.as_contract(&contract_id, || {
@@ -5907,7 +5961,14 @@ mod test {
 
         // Register blood but don't create any custody events
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         // Check custody trail - should be empty
         let trail = client.get_custody_trail(&unit_id, &0);
@@ -5933,7 +5994,14 @@ mod test {
 
         // Register and create one custody event
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         env.mock_all_auths();
         client.allocate_blood(&bank, &unit_id, &hospital);
@@ -5963,7 +6031,14 @@ mod test {
 
         // Register blood
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         // Migrate (should initialize empty metadata)
         env.mock_all_auths();
@@ -5996,7 +6071,14 @@ mod test {
         let expiration = current_time + (7 * 86400);
 
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         // With mock_all_auths, this will succeed even without admin
         // This test documents that behavior
@@ -6016,7 +6098,14 @@ mod test {
         let expiration = current_time + (30 * 86400);
 
         env.mock_all_auths();
-        let unit_id = client.register_blood(&bank, &BloodType::OPositive, &BloodComponent::WholeBlood, &450, &expiration, &None);
+        let unit_id = client.register_blood(
+            &bank,
+            &BloodType::OPositive,
+            &BloodComponent::WholeBlood,
+            &450,
+            &expiration,
+            &None,
+        );
 
         for i in 0..20 {
             env.as_contract(&contract_id, || {

--- a/contracts/src/storage_lifecycle.rs
+++ b/contracts/src/storage_lifecycle.rs
@@ -77,7 +77,7 @@ use soroban_sdk::{contracttype, symbol_short, Env, Vec};
 use crate::{
     BloodStatus, BloodUnit, CustodyEvent, CustodyStatus, DataKey, Error, StatusChangeEvent,
     BLOOD_BANKS, BLOOD_UNITS, CUSTODY_EVENTS, DISPUTES, DISPUTE_METADATA, HISTORY, HOSPITALS,
-    PAYMENT_STATS, PAYMENTS, PENDING_APPROVALS, REQUESTS, REQUEST_KEYS,
+    PAYMENTS, PAYMENT_STATS, PENDING_APPROVALS, REQUESTS, REQUEST_KEYS,
 };
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -146,10 +146,10 @@ pub struct ArchivedCustodySummary {
 ///
 /// Call this after every write to a persistent key to prevent rent expiry.
 /// No-op if the key does not exist.
-pub fn bump_persistent<K: soroban_sdk::TryIntoVal<Env, soroban_sdk::Val>>(
-    env: &Env,
-    key: &K,
-) {
+pub fn bump_persistent<K>(env: &Env, key: &K)
+where
+    K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
     env.storage()
         .persistent()
         .extend_ttl(key, MIN_TTL_LEDGERS, EXTENDED_TTL_LEDGERS);
@@ -215,7 +215,11 @@ pub fn is_terminal_status(status: BloodStatus) -> bool {
 /// 1. The unit is in a terminal status.
 /// 2. At least `ARCHIVE_AFTER_DAYS` have elapsed since the last status change,
 ///    giving off-chain indexers time to ingest all events.
-pub fn is_eligible_for_archival(env: &Env, unit: &BloodUnit, history: &Vec<StatusChangeEvent>) -> bool {
+pub fn is_eligible_for_archival(
+    env: &Env,
+    unit: &BloodUnit,
+    history: &Vec<StatusChangeEvent>,
+) -> bool {
     if !is_terminal_status(unit.status) {
         return false;
     }
@@ -224,7 +228,10 @@ pub fn is_eligible_for_archival(env: &Env, unit: &BloodUnit, history: &Vec<Statu
     }
     let last_event = history.get(history.len() - 1).unwrap();
     let current_time = env.ledger().timestamp();
-    current_time >= last_event.timestamp.saturating_add(ARCHIVE_AFTER_DAYS * SECONDS_PER_DAY)
+    current_time
+        >= last_event
+            .timestamp
+            .saturating_add(ARCHIVE_AFTER_DAYS * SECONDS_PER_DAY)
 }
 
 /// Compact the status history for a terminal blood unit.
@@ -379,20 +386,14 @@ pub fn archive_custody_events(env: &Env, unit_id: u64) -> Result<bool, Error> {
 // ── Read helpers for archived data ─────────────────────────────────────────────
 
 /// Retrieve the archived history summary for a unit, if it has been compacted.
-pub fn get_archived_history_summary(
-    env: &Env,
-    unit_id: u64,
-) -> Option<ArchivedHistorySummary> {
+pub fn get_archived_history_summary(env: &Env, unit_id: u64) -> Option<ArchivedHistorySummary> {
     env.storage()
         .persistent()
         .get(&ArchiveKey::HistorySummary(unit_id))
 }
 
 /// Retrieve the archived custody summary for a unit, if it has been compacted.
-pub fn get_archived_custody_summary(
-    env: &Env,
-    unit_id: u64,
-) -> Option<ArchivedCustodySummary> {
+pub fn get_archived_custody_summary(env: &Env, unit_id: u64) -> Option<ArchivedCustodySummary> {
     env.storage()
         .persistent()
         .get(&ArchiveKey::CustodySummary(unit_id))

--- a/contracts/src/test_payments.rs
+++ b/contracts/src/test_payments.rs
@@ -619,7 +619,12 @@ fn pending_approval_rejects_duplicate_votes() {
     );
 }
 
-fn satisfy_escrow_conditions(env: &Env, contract_id: &Address, payment_id: u64, approver: &Address) {
+fn satisfy_escrow_conditions(
+    env: &Env,
+    contract_id: &Address,
+    payment_id: u64,
+    approver: &Address,
+) {
     env.as_contract(contract_id, || {
         let mut escrow_accounts: Map<u64, EscrowAccount> =
             env.storage().persistent().get(&ESCROW_ACCOUNTS).unwrap();
@@ -630,7 +635,9 @@ fn satisfy_escrow_conditions(env: &Env, contract_id: &Address, payment_id: u64, 
             authorized_approver: Some(approver.clone()),
         };
         escrow_accounts.set(payment_id, escrow);
-        env.storage().persistent().set(&ESCROW_ACCOUNTS, &escrow_accounts);
+        env.storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrow_accounts);
     });
 }
 
@@ -752,7 +759,11 @@ fn high_value_release_requires_threshold_votes_and_prevents_duplicates() {
         let payment = payments.get(payment_id).unwrap();
         assert_eq!(payment.status, PaymentStatus::Completed);
 
-        let stats: PaymentStats = env.storage().persistent().get(&PAYMENT_STATS).unwrap_or(PaymentStats::new());
+        let stats: PaymentStats = env
+            .storage()
+            .persistent()
+            .get(&PAYMENT_STATS)
+            .unwrap_or(PaymentStats::new());
         assert_eq!(stats.count_auto_refunded, 0);
         assert_eq!(stats.total_auto_refunded, 0);
         let approvals: Map<u64, PendingApproval> =
@@ -804,7 +815,10 @@ fn escrow_conditions_block_release_when_unmet() {
 
     // Default conditions: medical_records_verified=false — release must be blocked.
     let result = client.try_propose_release(&payment_id, &admin);
-    assert!(result.is_err(), "release must fail when escrow conditions are unmet");
+    assert!(
+        result.is_err(),
+        "release must fail when escrow conditions are unmet"
+    );
 }
 
 #[test]
@@ -839,7 +853,9 @@ fn escrow_conditions_block_release_before_min_timestamp() {
             authorized_approver: Some(admin.clone()),
         };
         escrow_accounts.set(payment_id, escrow);
-        env.storage().persistent().set(&ESCROW_ACCOUNTS, &escrow_accounts);
+        env.storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrow_accounts);
     });
 
     // Ledger timestamp is 0 < 9_999_999 — must be blocked.
@@ -880,11 +896,16 @@ fn escrow_conditions_block_release_wrong_approver() {
             authorized_approver: Some(other.clone()),
         };
         escrow_accounts.set(payment_id, escrow);
-        env.storage().persistent().set(&ESCROW_ACCOUNTS, &escrow_accounts);
+        env.storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrow_accounts);
     });
 
     let result = client.try_propose_release(&payment_id, &admin);
-    assert!(result.is_err(), "release must fail when approver does not match");
+    assert!(
+        result.is_err(),
+        "release must fail when approver does not match"
+    );
 }
 
 #[test]
@@ -916,7 +937,10 @@ fn escrow_conditions_allow_release_when_all_met() {
 
     env.as_contract(&contract_id, || {
         let payments: Map<u64, Payment> = env.storage().persistent().get(&PAYMENTS).unwrap();
-        assert_eq!(payments.get(payment_id).unwrap().status, PaymentStatus::Completed);
+        assert_eq!(
+            payments.get(payment_id).unwrap().status,
+            PaymentStatus::Completed
+        );
     });
 }
 

--- a/contracts/src/test_protocol_invariants.rs
+++ b/contracts/src/test_protocol_invariants.rs
@@ -1,0 +1,449 @@
+#![cfg(test)]
+
+use crate::payments::{
+    EscrowAccount, FeeStructure, MultiSigConfig, Payment, PaymentError, PaymentStatus,
+    PendingApproval, ReleaseConditions, HIGH_VALUE_THRESHOLD,
+};
+use crate::{
+    BloodComponent, BloodRequest, BloodStatus, BloodType, BloodUnit, CustodyStatus, Error,
+    HealthChainContract, HealthChainContractClient, QuarantineReason, RequestStatus, UrgencyLevel,
+    BLOOD_UNITS, ESCROW_ACCOUNTS, PAYMENTS, REQUESTS,
+};
+
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    vec, Address, Env, Map, String, Symbol,
+};
+
+struct ProtocolFixture {
+    env: Env,
+    contract_id: Address,
+    bank: Address,
+    other_bank: Address,
+    hospital: Address,
+    admin: Address,
+}
+
+fn setup_protocol() -> ProtocolFixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(HealthChainContract, ());
+    let client = HealthChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let bank = Address::generate(&env);
+    let other_bank = Address::generate(&env);
+    let hospital = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.register_blood_bank(&bank);
+    client.register_blood_bank(&other_bank);
+    client.register_hospital(&hospital);
+
+    ProtocolFixture {
+        env,
+        contract_id,
+        bank,
+        other_bank,
+        hospital,
+        admin,
+    }
+}
+
+fn client<'a>(fixture: &'a ProtocolFixture) -> HealthChainContractClient<'a> {
+    HealthChainContractClient::new(&fixture.env, &fixture.contract_id)
+}
+
+fn valid_expiration(env: &Env) -> u64 {
+    env.ledger().timestamp() + (7 * 86_400)
+}
+
+fn register_unit(fixture: &ProtocolFixture, quantity: u32) -> u64 {
+    client(fixture).register_blood(
+        &fixture.bank,
+        &BloodType::OPositive,
+        &BloodComponent::WholeBlood,
+        &quantity,
+        &valid_expiration(&fixture.env),
+        &Some(symbol_short!("donor")),
+    )
+}
+
+fn create_request(fixture: &ProtocolFixture, quantity: u32) -> u64 {
+    client(fixture).create_request(
+        &fixture.hospital,
+        &BloodType::OPositive,
+        &quantity,
+        &UrgencyLevel::Urgent,
+        &(fixture.env.ledger().timestamp() + 3_600),
+        &String::from_str(&fixture.env, "Ward A"),
+    )
+}
+
+fn stored_unit(fixture: &ProtocolFixture, unit_id: u64) -> BloodUnit {
+    client(fixture).get_blood_unit(&unit_id)
+}
+
+fn stored_request(fixture: &ProtocolFixture, request_id: u64) -> BloodRequest {
+    fixture.env.as_contract(&fixture.contract_id, || {
+        let requests: Map<u64, BloodRequest> =
+            fixture.env.storage().persistent().get(&REQUESTS).unwrap();
+        requests.get(request_id).unwrap()
+    })
+}
+
+fn force_unit_quantity(fixture: &ProtocolFixture, unit_id: u64, quantity: u32) {
+    fixture.env.as_contract(&fixture.contract_id, || {
+        let mut units: Map<u64, BloodUnit> = fixture
+            .env
+            .storage()
+            .persistent()
+            .get(&BLOOD_UNITS)
+            .unwrap();
+        let mut unit = units.get(unit_id).unwrap();
+        unit.quantity = quantity;
+        units.set(unit_id, unit);
+        fixture.env.storage().persistent().set(&BLOOD_UNITS, &units);
+    });
+}
+
+fn escrow_payment(fixture: &ProtocolFixture, payment_id: u64, approver: &Address) {
+    fixture.env.as_contract(&fixture.contract_id, || {
+        let mut payments: Map<u64, Payment> =
+            fixture.env.storage().persistent().get(&PAYMENTS).unwrap();
+        let mut payment = payments.get(payment_id).unwrap();
+        payment.status = PaymentStatus::Escrowed;
+        payments.set(payment_id, payment);
+        fixture.env.storage().persistent().set(&PAYMENTS, &payments);
+
+        let mut escrows: Map<u64, EscrowAccount> = fixture
+            .env
+            .storage()
+            .persistent()
+            .get(&ESCROW_ACCOUNTS)
+            .unwrap();
+        let mut escrow = escrows.get(payment_id).unwrap();
+        escrow.release_conditions = ReleaseConditions {
+            medical_records_verified: true,
+            min_timestamp: 0,
+            authorized_approver: Some(approver.clone()),
+        };
+        escrows.set(payment_id, escrow);
+        fixture
+            .env
+            .storage()
+            .persistent()
+            .set(&ESCROW_ACCOUNTS, &escrows);
+    });
+}
+
+fn default_fee_structure(env: &Env) -> FeeStructure {
+    FeeStructure {
+        policy_id: Symbol::new(env, "default_fee_policy"),
+        service_fee: 0,
+        network_fee: 0,
+        performance_bonus: 0,
+        fixed_fee: 0,
+    }
+}
+
+fn payment_with_status(env: &Env, status: PaymentStatus) -> Payment {
+    Payment {
+        id: 1,
+        request_id: 1,
+        payer: Address::generate(env),
+        payee: Address::generate(env),
+        amount: 1_000,
+        asset: Address::generate(env),
+        fee_structure: default_fee_structure(env),
+        status,
+        escrow_released_at: None,
+    }
+}
+
+#[test]
+fn property_request_quantities_are_never_negative_and_invalid_ranges_fail() {
+    let fixture = setup_protocol();
+    let invalid_quantities = [0, 1, 49, 5_001, u32::MAX];
+
+    for quantity in invalid_quantities {
+        let result = client(&fixture).try_create_request(
+            &fixture.hospital,
+            &BloodType::OPositive,
+            &quantity,
+            &UrgencyLevel::Urgent,
+            &(fixture.env.ledger().timestamp() + 3_600),
+            &String::from_str(&fixture.env, "Ward A"),
+        );
+
+        assert!(matches!(result, Err(Ok(Error::InvalidQuantity))));
+    }
+
+    let request_id = create_request(&fixture, 500);
+    let request = stored_request(&fixture, request_id);
+    assert_eq!(request.quantity_ml, 500);
+    assert_eq!(request.fulfilled_quantity_ml, 0);
+}
+
+#[test]
+fn property_expired_units_cannot_be_allocated_or_transferred() {
+    let fixture = setup_protocol();
+    let unit_id = register_unit(&fixture, 450);
+
+    let expiration = stored_unit(&fixture, unit_id).expiration_date;
+    fixture.env.ledger().with_mut(|ledger| {
+        ledger.timestamp = expiration;
+    });
+
+    let allocation =
+        client(&fixture).try_allocate_blood(&fixture.bank, &unit_id, &fixture.hospital);
+    assert!(matches!(allocation, Err(Ok(Error::UnitExpired))));
+    assert_eq!(
+        stored_unit(&fixture, unit_id).status,
+        BloodStatus::Available
+    );
+}
+
+#[test]
+fn property_duplicate_and_invalid_request_transitions_fail_deterministically() {
+    let fixture = setup_protocol();
+    let required_by = fixture.env.ledger().timestamp() + 3_600;
+    let address = String::from_str(&fixture.env, "Ward A");
+
+    let first_id = client(&fixture).create_request(
+        &fixture.hospital,
+        &BloodType::OPositive,
+        &500,
+        &UrgencyLevel::Urgent,
+        &required_by,
+        &address,
+    );
+
+    let duplicate = client(&fixture).try_create_request(
+        &fixture.hospital,
+        &BloodType::OPositive,
+        &500,
+        &UrgencyLevel::Urgent,
+        &required_by,
+        &String::from_str(&fixture.env, "ward a"),
+    );
+    assert!(matches!(duplicate, Err(Ok(Error::DuplicateRequest))));
+
+    let invalid = client(&fixture).try_update_request_status(&first_id, &RequestStatus::Fulfilled);
+    assert!(matches!(invalid, Err(Ok(Error::InvalidTransition))));
+    assert_eq!(
+        stored_request(&fixture, first_id).status,
+        RequestStatus::Pending
+    );
+}
+
+#[test]
+fn property_request_approval_overflow_fails_before_state_mutation() {
+    let fixture = setup_protocol();
+    let first = register_unit(&fixture, 450);
+    let second = register_unit(&fixture, 450);
+    let request_id = create_request(&fixture, 500);
+
+    force_unit_quantity(&fixture, first, u32::MAX);
+    force_unit_quantity(&fixture, second, 1);
+
+    let unit_ids = vec![&fixture.env, first, second];
+    let result = client(&fixture).try_approve_request(&fixture.bank, &request_id, &unit_ids);
+
+    assert!(matches!(result, Err(Ok(Error::ArithmeticError))));
+    assert_eq!(
+        stored_request(&fixture, request_id).status,
+        RequestStatus::Pending
+    );
+    assert_eq!(stored_unit(&fixture, first).status, BloodStatus::Available);
+    assert_eq!(stored_unit(&fixture, second).status, BloodStatus::Available);
+}
+
+#[test]
+fn property_delivered_unit_cannot_be_concurrently_quarantined_by_duplicate_action() {
+    let fixture = setup_protocol();
+    let unit_id = register_unit(&fixture, 450);
+
+    client(&fixture).allocate_blood(&fixture.bank, &unit_id, &fixture.hospital);
+    let event_id = client(&fixture).initiate_transfer(&fixture.bank, &unit_id);
+    client(&fixture).confirm_transfer(&fixture.hospital, &event_id);
+
+    let duplicate_confirm = client(&fixture).try_confirm_transfer(&fixture.hospital, &event_id);
+    assert!(matches!(duplicate_confirm, Err(Ok(Error::InvalidStatus))));
+
+    let event = client(&fixture).get_custody_event(&event_id);
+    assert_eq!(event.status, CustodyStatus::Confirmed);
+    assert_eq!(
+        stored_unit(&fixture, unit_id).status,
+        BloodStatus::Delivered
+    );
+}
+
+#[test]
+fn property_custody_transfer_requires_authorized_current_custodian() {
+    let fixture = setup_protocol();
+    let unit_id = register_unit(&fixture, 450);
+
+    client(&fixture).allocate_blood(&fixture.bank, &unit_id, &fixture.hospital);
+
+    let non_custodian_attempt =
+        client(&fixture).try_initiate_transfer(&fixture.other_bank, &unit_id);
+    assert!(matches!(
+        non_custodian_attempt,
+        Err(Ok(Error::NotCurrentCustodian))
+    ));
+    assert_eq!(stored_unit(&fixture, unit_id).status, BloodStatus::Reserved);
+
+    let event_id = client(&fixture).initiate_transfer(&fixture.bank, &unit_id);
+    let unauthorized_recipient = Address::generate(&fixture.env);
+    let bad_confirm = client(&fixture).try_confirm_transfer(&unauthorized_recipient, &event_id);
+    assert!(matches!(bad_confirm, Err(Ok(Error::UnauthorizedHospital))));
+    assert_eq!(
+        stored_unit(&fixture, unit_id).status,
+        BloodStatus::InTransit
+    );
+}
+
+#[test]
+fn property_completed_payments_are_terminal_and_cannot_reenter_escrow() {
+    let fixture = setup_protocol();
+    let payer = Address::generate(&fixture.env);
+    let payee = Address::generate(&fixture.env);
+    let asset = Address::generate(&fixture.env);
+
+    let payment_id =
+        client(&fixture).create_payment(&1, &payer, &payee, &(HIGH_VALUE_THRESHOLD - 1), &asset);
+    escrow_payment(&fixture, payment_id, &fixture.admin);
+    assert!(client(&fixture).propose_release(&payment_id, &fixture.admin));
+
+    let second_release = client(&fixture).try_propose_release(&payment_id, &fixture.admin);
+    assert!(matches!(
+        second_release,
+        Err(Ok(Error::InvalidPaymentStatus))
+    ));
+
+    fixture.env.as_contract(&fixture.contract_id, || {
+        let payments: Map<u64, Payment> =
+            fixture.env.storage().persistent().get(&PAYMENTS).unwrap();
+        let payment = payments.get(payment_id).unwrap();
+        assert_eq!(payment.status, PaymentStatus::Completed);
+        assert!(payment.is_terminal());
+        assert!(!payment.can_transition_to(PaymentStatus::Escrowed));
+    });
+}
+
+#[test]
+fn property_payment_transition_matrix_rejects_arbitrary_invalid_sequences() {
+    let env = Env::default();
+    let statuses = [
+        PaymentStatus::Pending,
+        PaymentStatus::Escrowed,
+        PaymentStatus::Disputed,
+        PaymentStatus::Resolved,
+        PaymentStatus::Completed,
+        PaymentStatus::Refunded,
+        PaymentStatus::Cancelled,
+    ];
+    let allowed = [
+        (PaymentStatus::Pending, PaymentStatus::Escrowed),
+        (PaymentStatus::Pending, PaymentStatus::Cancelled),
+        (PaymentStatus::Escrowed, PaymentStatus::Completed),
+        (PaymentStatus::Escrowed, PaymentStatus::Refunded),
+        (PaymentStatus::Escrowed, PaymentStatus::Disputed),
+        (PaymentStatus::Disputed, PaymentStatus::Resolved),
+        (PaymentStatus::Resolved, PaymentStatus::Completed),
+        (PaymentStatus::Resolved, PaymentStatus::Refunded),
+    ];
+
+    for from in statuses {
+        let payment = payment_with_status(&env, from);
+        for to in statuses {
+            assert_eq!(
+                payment.can_transition_to(to),
+                allowed.contains(&(from, to)),
+                "unexpected payment transition result"
+            );
+        }
+    }
+}
+
+#[test]
+fn property_fee_and_multisig_arithmetic_fail_safely_for_arbitrary_edges() {
+    let env = Env::default();
+    let fee_cases = [
+        (0, 0, 0, 0, 1_000, Ok(1_000)),
+        (500, 400, 100, 1, 1_000, Err(PaymentError::FeesExceedAmount)),
+        (-1, 0, 0, 0, 1_000, Ok(1_001)),
+    ];
+
+    for (service_fee, network_fee, performance_bonus, fixed_fee, gross, expected_net) in fee_cases {
+        let fees = FeeStructure {
+            policy_id: Symbol::new(&env, "default_fee_policy"),
+            service_fee,
+            network_fee,
+            performance_bonus,
+            fixed_fee,
+        };
+
+        if service_fee < 0 || network_fee < 0 || performance_bonus < 0 || fixed_fee < 0 {
+            assert_eq!(fees.validate(), Err(PaymentError::InvalidFee));
+        } else {
+            assert_eq!(fees.calculate_net_amount(gross), expected_net);
+        }
+    }
+
+    let signer = Address::generate(&env);
+    let duplicate_config = MultiSigConfig {
+        signers: vec![&env, signer.clone(), signer.clone()],
+        threshold: 2,
+    };
+    assert_eq!(
+        duplicate_config.validate(),
+        Err(PaymentError::InvalidMultiSigConfig)
+    );
+
+    let mut approval = PendingApproval::new(&env, 7);
+    assert_eq!(approval.register_vote(signer.clone()), Ok(()));
+    assert_eq!(
+        approval.register_vote(signer),
+        Err(PaymentError::DuplicateApproval)
+    );
+}
+
+#[test]
+fn property_invalid_custody_and_quarantine_sequences_leave_single_status() {
+    let fixture = setup_protocol();
+    let unit_id = register_unit(&fixture, 450);
+
+    let invalid_quarantine_finalize = client(&fixture).try_finalize_quarantine(
+        &fixture.bank,
+        &unit_id,
+        &QuarantineReason::ManualOperatorAction,
+        &crate::QuarantineDisposition::Release,
+    );
+    assert!(matches!(
+        invalid_quarantine_finalize,
+        Err(Ok(Error::InvalidStatus))
+    ));
+
+    client(&fixture).quarantine_blood(
+        &fixture.bank,
+        &unit_id,
+        &QuarantineReason::ManualOperatorAction,
+    );
+    let duplicate_quarantine = client(&fixture).try_quarantine_blood(
+        &fixture.bank,
+        &unit_id,
+        &QuarantineReason::ManualOperatorAction,
+    );
+    assert!(matches!(
+        duplicate_quarantine,
+        Err(Ok(Error::InvalidStatus))
+    ));
+    assert_eq!(
+        stored_unit(&fixture, unit_id).status,
+        BloodStatus::Quarantined
+    );
+}

--- a/contracts/src/test_storage_layout.rs
+++ b/contracts/src/test_storage_layout.rs
@@ -251,7 +251,14 @@ fn test_expire_unit_updates_status_field_no_deletion() {
 
     // Register unit with short expiration
     let expiration = env.ledger().timestamp() + 86400; // 1 day
-    let unit_id = client.register_blood(&bank, &BloodType::ONegative, &BloodComponent::WholeBlood, &250, &expiration, &None);
+    let unit_id = client.register_blood(
+        &bank,
+        &BloodType::ONegative,
+        &BloodComponent::WholeBlood,
+        &250,
+        &expiration,
+        &None,
+    );
 
     // Fast-forward time past expiration
     env.ledger().with_mut(|li| {


### PR DESCRIPTION
Closes #580

Adds invariant and property/fuzz-style tests covering request, payment, and custody transitions, including quantity accounting, invalid state transitions, overflow cases, duplicate actions, and authorized custody movement.