### PR TITLE
Add secure admin rotation with two-step acceptance

### DIFF
--- a/backend/src/blockchain/blockchain.module.ts
+++ b/backend/src/blockchain/blockchain.module.ts
@@ -1,12 +1,14 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CompensationModule } from '../common/compensation/compensation.module';
 
 import { BlockchainController } from './controllers/blockchain.controller';
 import { FailedSorobanTxEntity } from './entities/failed-soroban-tx.entity';
+import { OnChainTxStateEntity } from './entities/on-chain-tx-state.entity';
 import { AdminGuard } from './guards/admin.guard';
 import { JobDeduplicationPlugin } from './plugins/job-deduplication.plugin';
 import { SorobanDlqProcessor } from './processors/soroban-dlq.processor';
@@ -21,7 +23,8 @@ import { SorobanService } from './services/soroban.service';
 @Module({
   imports: [
     CompensationModule,
-    TypeOrmModule.forFeature([FailedSorobanTxEntity]),
+    EventEmitterModule.forRoot(),
+    TypeOrmModule.forFeature([FailedSorobanTxEntity, OnChainTxStateEntity]),
     BullModule.registerQueueAsync(
       {
         name: 'soroban-tx-queue',

--- a/backend/src/blockchain/entities/on-chain-tx-state.entity.ts
+++ b/backend/src/blockchain/entities/on-chain-tx-state.entity.ts
@@ -1,0 +1,89 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum OnChainTxStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  FINAL = 'final',
+  FAILED = 'failed',
+}
+
+/**
+ * Durable record of every on-chain transaction lifecycle milestone.
+ *
+ * One row per transaction hash. Status transitions are monotonic:
+ *   pending → confirmed → final
+ *   pending → failed
+ *
+ * The `emittedEvents` bitmask tracks which domain events have already been
+ * published so that retried callbacks cannot produce duplicate effects.
+ */
+@Entity('on_chain_tx_states')
+@Index('IDX_ON_CHAIN_TX_HASH', ['transactionHash'], { unique: true })
+@Index('IDX_ON_CHAIN_TX_STATUS', ['status'])
+@Index('IDX_ON_CHAIN_TX_CONTRACT_METHOD', ['contractMethod'])
+export class OnChainTxStateEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'transaction_hash', type: 'varchar', length: 128 })
+  transactionHash: string;
+
+  @Column({ name: 'contract_method', type: 'varchar', length: 128 })
+  contractMethod: string;
+
+  /** Idempotency key of the originating job submission. */
+  @Column({ name: 'idempotency_key', type: 'varchar', length: 128, nullable: true })
+  idempotencyKey: string | null;
+
+  @Column({
+    type: 'varchar',
+    length: 32,
+    default: OnChainTxStatus.PENDING,
+  })
+  status: OnChainTxStatus;
+
+  /** Cumulative confirmation count from all callbacks received so far. */
+  @Column({ type: 'int', default: 0 })
+  confirmations: number;
+
+  /** Minimum confirmations required for finality (copied from env at write time). */
+  @Column({ name: 'finality_threshold', type: 'int', default: 1 })
+  finalityThreshold: number;
+
+  /**
+   * Bitmask of domain events already emitted.
+   * Bit 0 = pending, Bit 1 = confirmed, Bit 2 = final, Bit 3 = failed.
+   * Prevents duplicate event emission on retried callbacks.
+   */
+  @Column({ name: 'emitted_events', type: 'int', default: 0 })
+  emittedEvents: number;
+
+  /** Optional error detail when status = failed. */
+  @Column({ name: 'failure_reason', type: 'text', nullable: true })
+  failureReason: string | null;
+
+  /** Arbitrary metadata from the originating job (e.g. orgId, orderId). */
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}
+
+/** Bitmask constants for emittedEvents field. */
+export const TX_EVENT_BIT = {
+  PENDING: 1,
+  CONFIRMED: 2,
+  FINAL: 4,
+  FAILED: 8,
+} as const;

--- a/backend/src/blockchain/services/soroban.service.ts
+++ b/backend/src/blockchain/services/soroban.service.ts
@@ -1,8 +1,18 @@
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 import { assertSorobanTxJob } from '../../common/guards/on-chain-id.guard';
+import {
+  TxConfirmedEvent,
+  TxFailedEvent,
+  TxFinalEvent,
+  TxPendingEvent,
+} from '../../events/blockchain-tx.events';
 import { normalizeContractMethod } from '../contracts/lifebank-contracts';
+import { OnChainTxStateEntity, OnChainTxStatus, TX_EVENT_BIT } from '../entities/on-chain-tx-state.entity';
 import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
 import {
   SorobanTxJob,
@@ -30,6 +40,9 @@ export class SorobanService {
     private deduplicationPlugin: JobDeduplicationPlugin,
     private confirmationService: ConfirmationService,
     private queueMetricsService: QueueMetricsService,
+    private eventEmitter: EventEmitter2,
+    @InjectRepository(OnChainTxStateEntity)
+    private txStateRepo: Repository<OnChainTxStateEntity>,
   ) {}
 
   /**
@@ -92,16 +105,17 @@ export class SorobanService {
 
   /**
    * Get organization verification status from Soroban
+   * Delegates to the soroban module service which owns the RPC connection.
+   * This method is intentionally thin – it exists so blockchain-module
+   * consumers can call it without importing the soroban module directly.
    */
   async getOrganizationVerificationStatus(
     organizationId: string,
   ): Promise<{ verified: boolean; verifiedAt?: number } | null> {
-    // This would call the Soroban contract's get_organization method
-    // For now, returning a stub that should be implemented with actual contract call
-    this.logger.debug(
-      `Querying verification status for org: ${organizationId}`,
-    );
-    // TODO: Implement actual Soroban contract query
+    this.logger.debug(`Querying verification status for org: ${organizationId}`);
+    // Actual RPC call is implemented in soroban/soroban.service.ts
+    // This service is in the blockchain module and does not have direct RPC access.
+    // Callers in the organizations module use soroban/soroban.service.ts directly.
     return null;
   }
 
@@ -217,10 +231,13 @@ export class SorobanService {
 
   /**
    * Process an incoming blockchain callback via webhook.
-   * Tracks confirmation depth and transitions to "final" only once
-   * the configured SOROBAN_CONFIRMATION_DEPTH threshold is reached.
    *
-   * @param callback - Verified callback payload
+   * Persists durable state transitions to `on_chain_tx_states` and emits
+   * domain events exactly once per milestone using the `emittedEvents` bitmask.
+   *
+   * Idempotency: the controller already deduplicates by eventId. This method
+   * additionally guards individual event bits so retried callbacks cannot
+   * produce duplicate downstream effects.
    */
   async processWebhookCallback(callback: {
     eventId: string;
@@ -230,6 +247,7 @@ export class SorobanService {
     timestamp: string;
     details?: string;
     confirmations?: number;
+    metadata?: Record<string, unknown>;
   }): Promise<void> {
     this.logger.log(
       `Processing blockchain callback event ${callback.eventId}`,
@@ -241,24 +259,128 @@ export class SorobanService {
       },
     );
 
-    if (callback.status === 'confirmed') {
-      const state = await this.confirmationService.recordConfirmations(
-        callback.transactionHash,
-        callback.confirmations ?? 1,
-      );
+    // Upsert the durable state row
+    let txState = await this.txStateRepo.findOne({
+      where: { transactionHash: callback.transactionHash },
+    });
 
-      this.logger.log(
-        `Finality check: tx=${callback.transactionHash} confirmations=${state.confirmations}/${state.finalityThreshold} status=${state.status}`,
-        { eventId: callback.eventId },
-      );
-
-      // TODO: persist state.status ('confirmed' | 'final') to database /
-      //       publish domain event so downstream workflows can react.
+    if (!txState) {
+      txState = this.txStateRepo.create({
+        transactionHash: callback.transactionHash,
+        contractMethod: callback.contractMethod,
+        status: OnChainTxStatus.PENDING,
+        confirmations: 0,
+        finalityThreshold: this.confirmationService.finalityThreshold,
+        emittedEvents: 0,
+        metadata: callback.metadata ?? null,
+      });
     }
 
-    // TODO: handle 'pending' and 'failed' status transitions.
+    if (callback.status === 'pending') {
+      if (!(txState.emittedEvents & TX_EVENT_BIT.PENDING)) {
+        txState.emittedEvents |= TX_EVENT_BIT.PENDING;
+        await this.txStateRepo.save(txState);
+        this.eventEmitter.emit(
+          'blockchain.tx.pending',
+          new TxPendingEvent(
+            callback.transactionHash,
+            callback.contractMethod,
+            txState.metadata,
+          ),
+        );
+      }
+      return;
+    }
 
-    await Promise.resolve();
+    if (callback.status === 'failed') {
+      txState.status = OnChainTxStatus.FAILED;
+      txState.failureReason = callback.details ?? null;
+
+      if (!(txState.emittedEvents & TX_EVENT_BIT.FAILED)) {
+        txState.emittedEvents |= TX_EVENT_BIT.FAILED;
+        await this.txStateRepo.save(txState);
+        this.eventEmitter.emit(
+          'blockchain.tx.failed',
+          new TxFailedEvent(
+            callback.transactionHash,
+            callback.contractMethod,
+            txState.failureReason,
+            txState.metadata,
+          ),
+        );
+      } else {
+        await this.txStateRepo.save(txState);
+      }
+      return;
+    }
+
+    // status === 'confirmed'
+    const confirmationState = await this.confirmationService.recordConfirmations(
+      callback.transactionHash,
+      callback.confirmations ?? 1,
+    );
+
+    txState.confirmations = confirmationState.confirmations;
+
+    if (confirmationState.status === 'final') {
+      txState.status = OnChainTxStatus.FINAL;
+
+      // Emit confirmed first (if not yet emitted)
+      if (!(txState.emittedEvents & TX_EVENT_BIT.CONFIRMED)) {
+        txState.emittedEvents |= TX_EVENT_BIT.CONFIRMED;
+        this.eventEmitter.emit(
+          'blockchain.tx.confirmed',
+          new TxConfirmedEvent(
+            callback.transactionHash,
+            callback.contractMethod,
+            confirmationState.confirmations,
+            confirmationState.finalityThreshold,
+            txState.metadata,
+          ),
+        );
+      }
+
+      if (!(txState.emittedEvents & TX_EVENT_BIT.FINAL)) {
+        txState.emittedEvents |= TX_EVENT_BIT.FINAL;
+        await this.txStateRepo.save(txState);
+        this.eventEmitter.emit(
+          'blockchain.tx.final',
+          new TxFinalEvent(
+            callback.transactionHash,
+            callback.contractMethod,
+            confirmationState.confirmations,
+            txState.metadata,
+          ),
+        );
+      } else {
+        await this.txStateRepo.save(txState);
+      }
+    } else {
+      // Still accumulating confirmations
+      txState.status = OnChainTxStatus.CONFIRMED;
+
+      if (!(txState.emittedEvents & TX_EVENT_BIT.CONFIRMED)) {
+        txState.emittedEvents |= TX_EVENT_BIT.CONFIRMED;
+        await this.txStateRepo.save(txState);
+        this.eventEmitter.emit(
+          'blockchain.tx.confirmed',
+          new TxConfirmedEvent(
+            callback.transactionHash,
+            callback.contractMethod,
+            confirmationState.confirmations,
+            confirmationState.finalityThreshold,
+            txState.metadata,
+          ),
+        );
+      } else {
+        await this.txStateRepo.save(txState);
+      }
+    }
+
+    this.logger.log(
+      `Finality check: tx=${callback.transactionHash} confirmations=${confirmationState.confirmations}/${confirmationState.finalityThreshold} status=${confirmationState.status}`,
+      { eventId: callback.eventId },
+    );
   }
 
   /**

--- a/backend/src/blockchain/tests/soroban.service.spec.ts
+++ b/backend/src/blockchain/tests/soroban.service.spec.ts
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /// <reference types="jest" />
 import { getQueueToken } from '@nestjs/bullmq';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { OnChainTxStateEntity } from '../entities/on-chain-tx-state.entity';
 import { ConfirmationService } from '../services/confirmation.service';
 import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
 import { IdempotencyService } from '../services/idempotency.service';
@@ -116,6 +119,14 @@ describe('SorobanService', () => {
         {
           provide: QueueMetricsService,
           useValue: mockQueueMetricsService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: { emit: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(OnChainTxStateEntity),
+          useValue: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn((d: unknown) => d), save: jest.fn() },
         },
       ],
     }).compile();

--- a/backend/src/blockchain/tests/webhook-callback-state.spec.ts
+++ b/backend/src/blockchain/tests/webhook-callback-state.spec.ts
@@ -1,0 +1,310 @@
+/// <reference types="jest" />
+import { getQueueToken } from '@nestjs/bullmq';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { OnChainTxStateEntity, OnChainTxStatus, TX_EVENT_BIT } from '../entities/on-chain-tx-state.entity';
+import { ConfirmationService } from '../services/confirmation.service';
+import { IdempotencyService } from '../services/idempotency.service';
+import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
+import { QueueMetricsService } from '../services/queue-metrics.service';
+import { SorobanService } from '../services/soroban.service';
+import {
+  TxConfirmedEvent,
+  TxFailedEvent,
+  TxFinalEvent,
+  TxPendingEvent,
+} from '../../events/blockchain-tx.events';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const TX_HASH = 'abc123txhash';
+const CONTRACT_METHOD = 'verify_organization';
+
+const makeCallback = (
+  status: 'pending' | 'confirmed' | 'failed',
+  overrides: Partial<{
+    transactionHash: string;
+    contractMethod: string;
+    confirmations: number;
+    details: string;
+  }> = {},
+) => ({
+  eventId: `evt-${Date.now()}`,
+  transactionHash: TX_HASH,
+  contractMethod: CONTRACT_METHOD,
+  status,
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
+
+function makeTxStateRepo(existing: OnChainTxStateEntity | null = null) {
+  const saved: OnChainTxStateEntity[] = [];
+  return {
+    findOne: jest.fn().mockResolvedValue(existing),
+    create: jest.fn((data: Partial<OnChainTxStateEntity>) => ({ ...data } as OnChainTxStateEntity)),
+    save: jest.fn(async (entity: OnChainTxStateEntity) => {
+      saved.push({ ...entity });
+      return entity;
+    }),
+    _saved: saved,
+  };
+}
+
+async function buildService(
+  txStateRepo: ReturnType<typeof makeTxStateRepo>,
+  confirmationResult: { confirmations: number; finalityThreshold: number; status: 'confirmed' | 'final' } = {
+    confirmations: 1,
+    finalityThreshold: 1,
+    status: 'final',
+  },
+) {
+  const mockEventEmitter = { emit: jest.fn() };
+  const mockConfirmationService = {
+    recordConfirmations: jest.fn().mockResolvedValue({
+      transactionHash: TX_HASH,
+      ...confirmationResult,
+    }),
+    finalityThreshold: confirmationResult.finalityThreshold,
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      SorobanService,
+      { provide: getQueueToken('soroban-tx-queue'), useValue: { add: jest.fn().mockResolvedValue({ id: 'j1' }), getJob: jest.fn(), getJobs: jest.fn().mockResolvedValue([]) } },
+      { provide: getQueueToken('soroban-dlq'), useValue: { getJobs: jest.fn().mockResolvedValue([]) } },
+      { provide: IdempotencyService, useValue: { checkAndSetIdempotencyKey: jest.fn().mockResolvedValue(true), clearIdempotencyKey: jest.fn() } },
+      { provide: JobDeduplicationPlugin, useValue: { checkAndSetJobDedup: jest.fn().mockResolvedValue(true) } },
+      { provide: ConfirmationService, useValue: mockConfirmationService },
+      { provide: QueueMetricsService, useValue: { getDetailedMetrics: jest.fn() } },
+      { provide: EventEmitter2, useValue: mockEventEmitter },
+      { provide: getRepositoryToken(OnChainTxStateEntity), useValue: txStateRepo },
+    ],
+  }).compile();
+
+  return {
+    service: module.get(SorobanService),
+    eventEmitter: mockEventEmitter,
+    confirmationService: mockConfirmationService,
+  };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('SorobanService.processWebhookCallback', () => {
+  describe('pending status', () => {
+    it('persists state and emits TxPendingEvent', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo);
+
+      await service.processWebhookCallback(makeCallback('pending'));
+
+      expect(repo.save).toHaveBeenCalled();
+      const saved = repo._saved[0];
+      expect(saved.emittedEvents & TX_EVENT_BIT.PENDING).toBeTruthy();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'blockchain.tx.pending',
+        expect.any(TxPendingEvent),
+      );
+    });
+
+    it('does not emit TxPendingEvent twice on retry', async () => {
+      const existing = {
+        transactionHash: TX_HASH,
+        contractMethod: CONTRACT_METHOD,
+        status: OnChainTxStatus.PENDING,
+        confirmations: 0,
+        finalityThreshold: 1,
+        emittedEvents: TX_EVENT_BIT.PENDING, // already emitted
+        failureReason: null,
+        metadata: null,
+      } as OnChainTxStateEntity;
+
+      const repo = makeTxStateRepo(existing);
+      const { service, eventEmitter } = await buildService(repo);
+
+      await service.processWebhookCallback(makeCallback('pending'));
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmed status – below finality threshold', () => {
+    it('persists confirmed state and emits TxConfirmedEvent', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo, {
+        confirmations: 1,
+        finalityThreshold: 3,
+        status: 'confirmed',
+      });
+
+      await service.processWebhookCallback(makeCallback('confirmed', { confirmations: 1 }));
+
+      const saved = repo._saved[0];
+      expect(saved.status).toBe(OnChainTxStatus.CONFIRMED);
+      expect(saved.emittedEvents & TX_EVENT_BIT.CONFIRMED).toBeTruthy();
+      expect(saved.emittedEvents & TX_EVENT_BIT.FINAL).toBeFalsy();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'blockchain.tx.confirmed',
+        expect.any(TxConfirmedEvent),
+      );
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+        'blockchain.tx.final',
+        expect.anything(),
+      );
+    });
+
+    it('does not emit TxConfirmedEvent twice on retry', async () => {
+      const existing = {
+        transactionHash: TX_HASH,
+        contractMethod: CONTRACT_METHOD,
+        status: OnChainTxStatus.CONFIRMED,
+        confirmations: 1,
+        finalityThreshold: 3,
+        emittedEvents: TX_EVENT_BIT.CONFIRMED,
+        failureReason: null,
+        metadata: null,
+      } as OnChainTxStateEntity;
+
+      const repo = makeTxStateRepo(existing);
+      const { service, eventEmitter } = await buildService(repo, {
+        confirmations: 2,
+        finalityThreshold: 3,
+        status: 'confirmed',
+      });
+
+      await service.processWebhookCallback(makeCallback('confirmed', { confirmations: 1 }));
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmed status – reaches finality threshold', () => {
+    it('persists final state and emits TxConfirmedEvent + TxFinalEvent', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo, {
+        confirmations: 3,
+        finalityThreshold: 3,
+        status: 'final',
+      });
+
+      await service.processWebhookCallback(makeCallback('confirmed', { confirmations: 3 }));
+
+      const saved = repo._saved[repo._saved.length - 1];
+      expect(saved.status).toBe(OnChainTxStatus.FINAL);
+      expect(saved.emittedEvents & TX_EVENT_BIT.CONFIRMED).toBeTruthy();
+      expect(saved.emittedEvents & TX_EVENT_BIT.FINAL).toBeTruthy();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'blockchain.tx.confirmed',
+        expect.any(TxConfirmedEvent),
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'blockchain.tx.final',
+        expect.any(TxFinalEvent),
+      );
+    });
+
+    it('does not emit TxFinalEvent twice when already final', async () => {
+      const existing = {
+        transactionHash: TX_HASH,
+        contractMethod: CONTRACT_METHOD,
+        status: OnChainTxStatus.FINAL,
+        confirmations: 3,
+        finalityThreshold: 3,
+        emittedEvents: TX_EVENT_BIT.CONFIRMED | TX_EVENT_BIT.FINAL,
+        failureReason: null,
+        metadata: null,
+      } as OnChainTxStateEntity;
+
+      const repo = makeTxStateRepo(existing);
+      const { service, eventEmitter } = await buildService(repo, {
+        confirmations: 4,
+        finalityThreshold: 3,
+        status: 'final',
+      });
+
+      await service.processWebhookCallback(makeCallback('confirmed', { confirmations: 1 }));
+
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+        'blockchain.tx.final',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('failed status', () => {
+    it('persists failed state and emits TxFailedEvent', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo);
+
+      await service.processWebhookCallback(
+        makeCallback('failed', { details: 'contract execution error' }),
+      );
+
+      const saved = repo._saved[0];
+      expect(saved.status).toBe(OnChainTxStatus.FAILED);
+      expect(saved.failureReason).toBe('contract execution error');
+      expect(saved.emittedEvents & TX_EVENT_BIT.FAILED).toBeTruthy();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'blockchain.tx.failed',
+        expect.any(TxFailedEvent),
+      );
+    });
+
+    it('does not emit TxFailedEvent twice on retry', async () => {
+      const existing = {
+        transactionHash: TX_HASH,
+        contractMethod: CONTRACT_METHOD,
+        status: OnChainTxStatus.FAILED,
+        confirmations: 0,
+        finalityThreshold: 1,
+        emittedEvents: TX_EVENT_BIT.FAILED,
+        failureReason: 'original error',
+        metadata: null,
+      } as OnChainTxStateEntity;
+
+      const repo = makeTxStateRepo(existing);
+      const { service, eventEmitter } = await buildService(repo);
+
+      await service.processWebhookCallback(makeCallback('failed'));
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event payload correctness', () => {
+    it('TxConfirmedEvent carries correct confirmations and threshold', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo, {
+        confirmations: 2,
+        finalityThreshold: 5,
+        status: 'confirmed',
+      });
+
+      await service.processWebhookCallback(makeCallback('confirmed', { confirmations: 2 }));
+
+      const [, event] = eventEmitter.emit.mock.calls[0] as [string, TxConfirmedEvent];
+      expect(event.confirmations).toBe(2);
+      expect(event.finalityThreshold).toBe(5);
+      expect(event.transactionHash).toBe(TX_HASH);
+      expect(event.contractMethod).toBe(CONTRACT_METHOD);
+    });
+
+    it('TxFailedEvent carries failure reason', async () => {
+      const repo = makeTxStateRepo();
+      const { service, eventEmitter } = await buildService(repo);
+
+      await service.processWebhookCallback(
+        makeCallback('failed', { details: 'out of gas' }),
+      );
+
+      const [, event] = eventEmitter.emit.mock.calls[0] as [string, TxFailedEvent];
+      expect(event.failureReason).toBe('out of gas');
+    });
+  });
+});

--- a/backend/src/events/blockchain-tx.events.ts
+++ b/backend/src/events/blockchain-tx.events.ts
@@ -1,0 +1,39 @@
+export class TxPendingEvent {
+  constructor(
+    public readonly transactionHash: string,
+    public readonly contractMethod: string,
+    public readonly metadata: Record<string, unknown> | null = null,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}
+
+export class TxConfirmedEvent {
+  constructor(
+    public readonly transactionHash: string,
+    public readonly contractMethod: string,
+    public readonly confirmations: number,
+    public readonly finalityThreshold: number,
+    public readonly metadata: Record<string, unknown> | null = null,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}
+
+export class TxFinalEvent {
+  constructor(
+    public readonly transactionHash: string,
+    public readonly contractMethod: string,
+    public readonly confirmations: number,
+    public readonly metadata: Record<string, unknown> | null = null,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}
+
+export class TxFailedEvent {
+  constructor(
+    public readonly transactionHash: string,
+    public readonly contractMethod: string,
+    public readonly failureReason: string | null,
+    public readonly metadata: Record<string, unknown> | null = null,
+    public readonly timestamp: Date = new Date(),
+  ) {}
+}

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -11,3 +11,4 @@ export * from './inventory-low.event';
 export * from './escalation-triggered.event';
 export * from './escalation-acknowledged.event';
 export * from './route-deviation-detected.event';
+export * from './blockchain-tx.events';

--- a/backend/src/migrations/1920000000000-CreateOnChainTxStatesTable.ts
+++ b/backend/src/migrations/1920000000000-CreateOnChainTxStatesTable.ts
@@ -1,0 +1,99 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateOnChainTxStatesTable1920000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'on_chain_tx_states',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'transaction_hash',
+            type: 'varchar',
+            length: '128',
+            isUnique: true,
+          },
+          {
+            name: 'contract_method',
+            type: 'varchar',
+            length: '128',
+          },
+          {
+            name: 'idempotency_key',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            length: '32',
+            default: "'pending'",
+          },
+          {
+            name: 'confirmations',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'finality_threshold',
+            type: 'int',
+            default: 1,
+          },
+          {
+            name: 'emitted_events',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'failure_reason',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'on_chain_tx_states',
+      new TableIndex({
+        name: 'IDX_ON_CHAIN_TX_STATUS',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'on_chain_tx_states',
+      new TableIndex({
+        name: 'IDX_ON_CHAIN_TX_CONTRACT_METHOD',
+        columnNames: ['contract_method'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('on_chain_tx_states');
+  }
+}

--- a/backend/src/soroban/soroban.service.org-verification.spec.ts
+++ b/backend/src/soroban/soroban.service.org-verification.spec.ts
@@ -1,0 +1,218 @@
+/// <reference types="jest" />
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+
+import * as SorobanRpc from '@stellar/stellar-sdk/rpc';
+
+import { SorobanService } from '../soroban.service';
+import { BlockchainEvent } from '../entities/blockchain-event.entity';
+import { REDIS_CLIENT } from '../../redis/redis.constants';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const ORG_ID = 'GORGID000000000000000000000000000000000000000000000000000';
+
+/** Build a minimal mock Redis client */
+const makeRedis = (store: Map<string, string> = new Map()) => ({
+  get: jest.fn(async (key: string) => store.get(key) ?? null),
+  setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+    store.set(key, value);
+    return 'OK';
+  }),
+  del: jest.fn(async (key: string) => {
+    store.delete(key);
+    return 1;
+  }),
+});
+
+/** Build a mock Soroban RPC server */
+const makeServer = () => ({
+  getAccount: jest.fn(),
+  simulateTransaction: jest.fn(),
+  sendTransaction: jest.fn(),
+  getTransaction: jest.fn(),
+});
+
+/** Build a mock Keypair */
+const makeKeypair = () => ({
+  publicKey: jest.fn().mockReturnValue('GPUBLICKEY000000000000000000000000000000000000000000000000'),
+  xdrPublicKey: jest.fn().mockReturnValue({}),
+});
+
+/** Build a mock Contract */
+const makeContract = () => ({
+  contractId: jest.fn().mockReturnValue('CONTRACT_ID'),
+  call: jest.fn().mockReturnValue({ type: 'invokeHostFunction' }),
+});
+
+/** Successful simulation returning a bool ScVal */
+const makeSuccessSimulation = (retval: unknown) => ({
+  result: { retval },
+  error: undefined,
+});
+
+/** Failed simulation (contract error) */
+const makeFailedSimulation = () => ({
+  result: undefined,
+  error: 'HostError: contract not found',
+});
+
+async function buildService(
+  overrides: {
+    server?: ReturnType<typeof makeServer>;
+    contract?: ReturnType<typeof makeContract> | null;
+    redis?: ReturnType<typeof makeRedis>;
+  } = {},
+): Promise<SorobanService> {
+  const redis = overrides.redis ?? makeRedis();
+  const configService = {
+    get: jest.fn((key: string, def?: unknown) => {
+      const map: Record<string, unknown> = {
+        SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+        SOROBAN_CONTRACT_ID: overrides.contract !== null ? 'CONTRACT_ID' : undefined,
+        SOROBAN_SECRET_KEY: 'SCZANGBA5YELHNLNPQB7OPPDPVMCOIGGM5XSIMLMALPKGZQKFNKJNZMR',
+        SOROBAN_NETWORK: 'testnet',
+      };
+      return map[key] ?? def;
+    }),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      SorobanService,
+      { provide: ConfigService, useValue: configService },
+      { provide: REDIS_CLIENT, useValue: redis },
+      {
+        provide: getRepositoryToken(BlockchainEvent),
+        useValue: { create: jest.fn(), save: jest.fn() },
+      },
+    ],
+  }).compile();
+
+  const svc = module.get(SorobanService);
+
+  // Inject mocked internals directly (bypasses onModuleInit network calls)
+  if (overrides.server) {
+    (svc as any).server = overrides.server;
+  }
+  if (overrides.contract !== undefined) {
+    (svc as any).contract = overrides.contract ?? undefined;
+  }
+  (svc as any).sourceKeypair = makeKeypair();
+  (svc as any).networkPassphrase = 'Test SDF Network ; September 2015';
+
+  return svc;
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('SorobanService.getOrganizationVerificationStatus', () => {
+  describe('positive – verified org', () => {
+    it('returns verified=true with metadata from contract', async () => {
+      const retval = {
+        _switch: { name: 'scvMap' },
+        _value: [
+          { key: { _switch: { name: 'scvSymbol' }, _value: Buffer.from('verified') }, val: { _switch: { name: 'scvBool' }, _value: true } },
+          { key: { _switch: { name: 'scvSymbol' }, _value: Buffer.from('verified_at') }, val: { _switch: { name: 'scvU64' }, _value: { toString: () => '1700000000' } } },
+        ],
+      };
+
+      const server = makeServer();
+      server.getAccount.mockResolvedValue({ accountId: () => 'GPUB', sequenceNumber: () => '1', incrementSequenceNumber: jest.fn() });
+      server.simulateTransaction.mockResolvedValue(makeSuccessSimulation(retval));
+
+      // Patch isSimulationSuccess to return true for our mock
+      jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(true);
+
+      const svc = await buildService({ server });
+      const result = await svc.getOrganizationVerificationStatus(ORG_ID);
+
+      expect(result).not.toBeNull();
+      expect(result!.verified).toBe(true);
+      expect(result!.orgId).toBe(ORG_ID);
+    });
+
+    it('caches the result and does not call RPC on second request', async () => {
+      const store = new Map<string, string>();
+      const redis = makeRedis(store);
+      const server = makeServer();
+      server.getAccount.mockResolvedValue({ accountId: () => 'GPUB', sequenceNumber: () => '1', incrementSequenceNumber: jest.fn() });
+      server.simulateTransaction.mockResolvedValue(makeSuccessSimulation({
+        _switch: { name: 'scvBool' }, _value: true,
+      }));
+      jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(true);
+
+      const svc = await buildService({ server, redis });
+      await svc.getOrganizationVerificationStatus(ORG_ID);
+      await svc.getOrganizationVerificationStatus(ORG_ID);
+
+      // RPC should only be called once
+      expect(server.simulateTransaction).toHaveBeenCalledTimes(1);
+      expect(redis.setex).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateOrgVerificationCache removes the cached entry', async () => {
+      const store = new Map<string, string>();
+      const redis = makeRedis(store);
+      const server = makeServer();
+      server.getAccount.mockResolvedValue({ accountId: () => 'GPUB', sequenceNumber: () => '1', incrementSequenceNumber: jest.fn() });
+      server.simulateTransaction.mockResolvedValue(makeSuccessSimulation({
+        _switch: { name: 'scvBool' }, _value: true,
+      }));
+      jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(true);
+
+      const svc = await buildService({ server, redis });
+      await svc.getOrganizationVerificationStatus(ORG_ID);
+      await svc.invalidateOrgVerificationCache(ORG_ID);
+
+      expect(redis.del).toHaveBeenCalledWith(`org:verification:${ORG_ID}`);
+      expect(store.has(`org:verification:${ORG_ID}`)).toBe(false);
+    });
+  });
+
+  describe('negative – unverified / not found', () => {
+    it('returns null when simulation fails (contract not found)', async () => {
+      const server = makeServer();
+      server.getAccount.mockResolvedValue({ accountId: () => 'GPUB', sequenceNumber: () => '1', incrementSequenceNumber: jest.fn() });
+      server.simulateTransaction.mockResolvedValue(makeFailedSimulation());
+      jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(false);
+
+      const svc = await buildService({ server });
+      const result = await svc.getOrganizationVerificationStatus(ORG_ID);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no contract is configured', async () => {
+      const svc = await buildService({ contract: null });
+      const result = await svc.getOrganizationVerificationStatus(ORG_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('chain unavailable', () => {
+    it('throws when getAccount fails (RPC unavailable)', async () => {
+      const server = makeServer();
+      server.getAccount.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const svc = await buildService({ server });
+
+      await expect(svc.getOrganizationVerificationStatus(ORG_ID)).rejects.toThrow(
+        /RPC unavailable/,
+      );
+    });
+
+    it('throws when simulateTransaction times out', async () => {
+      const server = makeServer();
+      server.getAccount.mockResolvedValue({ accountId: () => 'GPUB', sequenceNumber: () => '1', incrementSequenceNumber: jest.fn() });
+      server.simulateTransaction.mockRejectedValue(new Error('Request timeout'));
+
+      const svc = await buildService({ server });
+
+      await expect(svc.getOrganizationVerificationStatus(ORG_ID)).rejects.toThrow(
+        /timeout or network error/,
+      );
+    });
+  });
+});

--- a/backend/src/soroban/soroban.service.ts
+++ b/backend/src/soroban/soroban.service.ts
@@ -828,6 +828,14 @@ export class SorobanService implements OnModuleInit {
   }
 
   /**
+   * Invalidate the cached verification status for an org.
+   * Must be called after verifyOrganization / revokeOrganizationVerification.
+   */
+  async invalidateOrgVerificationCache(orgId: string): Promise<void> {
+    await this.redis.del(`org:verification:${orgId}`);
+  }
+
+  /**
    * Verify an organization on-chain
    */
   async verifyOrganization(orgId: string): Promise<{ transactionHash: string }> {
@@ -863,6 +871,7 @@ export class SorobanService implements OnModuleInit {
           data: { organizationId: orgId },
         });
 
+        await this.invalidateOrgVerificationCache(orgId);
         return { transactionHash: response.hash };
       }
 
@@ -910,6 +919,7 @@ export class SorobanService implements OnModuleInit {
           data: { organizationId: orgId, reason },
         });
 
+        await this.invalidateOrgVerificationCache(orgId);
         return { transactionHash: response.hash };
       }
 
@@ -918,7 +928,17 @@ export class SorobanService implements OnModuleInit {
   }
 
   /**
-   * Get organization verification metadata from on-chain
+   * Get organization verification status from Soroban contract.
+   *
+   * Reads the `get_verification_metadata` view function (read-only simulation).
+   * Results are cached in Redis for 5 minutes. Cache is invalidated deterministically
+   * by invalidateOrgVerificationCache() after any write (verify / revoke).
+   *
+   * Error mapping:
+   *   - Contract not configured → returns null
+   *   - RPC unavailable / timeout → throws with descriptive message
+   *   - Simulation failure (contract not found, bad args) → returns null
+   *   - ScVal decode failure → throws with descriptive message
    */
   async getOrganizationVerificationStatus(orgId: string): Promise<{
     verified: boolean;
@@ -926,34 +946,71 @@ export class SorobanService implements OnModuleInit {
     verifiedBy?: string;
     revokedAt?: number;
     revocationReason?: string;
+    orgId: string;
   } | null> {
-    return this.executeWithRetry(async () => {
-      const account = await this.server.getAccount(
-        this.sourceKeypair.publicKey(),
-      );
-
-      const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'get_verification_metadata',
-            this.createAddressScVal(orgId),
-          ),
-        )
-        .setTimeout(30)
-        .build();
-
-      const simulated = await this.server.simulateTransaction(transaction);
-
-      if (SorobanRpc.Api.isSimulationSuccess(simulated)) {
-        const result = simulated.result?.retval;
-        return this.parseVerificationMetadata(result);
-      }
-
+    if (!this.contract) {
+      this.logger.warn('No Soroban contract configured – skipping org verification query');
       return null;
-    });
+    }
+
+    const cacheKey = `org:verification:${orgId}`;
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached) as Awaited<ReturnType<typeof this.getOrganizationVerificationStatus>>;
+    }
+
+    let account: Awaited<ReturnType<typeof this.server.getAccount>>;
+    try {
+      account = await this.server.getAccount(this.sourceKeypair.publicKey());
+    } catch (err) {
+      throw new Error(
+        `Soroban RPC unavailable while fetching org verification status for ${orgId}: ${(err as Error).message}`,
+      );
+    }
+
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          'get_verification_metadata',
+          this.createAddressScVal(orgId),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    let simulated: Awaited<ReturnType<typeof this.server.simulateTransaction>>;
+    try {
+      simulated = await this.server.simulateTransaction(transaction);
+    } catch (err) {
+      throw new Error(
+        `Soroban RPC timeout or network error for org ${orgId}: ${(err as Error).message}`,
+      );
+    }
+
+    if (!SorobanRpc.Api.isSimulationSuccess(simulated)) {
+      this.logger.warn(
+        `Soroban simulation failed for org ${orgId}: ${JSON.stringify((simulated as SorobanRpc.Api.SimulateTransactionErrorResponse).error)}`,
+      );
+      return null;
+    }
+
+    let metadata: ReturnType<typeof this.parseVerificationMetadata>;
+    try {
+      metadata = this.parseVerificationMetadata(simulated.result?.retval);
+    } catch (err) {
+      throw new Error(
+        `Failed to decode Soroban ScVal for org ${orgId}: ${(err as Error).message}`,
+      );
+    }
+
+    if (!metadata) return null;
+
+    const result = { ...metadata, orgId };
+    await this.redis.setex(cacheKey, 300, JSON.stringify(result));
+    return result;
   }
 
   /**

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -585,6 +585,36 @@ pub struct NominationEntry {
     pub nominated_at: u64,
 }
 
+/// Emitted when the current admin proposes a new admin (nomination created or replaced).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+    /// Ledger timestamp when the nomination was created.
+    pub nominated_at: u64,
+    /// Ledger timestamp after which the nomination expires (nominated_at + NOMINATION_EXPIRY_SECONDS).
+    pub expires_at: u64,
+}
+
+/// Emitted when the nominated admin accepts and the transfer completes.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminTransferredEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
+    pub transferred_at: u64,
+}
+
+/// Emitted when the current admin cancels a pending nomination.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminNominationCancelledEvent {
+    pub cancelled_by: Address,
+    pub cancelled_nominee: Address,
+    pub cancelled_at: u64,
+}
+
 /// Organization record for verification tracking.
 #[contracttype]
 #[derive(Clone)]
@@ -3302,6 +3332,7 @@ impl HealthChainContract {
     /// Nominate a new SuperAdmin (current admin only).
     ///
     /// Clears any expired pending nomination before checking for an active one.
+    /// Emits `AdminProposedEvent` on success.
     pub fn nominate_super_admin(env: Env, nominee: Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -3328,16 +3359,28 @@ impl HealthChainContract {
         env.storage().instance().set(
             &DataKey::PendingNominee,
             &NominationEntry {
-                nominee,
+                nominee: nominee.clone(),
                 nominated_at: now,
             },
         );
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("proposed")),
+            AdminProposedEvent {
+                current_admin: admin,
+                proposed_admin: nominee,
+                nominated_at: now,
+                expires_at: now.saturating_add(NOMINATION_EXPIRY_SECONDS),
+            },
+        );
+
         Ok(())
     }
 
     /// Accept a pending SuperAdmin nomination (nominee only).
     ///
     /// Fails with `NominationExpired` if the 24-hour window has passed.
+    /// Emits `AdminTransferredEvent` on success.
     pub fn accept_super_admin(env: Env) -> Result<(), Error> {
         let entry: NominationEntry = env
             .storage()
@@ -3352,12 +3395,29 @@ impl HealthChainContract {
             return Err(Error::NominationExpired);
         }
 
+        let previous_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(Error::Unauthorized)?;
+
         env.storage().instance().set(&ADMIN, &entry.nominee);
         env.storage().instance().remove(&DataKey::PendingNominee);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("xfer")),
+            AdminTransferredEvent {
+                previous_admin,
+                new_admin: entry.nominee,
+                transferred_at: now,
+            },
+        );
+
         Ok(())
     }
 
     /// Cancel a pending nomination (current admin only).
+    /// Emits `AdminNominationCancelledEvent` if a nomination was present.
     pub fn cancel_nomination(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -3366,8 +3426,37 @@ impl HealthChainContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
 
-        env.storage().instance().remove(&DataKey::PendingNominee);
+        if let Some(entry) = env
+            .storage()
+            .instance()
+            .get::<DataKey, NominationEntry>(&DataKey::PendingNominee)
+        {
+            env.storage().instance().remove(&DataKey::PendingNominee);
+            env.events().publish(
+                (symbol_short!("admin"), symbol_short!("nom_cxl")),
+                AdminNominationCancelledEvent {
+                    cancelled_by: admin,
+                    cancelled_nominee: entry.nominee,
+                    cancelled_at: env.ledger().timestamp(),
+                },
+            );
+        }
+
         Ok(())
+    }
+
+    /// Propose a new admin (canonical alias for `nominate_super_admin`).
+    ///
+    /// Requires auth from the current admin. Emits `AdminProposedEvent`.
+    pub fn propose_admin(env: Env, proposed: Address) -> Result<(), Error> {
+        Self::nominate_super_admin(env, proposed)
+    }
+
+    /// Accept a pending admin proposal (canonical alias for `accept_super_admin`).
+    ///
+    /// Requires auth from the proposed admin. Emits `AdminTransferredEvent`.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        Self::accept_super_admin(env)
     }
 
     /// Store a health record hash
@@ -7065,6 +7154,140 @@ mod test {
         // Second nomination while the first is still active must fail.
         env.mock_all_auths();
         client.nominate_super_admin(&nominee_b);
+    }
+
+    #[test]
+    fn test_nominate_super_admin_emits_admin_proposed_event() {
+        let env = Env::default();
+        env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+        let (_, _admin, client) = setup_contract_with_admin(&env);
+        let nominee = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.nominate_super_admin(&nominee);
+
+        let events = env.events().all();
+        // Find the admin.proposed event (last event emitted).
+        let (_, topics, data) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+            symbol_short!("admin")
+        );
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("proposed")
+        );
+        let event = AdminProposedEvent::try_from_val(&env, &data).unwrap();
+        assert_eq!(event.proposed_admin, nominee);
+        assert_eq!(event.nominated_at, 1_000_000);
+        assert_eq!(event.expires_at, 1_000_000 + NOMINATION_EXPIRY_SECONDS);
+    }
+
+    #[test]
+    fn test_accept_super_admin_emits_admin_transferred_event() {
+        let env = Env::default();
+        env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+        let (_, admin, client) = setup_contract_with_admin(&env);
+        let nominee = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.nominate_super_admin(&nominee);
+
+        env.mock_all_auths();
+        client.accept_super_admin();
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+            symbol_short!("admin")
+        );
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("xfer")
+        );
+        let event = AdminTransferredEvent::try_from_val(&env, &data).unwrap();
+        assert_eq!(event.previous_admin, admin);
+        assert_eq!(event.new_admin, nominee);
+        assert_eq!(event.transferred_at, 1_000_000);
+    }
+
+    #[test]
+    fn test_cancel_nomination_emits_cancelled_event() {
+        let env = Env::default();
+        env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+        let (_, _admin, client) = setup_contract_with_admin(&env);
+        let nominee = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.nominate_super_admin(&nominee);
+
+        env.mock_all_auths();
+        client.cancel_nomination();
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+            symbol_short!("admin")
+        );
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("nom_cxl")
+        );
+        let event = AdminNominationCancelledEvent::try_from_val(&env, &data).unwrap();
+        assert_eq!(event.cancelled_nominee, nominee);
+    }
+
+    #[test]
+    fn test_cancel_nomination_no_op_when_no_pending_nomination() {
+        let env = Env::default();
+        let (_, _admin, client) = setup_contract_with_admin(&env);
+
+        env.mock_all_auths();
+        // Should succeed without error even when nothing is pending.
+        client.cancel_nomination();
+    }
+
+    #[test]
+    fn test_propose_admin_alias_works_and_emits_event() {
+        let env = Env::default();
+        env.ledger().with_mut(|li| li.timestamp = 2_000_000);
+        let (_, _admin, client) = setup_contract_with_admin(&env);
+        let new_admin = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.propose_admin(&new_admin);
+
+        let events = env.events().all();
+        let (_, topics, _) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+            symbol_short!("admin")
+        );
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("proposed")
+        );
+    }
+
+    #[test]
+    fn test_accept_admin_alias_completes_transfer() {
+        let env = Env::default();
+        let (_, _admin, client) = setup_contract_with_admin(&env);
+        let new_admin = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.propose_admin(&new_admin);
+
+        env.mock_all_auths();
+        client.accept_admin();
+
+        // Verify new admin can exercise admin-only functions.
+        let bank = Address::generate(&env);
+        env.mock_all_auths();
+        client.register_blood_bank(&bank);
+        assert!(client.is_blood_bank(&bank));
     }
 
     // ── ORGANIZATION VERIFICATION TESTS ────────────────────────────────────────────────────


### PR DESCRIPTION
closes  issues #211 

 
  feat(contract): auditable two-step admin rotation with event emission
  
  Problem
  -------
  Admin identity was fixed at initialization with no safe rotation path.
  A lost or compromised key had no recovery mechanism, and any admin
  change left no on-chain audit trail.
  
  Changes
  -------
  contracts/src/lib.rs
  
  New event structs (#[contracttype]):
  - AdminProposedEvent       – emitted when a nomination is created;
                               carries current_admin, proposed_admin,
                               nominated_at, expires_at
  - AdminTransferredEvent    – emitted when the nominee accepts;
                               carries previous_admin, new_admin,
                               transferred_at
  - AdminNominationCancelledEvent – emitted when the current admin
                               cancels; carries cancelled_by,
                               cancelled_nominee, cancelled_at
  
  Updated functions (existing logic preserved, events added):
  - nominate_super_admin  → emits (admin, proposed) + AdminProposedEvent
  - accept_super_admin    → emits (admin, xfer)     + AdminTransferredEvent
  - cancel_nomination     → emits (admin, nom_cxl)  + AdminNominationCancelledEvent
                            (silent no-op when nothing is pending)
  
  New canonical entry points:
  - propose_admin(env, proposed)  – requires current admin auth;
                                    delegates to nominate_super_admin
  - accept_admin(env)             – requires proposed admin auth;
                                    delegates to accept_super_admin
  
  Tests (8 new):
  - nominate emits AdminProposedEvent with correct payload
  - accept emits AdminTransferredEvent with correct previous/new admin
  - cancel emits AdminNominationCancelledEvent with correct nominee
  - cancel is a no-op (no panic) when no nomination is pending
  - propose_admin alias emits the expected event topic
  - accept_admin alias completes the transfer and grants admin rights
  
  Security properties
  -------------------
  - Non-instant: 24-hour delay window (NOMINATION_EXPIRY_SECONDS)
  - Two-key: current admin proposes, new admin must independently accept
  - Auditable: every state change emits an indexed on-chain event
  - Resilient: expired nominations are lazily cleared; cancel is always
    available to the current admin