### PR TITLE
fix: safe TypeORM sync, single config bootstrap, health module, full …module graph

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,11 @@
     "test:contracts:watch": "jest --testPathPatterns='__contracts__' --watch",
     "test:contracts:cov": "jest --testPathPatterns='__contracts__' --coverage --detectOpenHandles --forceExit",
     "prepare": "cd .. && husky backend/.husky",
-    "seed": "ts-node -r tsconfig-paths/register src/scripts/seed.ts"
+    "seed": "ts-node -r tsconfig-paths/register src/scripts/seed.ts",
+    "migration:run": "typeorm migration:run -d dist/data-source.js",
+    "migration:revert": "typeorm migration:revert -d dist/data-source.js",
+    "migration:generate": "typeorm migration:generate -d dist/data-source.js",
+    "migration:create": "typeorm migration:create"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.600.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,7 +1,7 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -9,6 +9,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
 
 import { AnomalyModule } from './anomaly/anomaly.module';
+import { ApprovalModule } from './approvals/approval.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
@@ -18,40 +19,73 @@ import { BatchImportModule } from './batch-import/batch-import.module';
 import { BlockchainModule } from './blockchain/blockchain.module';
 import { BloodRequestsModule } from './blood-requests/blood-requests.module';
 import { BloodUnitsModule } from './blood-units/blood-units.module';
+import { ColdChainModule } from './cold-chain/cold-chain.module';
 import { AuditLogModule } from './common/audit/audit-log.module';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { CorrelationIdService } from './common/middleware/correlation-id.service';
 import { AppConfigModule } from './config/config.module';
-import { DatabaseSyncGuard } from './config/database-sync.guard';
+import { ContractEventIndexerModule } from './contract-event-indexer/contract-event-indexer.module';
+import { CustodyModule } from './custody/custody.module';
+import { DeliveryProofModule } from './delivery-proof/delivery-proof.module';
 import { DispatchModule } from './dispatch/dispatch.module';
+import { DisputesModule } from './disputes/disputes.module';
+import { DonationModule } from './donations/donation.module';
+import { DonorEligibilityModule } from './donor-eligibility/donor-eligibility.module';
 import { DonorImpactModule } from './donor-impact/donor-impact.module';
 import { EscalationModule } from './escalation/escalation.module';
 import { EventsModule } from './events/events.module';
+import { HealthModule } from './health/health.module';
 import { HospitalsModule } from './hospitals/hospitals.module';
+import { IncidentReviewsModule } from './incident-reviews/incident-reviews.module';
 import { InventoryModule } from './inventory/inventory.module';
 import { LocationHistoryModule } from './location-history/location-history.module';
 import { MapsModule } from './maps/maps.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { OnboardingModule } from './onboarding/onboarding.module';
+import { OrdersModule } from './orders/orders.module';
+import { OrganizationsModule } from './organizations/organizations.module';
 import { PolicyCenterModule } from './policy-center/policy-center.module';
 import { ProofBundleModule } from './proof-bundle/proof-bundle.module';
+import { ReadinessModule } from './readiness/readiness.module';
 import { ReconciliationModule } from './reconciliation/reconciliation.module';
+import { RedisModule } from './redis/redis.module';
+import { RegionsModule } from './regions/regions.module';
+import { ReportingModule } from './reporting/reporting.module';
+import { ReputationModule } from './reputation/reputation.module';
+import { RidersModule } from './riders/riders.module';
 import { RouteDeviationModule } from './route-deviation/route-deviation.module';
 import { FileMetadataModule } from './file-metadata/file-metadata.module';
+import { SlaModule } from './sla/sla.module';
+import { SorobanModule } from './soroban/soroban.module';
+import { SurgeSimulationModule } from './surge-simulation/surge-simulation.module';
+import { THROTTLE_TTL_MS } from './config/throttle-limits.config';
 import { TrackingModule } from './tracking/tracking.module';
 import { TransparencyModule } from './transparency/transparency.module';
 import { UserActivityModule } from './user-activity/user-activity.module';
 import { UsersModule } from './users/users.module';
+import { UssdModule } from './ussd/ussd.module';
+// UssdSessionModule (ussd-session/) is excluded: its UssdService injects IOrderService
+// by interface type which is erased at runtime and cannot be resolved by NestJS DI
+// without a concrete token. Deferred until the module is refactored to use a
+// proper injection token (e.g. Symbol('ORDER_SERVICE') or a concrete class).
 import { WorkflowModule } from './workflow/workflow.module';
+import { RoleAwareThrottlerGuard } from './throttler/role-aware-throttler.guard';
+import { throttleGetTracker } from './throttler/throttle-tracker.util';
 
 import type Redis from 'ioredis';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    // ── Single authoritative configuration bootstrap ──────────────────────
+    // AppConfigModule wraps ConfigModule.forRoot with env validation.
+    // All other modules that need ConfigService import ConfigModule (not forRoot)
+    // to receive the already-initialised global config.
+    AppConfigModule,
+
     EventEmitterModule.forRoot(),
+
     // Global BullMQ Redis connection — individual modules register their own queues
     BullModule.forRootAsync({
-      imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
         connection: {
           host: configService.get<string>('REDIS_HOST', 'localhost'),
@@ -60,27 +94,36 @@ import type Redis from 'ioredis';
       }),
       inject: [ConfigService],
     }),
+
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: (config: ConfigService) => ({
-        type: 'postgres',
-        host: config.get<string>('DB_HOST', 'localhost'),
-        port: config.get<number>('DB_PORT', 5432),
-        username: config.get<string>('DB_USERNAME', 'postgres'),
-        password: config.get<string>('DB_PASSWORD', 'postgres'),
-        database: config.get<string>('DB_DATABASE', 'health_chain'),
-        autoLoadEntities: true,
-        synchronize: true, // DEV ONLY
-      }),
+      useFactory: (config: ConfigService) => {
+        const nodeEnv = config.get<string>('NODE_ENV', 'development');
+        // synchronize is only permitted in local development/test environments.
+        // DatabaseSyncGuard.validateSynchronizeConfig is called in main.ts before
+        // the app initialises, so this value is already validated at bootstrap.
+        const synchronize = nodeEnv === 'development' || nodeEnv === 'test';
+        return {
+          type: 'postgres',
+          host: config.get<string>('DATABASE_HOST', 'localhost'),
+          port: config.get<number>('DATABASE_PORT', 5432),
+          username: config.get<string>('DATABASE_USERNAME', 'postgres'),
+          password: config.get<string>('DATABASE_PASSWORD', ''),
+          database: config.get<string>('DATABASE_NAME'),
+          autoLoadEntities: true,
+          synchronize,
+          migrations: ['dist/migrations/*.js'],
+          migrationsRun: false,
+        };
+      },
       inject: [ConfigService],
     }),
+
     /**
      * ThrottlerModule with Redis storage for distributed rate limiting.
      * Per-role limits are resolved at request time by RoleAwareThrottlerGuard;
      * the base limit here acts as a fallback only.
      */
     ThrottlerModule.forRootAsync({
-      imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
         throttlers: [
@@ -98,31 +141,61 @@ import type Redis from 'ioredis';
         getTracker: throttleGetTracker,
       }),
     }),
+
+    // ── Core infrastructure ───────────────────────────────────────────────
+    RedisModule,
     UsersModule,
     AuthModule,
-    InventoryModule,
-    NotificationsModule,
-    UserActivityModule,
-    EventsModule,
-    TrackingModule,
+
+    // ── Health & observability ────────────────────────────────────────────
+    HealthModule,
+
+    // ── Domain modules ────────────────────────────────────────────────────
     AnomalyModule,
+    ApprovalModule,
     BatchImportModule,
-    WorkflowModule,
+    BlockchainModule,
     BloodRequestsModule,
     BloodUnitsModule,
-    BlockchainModule,
+    ColdChainModule,
+    ContractEventIndexerModule,
+    CustodyModule,
+    DeliveryProofModule,
     DispatchModule,
-    EscalationModule,
+    DisputesModule,
+    DonationModule,
+    DonorEligibilityModule,
     DonorImpactModule,
-    LocationHistoryModule,
-    HospitalsModule,
-    MapsModule,
-    TransparencyModule,
-    ProofBundleModule,
-    PolicyCenterModule,
-    ReconciliationModule,
-    RouteDeviationModule,
+    EscalationModule,
+    EventsModule,
     FileMetadataModule,
+    HospitalsModule,
+    IncidentReviewsModule,
+    InventoryModule,
+    LocationHistoryModule,
+    MapsModule,
+    NotificationsModule,
+    OnboardingModule,
+    OrdersModule,
+    OrganizationsModule,
+    PolicyCenterModule,
+    ProofBundleModule,
+    ReadinessModule,
+    ReconciliationModule,
+    RegionsModule,
+    ReportingModule,
+    ReputationModule,
+    RidersModule,
+    RouteDeviationModule,
+    SlaModule,
+    SorobanModule,
+    SurgeSimulationModule,
+    TrackingModule,
+    TransparencyModule,
+    UserActivityModule,
+    UssdModule,
+    WorkflowModule,
+    AuditLogModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,0 +1,29 @@
+/**
+ * TypeORM DataSource used exclusively by the TypeORM CLI for migrations.
+ * Not imported by the NestJS application — the app uses TypeOrmModule.forRootAsync.
+ *
+ * Usage:
+ *   npm run build
+ *   npm run migration:run      # apply pending migrations
+ *   npm run migration:revert   # roll back the last migration
+ *   npm run migration:generate src/migrations/<Name>  # generate from entity diff
+ *   npm run migration:create   src/migrations/<Name>  # empty migration scaffold
+ */
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DATABASE_HOST ?? 'localhost',
+  port: Number(process.env.DATABASE_PORT ?? 5432),
+  username: process.env.DATABASE_USERNAME ?? 'postgres',
+  password: process.env.DATABASE_PASSWORD ?? '',
+  database: process.env.DATABASE_NAME ?? 'health_chain',
+  // Entities are loaded from compiled output so the CLI can resolve them
+  entities: ['dist/**/*.entity.js'],
+  migrations: ['dist/migrations/*.js'],
+  synchronize: false,
+  migrationsRun: false,
+});
+
+export default AppDataSource;

--- a/backend/src/incident-reviews/listeners/incident-scoring.listener.ts
+++ b/backend/src/incident-reviews/listeners/incident-scoring.listener.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { ReputationService } from '../../reputation/reputation.service';
+import { IncidentReviewsService } from '../incident-reviews.service';
+import { IncidentReviewClosedEvent } from '../events/incident-review-closed.event';
+
+/**
+ * Listens for closed incident reviews and applies a reputation penalty
+ * to the associated rider when the review is flagged as affecting scoring.
+ */
+@Injectable()
+export class IncidentScoringListener {
+  private readonly logger = new Logger(IncidentScoringListener.name);
+
+  constructor(
+    private readonly reputationService: ReputationService,
+    private readonly incidentReviewsService: IncidentReviewsService,
+  ) {}
+
+  @OnEvent('incident.review.closed')
+  async handleIncidentReviewClosed(
+    event: IncidentReviewClosedEvent,
+  ): Promise<void> {
+    if (!event.affectsScoring || !event.riderId) {
+      return;
+    }
+
+    try {
+      // Record as a failed delivery outcome to apply the reputation penalty
+      await this.reputationService.recordDelivery(
+        event.riderId,
+        event.orderId,
+        'failed',
+      );
+
+      await this.incidentReviewsService.markScoringApplied(event.reviewId);
+
+      this.logger.log(
+        `Scoring applied for incident review ${event.reviewId} on rider ${event.riderId}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to apply scoring for incident review ${event.reviewId}`,
+        err,
+      );
+    }
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { AppErrorFilter } from './common/filters/irrecoverable-error.filter';
 import { ValidationExceptionFilter } from './common/filters/validation-exception.filter';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
+import { DatabaseSyncGuard } from './config/database-sync.guard';
 import { validateEnv } from './config/validate-env';
 import { ThrottlerExceptionFilter } from './throttler/throttler-exception.filter';
 
@@ -19,6 +20,11 @@ async function bootstrap() {
   } catch {
     process.exit(1);
   }
+
+  // Fail fast if synchronize is enabled outside local environments.
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  const synchronize = nodeEnv === 'development' || nodeEnv === 'test';
+  DatabaseSyncGuard.validateSynchronizeConfig(nodeEnv, synchronize);
 
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);

--- a/backend/src/ussd-session/ussd.module.ts
+++ b/backend/src/ussd-session/ussd.module.ts
@@ -1,36 +1,57 @@
 import { Module } from '@nestjs/common';
 
-import { UssdSessionStore, REDIS_CLIENT } from './ussd-session.store';
+import { OrdersModule } from '../orders/orders.module';
+import { OrdersService } from '../orders/orders.service';
+import { RedisModule } from '../redis/redis.module';
+
+import { UssdSessionStore } from './ussd-session.store';
 import { UssdStateMachine } from './ussd-state-machine.service';
 import { UssdController } from './ussd.controller';
-import { UssdService } from './ussd.service';
+import { IOrderService, UssdService } from './ussd.service';
 
 /**
- * UssdModule wires together the USSD flow.
- *
- * Consumers must provide:
- *  1. REDIS_CLIENT token (ioredis Redis instance) – typically via a shared RedisModule
- *  2. ORDER_SERVICE token (IOrderService) – typically by importing OrdersModule
- *
- * Example registration in AppModule:
- *
- * @Module({
- *   imports: [
- *     RedisModule,   // must export REDIS_CLIENT
- *     OrdersModule,  // must export ORDER_SERVICE
- *     UssdModule,
- *   ],
- * })
+ * Adapts OrdersService to the IOrderService interface expected by UssdService.
+ * OrdersService.create() maps to IOrderService.createOrder().
  */
+class OrderServiceAdapter implements IOrderService {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  async createOrder(params: {
+    userId: string;
+    bloodType: string;
+    quantity: number;
+    bloodBankId: string;
+    channel: string;
+  }): Promise<{ id: string }> {
+    const order = await this.ordersService.create(
+      {
+        bloodType: params.bloodType,
+        quantity: params.quantity,
+        bloodBankId: params.bloodBankId,
+        channel: params.channel,
+      } as any,
+      params.userId,
+    );
+    return { id: order.id };
+  }
+}
+
 @Module({
+  imports: [
+    RedisModule,   // provides REDIS_CLIENT token for UssdSessionStore
+    OrdersModule,  // provides OrdersService
+  ],
   controllers: [UssdController],
   providers: [
-    UssdService,
     UssdStateMachine,
     UssdSessionStore,
-    // REDIS_CLIENT and ORDER_SERVICE are expected to be provided by the importing module.
-    // Register them in your root/feature module before importing UssdModule, or use
-    // forRootAsync() pattern if you prefer self-contained configuration.
+    {
+      provide: IOrderService as unknown as string,
+      useFactory: (ordersService: OrdersService) =>
+        new OrderServiceAdapter(ordersService),
+      inject: [OrdersService],
+    },
+    UssdService,
   ],
   exports: [UssdService],
 })


### PR DESCRIPTION
closes #550 
closes #551 
closes #552 
closes #553 

- Issue 1: Remove synchronize:true; derive from NODE_ENV (dev/test only); call DatabaseSyncGuard before bootstrap; add migration CLI scripts; add data-source.ts for TypeORM CLI
- Issue 2: Replace ConfigModule.forRoot with AppConfigModule as single authoritative config entry point
- Issue 3: Import HealthModule into AppModule so /health endpoints are live
- Issue 4: Wire all production modules into AppModule (orders, cold-chain, custody, disputes, delivery-proof, soroban, riders, regions, sla, reputation, onboarding, organizations, donations, surge-simulation, incident-reviews, readiness, donor-eligibility, approvals, reporting, ussd, contract-event-indexer); create missing IncidentScoringListener; document ussd-session exclusion (unresolvable interface DI token)