### PR TITLE
feat(contract): enforce richer request lifecycle rules

### DIFF
--- a/lifebank-soroban/contracts/requests/src/error.rs
+++ b/lifebank-soroban/contracts/requests/src/error.rs
@@ -15,4 +15,6 @@ pub enum ContractError {
     InvalidRequestStatus = 307,
     /// Caller is not the hospital that owns this request.
     NotRequestOwner = 308,
+    /// Transition requires a non-empty human-readable reason.
+    InvalidReason = 309,
 }

--- a/lifebank-soroban/contracts/requests/src/lib.rs
+++ b/lifebank-soroban/contracts/requests/src/lib.rs
@@ -11,12 +11,12 @@ mod test;
 pub use crate::error::ContractError;
 pub use crate::types::{
     BloodComponent, BloodRequest, BloodType, ContractMetadata, DataKey, RequestCreatedEvent,
-    RequestStatus, Urgency,
+    RequestHistoryEntry, RequestStatus, Urgency,
 };
 
 mod validation;
 
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 mod inventory_client {
     use soroban_sdk::{contractclient, Env};
@@ -34,6 +34,49 @@ pub struct RequestContract;
 
 #[contractimpl]
 impl RequestContract {
+    fn append_history(
+        env: &Env,
+        request: &mut BloodRequest,
+        actor: &Address,
+        previous_status: RequestStatus,
+        is_initial_transition: bool,
+        new_status: RequestStatus,
+        reason: String,
+        fulfilled_delta_ml: u32,
+        released_reservation: bool,
+    ) {
+        request.history.push_back(RequestHistoryEntry {
+            previous_status,
+            is_initial_transition,
+            new_status,
+            actor: actor.clone(),
+            reason,
+            fulfilled_delta_ml,
+            released_reservation,
+            timestamp: env.ledger().timestamp(),
+        });
+    }
+
+    fn ensure_non_empty_reason(reason: &String) -> Result<(), ContractError> {
+        if reason.len() == 0 {
+            Err(ContractError::InvalidReason)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn release_reservation_if_present(env: &Env, request: &mut BloodRequest) -> bool {
+        if let Some(res_id) = request.reservation_id {
+            let inventory_addr = storage::get_inventory_contract(env);
+            let inv_client = InventoryContractClient::new(env, &inventory_addr);
+            inv_client.release_reservation(&res_id);
+            request.reservation_id = None;
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -104,7 +147,20 @@ impl RequestContract {
             assigned_units: soroban_sdk::Vec::new(&env),
             fulfilled_quantity_ml: 0,
             reservation_id: None,
+            history: soroban_sdk::Vec::new(&env),
         };
+        let mut request = request;
+        Self::append_history(
+            &env,
+            &mut request,
+            &hospital,
+            RequestStatus::Pending,
+            true,
+            RequestStatus::Pending,
+            String::from_str(&env, "Request created"),
+            0,
+            false,
+        );
 
         storage::set_request(&env, &request);
         events::emit_request_created(&env, &request);
@@ -148,7 +204,20 @@ impl RequestContract {
                 assigned_units: soroban_sdk::Vec::new(&env),
                 fulfilled_quantity_ml: 0,
                 reservation_id: None,
+                history: soroban_sdk::Vec::new(&env),
             };
+            let mut request = request;
+            Self::append_history(
+                &env,
+                &mut request,
+                &hospital,
+                RequestStatus::Pending,
+                true,
+                RequestStatus::Pending,
+                String::from_str(&env, "Request created"),
+                0,
+                false,
+            );
             storage::set_request(&env, &request);
             events::emit_request_created(&env, &request);
             ids.push_back(request_id);
@@ -162,9 +231,11 @@ impl RequestContract {
         env: Env,
         caller: Address,
         request_id: u64,
+        reason: String,
     ) -> Result<(), ContractError> {
         caller.require_auth();
         storage::require_initialized(&env)?;
+        Self::ensure_non_empty_reason(&reason)?;
 
         let mut request = storage::get_request(&env, request_id)
             .ok_or(ContractError::RequestNotFound)?;
@@ -175,18 +246,25 @@ impl RequestContract {
         }
 
         match request.status {
-            RequestStatus::Pending | RequestStatus::Approved => {}
+            RequestStatus::Pending | RequestStatus::Approved | RequestStatus::InProgress => {}
             _ => return Err(ContractError::InvalidRequestStatus),
         }
 
+        let old_status = request.status;
         request.status = RequestStatus::Cancelled;
+        let released_reservation = Self::release_reservation_if_present(&env, &mut request);
+        Self::append_history(
+            &env,
+            &mut request,
+            &caller,
+            old_status,
+            false,
+            RequestStatus::Cancelled,
+            reason,
+            0,
+            released_reservation,
+        );
         storage::set_request(&env, &request);
-
-        if let Some(res_id) = request.reservation_id {
-            let inventory_addr = storage::get_inventory_contract(&env);
-            let inv_client = InventoryContractClient::new(&env, &inventory_addr);
-            inv_client.release_reservation(&res_id);
-        }
 
         events::emit_request_cancelled(
             &env,
@@ -205,6 +283,7 @@ impl RequestContract {
         caller: Address,
         request_id: u64,
         new_status: RequestStatus,
+        reason: String,
     ) -> Result<(), ContractError> {
         caller.require_auth();
         storage::require_initialized(&env)?;
@@ -222,7 +301,47 @@ impl RequestContract {
         }
 
         let old_status = request.status;
+        let mut released_reservation = false;
+        let mut fulfilled_delta_ml = 0;
+
+        match new_status {
+            RequestStatus::Approved => {
+                if old_status != RequestStatus::Pending {
+                    return Err(ContractError::InvalidRequestStatus);
+                }
+            }
+            RequestStatus::Rejected => {
+                if old_status != RequestStatus::Pending && old_status != RequestStatus::Approved {
+                    return Err(ContractError::InvalidRequestStatus);
+                }
+                Self::ensure_non_empty_reason(&reason)?;
+                released_reservation = Self::release_reservation_if_present(&env, &mut request);
+            }
+            RequestStatus::Fulfilled => {
+                if old_status != RequestStatus::Approved && old_status != RequestStatus::InProgress {
+                    return Err(ContractError::InvalidRequestStatus);
+                }
+                let remaining = request.quantity_ml.saturating_sub(request.fulfilled_quantity_ml);
+                fulfilled_delta_ml = remaining;
+                request.fulfilled_quantity_ml = request.quantity_ml;
+            }
+            RequestStatus::InProgress | RequestStatus::Pending | RequestStatus::Cancelled => {
+                return Err(ContractError::InvalidRequestStatus);
+            }
+        }
+
         request.status = new_status;
+        Self::append_history(
+            &env,
+            &mut request,
+            &caller,
+            old_status,
+            false,
+            new_status,
+            reason.clone(),
+            fulfilled_delta_ml,
+            released_reservation,
+        );
         storage::set_request(&env, &request);
 
         events::emit_request_status_updated(
@@ -235,6 +354,77 @@ impl RequestContract {
         );
 
         Ok(())
+    }
+
+    /// Register partial fulfillment. Admin only.
+    /// Allows Approved/InProgress requests, transitions to InProgress or Fulfilled.
+    pub fn partial_fulfill_request(
+        env: Env,
+        caller: Address,
+        request_id: u64,
+        fulfilled_delta_ml: u32,
+        reason: String,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        storage::require_initialized(&env)?;
+        Self::ensure_non_empty_reason(&reason)?;
+        validation::validate_quantity(fulfilled_delta_ml)?;
+
+        let admin = storage::get_admin(&env);
+        if caller != admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let mut request =
+            storage::get_request(&env, request_id).ok_or(ContractError::RequestNotFound)?;
+        if request.status != RequestStatus::Approved && request.status != RequestStatus::InProgress {
+            return Err(ContractError::InvalidRequestStatus);
+        }
+
+        let remaining = request.quantity_ml.saturating_sub(request.fulfilled_quantity_ml);
+        if fulfilled_delta_ml > remaining {
+            return Err(ContractError::InvalidQuantity);
+        }
+
+        let old_status = request.status;
+        request.fulfilled_quantity_ml += fulfilled_delta_ml;
+        let new_status = if request.fulfilled_quantity_ml == request.quantity_ml {
+            RequestStatus::Fulfilled
+        } else {
+            RequestStatus::InProgress
+        };
+        request.status = new_status;
+        Self::append_history(
+            &env,
+            &mut request,
+            &caller,
+            old_status,
+            false,
+            new_status,
+            reason,
+            fulfilled_delta_ml,
+            false,
+        );
+        storage::set_request(&env, &request);
+
+        events::emit_request_status_updated(
+            &env,
+            request_id,
+            &caller,
+            old_status,
+            new_status,
+            env.ledger().timestamp(),
+        );
+        Ok(())
+    }
+
+    pub fn get_request_history(
+        env: Env,
+        request_id: u64,
+    ) -> Result<soroban_sdk::Vec<RequestHistoryEntry>, ContractError> {
+        storage::require_initialized(&env)?;
+        let request = storage::get_request(&env, request_id).ok_or(ContractError::RequestNotFound)?;
+        Ok(request.history)
     }
 
     pub fn get_request(env: Env, request_id: u64) -> Result<BloodRequest, ContractError> {

--- a/lifebank-soroban/contracts/requests/src/test.rs
+++ b/lifebank-soroban/contracts/requests/src/test.rs
@@ -214,3 +214,171 @@ fn test_create_request_rejects_zero_quantity() {
     );
 }
 
+#[test]
+fn test_partial_fulfillment_transitions_and_accounting() {
+    let (env, client, _contract_id, admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(3_000);
+
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::OPositive,
+        &BloodComponent::WholeBlood,
+        &500u32,
+        &Urgency::Urgent,
+        &3_600u64,
+    );
+
+    client.update_request_status(
+        &admin,
+        &request_id,
+        &RequestStatus::Approved,
+        &String::from_str(&env, "Approved for dispatch"),
+    );
+
+    client.partial_fulfill_request(
+        &admin,
+        &request_id,
+        &200u32,
+        &String::from_str(&env, "First leg delivered"),
+    );
+    let partial = client.get_request(&request_id);
+    assert_eq!(partial.status, RequestStatus::InProgress);
+    assert_eq!(partial.fulfilled_quantity_ml, 200);
+
+    client.partial_fulfill_request(
+        &admin,
+        &request_id,
+        &300u32,
+        &String::from_str(&env, "Final leg delivered"),
+    );
+    let fulfilled = client.get_request(&request_id);
+    assert_eq!(fulfilled.status, RequestStatus::Fulfilled);
+    assert_eq!(fulfilled.fulfilled_quantity_ml, 500);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #302)")]
+fn test_partial_fulfillment_restricted_to_admin() {
+    let (env, client, _contract_id, admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(4_000);
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::APositive,
+        &BloodComponent::RedCells,
+        &300u32,
+        &Urgency::Routine,
+        &4_500u64,
+    );
+    client.update_request_status(
+        &admin,
+        &request_id,
+        &RequestStatus::Approved,
+        &String::from_str(&env, "Approved"),
+    );
+
+    client.partial_fulfill_request(
+        &hospital,
+        &request_id,
+        &100u32,
+        &String::from_str(&env, "Unauthorized attempt"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #309)")]
+fn test_cancel_requires_reason() {
+    let (env, client, _contract_id, _admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(5_000);
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::BPositive,
+        &BloodComponent::Plasma,
+        &250u32,
+        &Urgency::Routine,
+        &5_500u64,
+    );
+    client.cancel_request(&hospital, &request_id, &String::from_str(&env, ""));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #309)")]
+fn test_reject_requires_reason() {
+    let (env, client, _contract_id, admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(6_000);
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::ABPositive,
+        &BloodComponent::Platelets,
+        &100u32,
+        &Urgency::Urgent,
+        &6_500u64,
+    );
+    client.update_request_status(
+        &admin,
+        &request_id,
+        &RequestStatus::Rejected,
+        &String::from_str(&env, ""),
+    );
+}
+
+#[test]
+fn test_request_history_captures_transition_rationale() {
+    let (env, client, _contract_id, admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(7_000);
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::ONegative,
+        &BloodComponent::WholeBlood,
+        &400u32,
+        &Urgency::Critical,
+        &7_300u64,
+    );
+    client.update_request_status(
+        &admin,
+        &request_id,
+        &RequestStatus::Approved,
+        &String::from_str(&env, "Stock confirmed"),
+    );
+    client.partial_fulfill_request(
+        &admin,
+        &request_id,
+        &150u32,
+        &String::from_str(&env, "Initial transport completed"),
+    );
+    client.cancel_request(
+        &hospital,
+        &request_id,
+        &String::from_str(&env, "Hospital no longer needs remaining units"),
+    );
+
+    let history = client.get_request_history(&request_id);
+    assert_eq!(history.len(), 4);
+    let created = history.get(0).unwrap();
+    assert_eq!(created.new_status, RequestStatus::Pending);
+    assert_eq!(created.reason, String::from_str(&env, "Request created"));
+
+    let approved = history.get(1).unwrap();
+    assert_eq!(approved.new_status, RequestStatus::Approved);
+    assert_eq!(approved.reason, String::from_str(&env, "Stock confirmed"));
+
+    let partial = history.get(2).unwrap();
+    assert_eq!(partial.new_status, RequestStatus::InProgress);
+    assert_eq!(partial.fulfilled_delta_ml, 150);
+    assert_eq!(
+        partial.reason,
+        String::from_str(&env, "Initial transport completed")
+    );
+
+    let cancelled = history.get(3).unwrap();
+    assert_eq!(cancelled.new_status, RequestStatus::Cancelled);
+    assert_eq!(
+        cancelled.reason,
+        String::from_str(&env, "Hospital no longer needs remaining units")
+    );
+}
+

--- a/lifebank-soroban/contracts/requests/src/types.rs
+++ b/lifebank-soroban/contracts/requests/src/types.rs
@@ -67,8 +67,23 @@ impl Urgency {
 pub enum RequestStatus {
     Pending,
     Approved,
+    InProgress,
     Fulfilled,
     Cancelled,
+    Rejected,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RequestHistoryEntry {
+    pub previous_status: RequestStatus,
+    pub is_initial_transition: bool,
+    pub new_status: RequestStatus,
+    pub actor: Address,
+    pub reason: String,
+    pub fulfilled_delta_ml: u32,
+    pub released_reservation: bool,
+    pub timestamp: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -87,6 +102,8 @@ pub struct BloodRequest {
     pub fulfilled_quantity_ml: u32,
     /// Reservation ID on the inventory contract, set when units are reserved.
     pub reservation_id: Option<u64>,
+    /// Request lifecycle transitions with rationale and accounting details.
+    pub history: Vec<RequestHistoryEntry>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Overview
This PR enforces richer request lifecycle rules in the Soroban `request-contract`, covering partial fulfillment behavior, actor + reason constraints for cancellation/rejection, consistent reservation release semantics, and request history entries that reconstruct transition rationale.

## Related Issue
Closes #583

## Changes

### ⚙️ Request Lifecycle Rules (Soroban)
- **[MODIFY]** `lifebank-soroban/contracts/requests/src/types.rs`
- Added `InProgress` + `Rejected` statuses.
- Added `RequestHistoryEntry` and persisted per-request `history` for lifecycle rationale and accounting.

- **[MODIFY]** `lifebank-soroban/contracts/requests/src/lib.rs`
- Added explicit, reason-aware transitions for cancel/reject.
- Added `partial_fulfill_request(...)` with explicit accounting + state transitions (`Approved/InProgress` -> `InProgress/Fulfilled`).
- Ensured reservations are released consistently on cancellation/rejection (and cleared after release).
- Added `get_request_history(...)` for reconstructing lifecycle rationale.

- **[MODIFY]** `lifebank-soroban/contracts/requests/src/error.rs`
- Added `InvalidReason` for reason-aware transitions.

- **[MODIFY]** `lifebank-soroban/contracts/requests/src/test.rs`
- Added tests for partial fulfillment behavior, actor restrictions, reason requirements, and history reconstruction.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Partial fulfillment has explicit, tested behavior | ✅ |
| Cancellation and rejection are actor-restricted and reason-aware | ✅ |
| Reserved units are always released or preserved consistently | ✅ |
| Request history reconstructs all transition rationale | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the contract unit tests (from lifebank-soroban)
cargo test -p request-contract

# 3. Optional: inspect the changed files
git diff -- lifebank-soroban/contracts/requests/src/{types.rs,lib.rs,error.rs,test.rs}
```

## Screenshots

### ✅ Request contract tests pass
A screenshot of:

```bash
cargo test -p request-contract
```

