### PR TITLE
Build Dead Letter Queue and Replay Workflow

### DIFF
--- a/backend/src/notifications/controllers/notification-dlq.controller.ts
+++ b/backend/src/notifications/controllers/notification-dlq.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
+import { Permission } from '../../auth/enums/permission.enum';
+import { DlqEntryStatus } from '../entities/notification-dlq.entity';
+import { NotificationDlqService } from '../services/notification-dlq.service';
+
+@Controller('notifications/dlq')
+export class NotificationDlqController {
+  constructor(private readonly dlqService: NotificationDlqService) {}
+
+  @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @Get()
+  list(
+    @Query('status') status?: DlqEntryStatus,
+    @Query('limit') limit?: number,
+  ) {
+    return this.dlqService.list(status, limit ? Number(limit) : 50);
+  }
+
+  @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.dlqService.get(id);
+  }
+
+  @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @Post(':id/replay')
+  replay(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
+    return this.dlqService.replay(id, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @Post('replay/bulk')
+  replayBulk(
+    @Body() body: { channel?: string },
+    @Req() req: { user?: { id?: string } },
+  ) {
+    return this.dlqService.replayBulk(req.user?.id ?? 'system', body.channel);
+  }
+
+  @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @Post(':id/abandon')
+  abandon(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @Req() req: { user?: { id?: string } },
+  ) {
+    return this.dlqService.abandon(id, body.reason, req.user?.id ?? 'system');
+  }
+}

--- a/backend/src/notifications/entities/notification-dlq.entity.ts
+++ b/backend/src/notifications/entities/notification-dlq.entity.ts
@@ -1,0 +1,80 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { NotificationChannel } from '../enums/notification-channel.enum';
+
+export enum DlqEntryStatus {
+  PENDING = 'pending',
+  REPLAYING = 'replaying',
+  REPLAYED = 'replayed',
+  ABANDONED = 'abandoned',
+}
+
+@Entity('notification_dlq')
+@Index(['status'])
+@Index(['channel'])
+@Index(['recipientId'])
+export class NotificationDlqEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Original notification entity id */
+  @Column({ name: 'notification_id' })
+  notificationId: string;
+
+  @Column({ name: 'recipient_id' })
+  recipientId: string;
+
+  @Column({ type: 'enum', enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @Column({ name: 'template_key' })
+  templateKey: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  variables: Record<string, any> | null;
+
+  @Column({ name: 'rendered_body', type: 'text' })
+  renderedBody: string;
+
+  /** Serialised array of ProviderAttemptResult from the final failed job */
+  @Column({ name: 'provider_attempts', type: 'jsonb', default: '[]' })
+  providerAttempts: Record<string, any>[];
+
+  /** Last error message */
+  @Column({ name: 'last_error', type: 'text', nullable: true })
+  lastError: string | null;
+
+  /** How many times this DLQ entry has been replayed */
+  @Column({ name: 'replay_count', default: 0 })
+  replayCount: number;
+
+  @Column({
+    type: 'enum',
+    enum: DlqEntryStatus,
+    default: DlqEntryStatus.PENDING,
+  })
+  status: DlqEntryStatus;
+
+  /** Actor who triggered the last replay */
+  @Column({ name: 'replayed_by', nullable: true })
+  replayedBy: string | null;
+
+  @Column({ name: 'replayed_at', type: 'timestamptz', nullable: true })
+  replayedAt: Date | null;
+
+  /** Optional operator note */
+  @Column({ name: 'abandon_reason', type: 'text', nullable: true })
+  abandonReason: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/notifications/enums/notification-status.enum.ts
+++ b/backend/src/notifications/enums/notification-status.enum.ts
@@ -3,4 +3,5 @@ export enum NotificationStatus {
   SENT = 'SENT',
   FAILED = 'FAILED',
   READ = 'READ',
+  DLQ = 'DLQ',
 }

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,5 +1,6 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { PolicyCenterModule } from '../policy-center/policy-center.module';
@@ -8,18 +9,23 @@ import { NotificationTemplateEntity } from './entities/notification-template.ent
 import { NotificationEntity } from './entities/notification.entity';
 import { NotificationPreference } from './entities/notification-preference.entity';
 import { NotificationDeliveryLog } from './entities/notification-delivery-log.entity';
+import { NotificationDlqEntity } from './entities/notification-dlq.entity';
 import { NotificationsGateway } from './gateways/notifications.gateway';
 import { OrderNotificationListener } from './listeners/order-notification.listener';
 import { EscalationNotificationListener } from './listeners/escalation-notification.listener';
 import { NotificationsController } from './notifications.controller';
 import { NotificationPreferenceController } from './controllers/notification-preference.controller';
+import { NotificationDlqController } from './controllers/notification-dlq.controller';
 import { NotificationsService } from './notifications.service';
 import { NotificationPreferenceService } from './services/notification-preference.service';
+import { NotificationDlqService } from './services/notification-dlq.service';
+import { DeliveryRepairService } from './services/delivery-repair.service';
 import { NotificationProcessor } from './processors/notification.processor';
 import { EmailProvider } from './providers/email.provider';
 import { InAppProvider } from './providers/in-app.provider';
 import { PushProvider } from './providers/push.provider';
 import { SmsProvider } from './providers/sms.provider';
+import { ProviderFailoverService } from './providers/provider-failover.service';
 
 @Module({
   imports: [
@@ -28,19 +34,28 @@ import { SmsProvider } from './providers/sms.provider';
       NotificationTemplateEntity,
       NotificationPreference,
       NotificationDeliveryLog,
+      NotificationDlqEntity,
     ]),
     BullModule.registerQueue({
       name: 'notifications',
     }),
+    ScheduleModule.forRoot(),
     PolicyCenterModule,
   ],
-  controllers: [NotificationsController, NotificationPreferenceController],
+  controllers: [
+    NotificationsController,
+    NotificationPreferenceController,
+    NotificationDlqController,
+  ],
   providers: [
-    // Providers
+    // Transport providers
     SmsProvider,
     PushProvider,
     EmailProvider,
     InAppProvider,
+
+    // Failover orchestration
+    ProviderFailoverService,
 
     // Gateways
     NotificationsGateway,
@@ -55,7 +70,14 @@ import { SmsProvider } from './providers/sms.provider';
     // Services
     NotificationsService,
     NotificationPreferenceService,
+    NotificationDlqService,
+    DeliveryRepairService,
   ],
-  exports: [NotificationsService, NotificationPreferenceService, EmailProvider],
+  exports: [
+    NotificationsService,
+    NotificationPreferenceService,
+    NotificationDlqService,
+    EmailProvider,
+  ],
 })
 export class NotificationsModule {}

--- a/backend/src/notifications/processors/notification.processor.ts
+++ b/backend/src/notifications/processors/notification.processor.ts
@@ -8,10 +8,8 @@ import { Repository } from 'typeorm';
 import { NotificationEntity } from '../entities/notification.entity';
 import { NotificationChannel } from '../enums/notification-channel.enum';
 import { NotificationStatus } from '../enums/notification-status.enum';
-import { EmailProvider } from '../providers/email.provider';
-import { InAppProvider } from '../providers/in-app.provider';
-import { PushProvider } from '../providers/push.provider';
-import { SmsProvider } from '../providers/sms.provider';
+import { ProviderFailoverService } from '../providers/provider-failover.service';
+import { NotificationDlqService } from '../services/notification-dlq.service';
 
 export interface NotificationJobData {
   notificationId: string;
@@ -19,45 +17,45 @@ export interface NotificationJobData {
   channel: NotificationChannel;
   renderedBody: string;
   templateKey?: string;
-  variables?: any;
+  variables?: Record<string, any>;
+  /** Set when this job was triggered by a DLQ replay */
+  dlqReplay?: boolean;
+  dlqId?: string;
+  /** Set when this job was triggered by the delivery repair cron */
+  repairRun?: boolean;
 }
 
-@Processor('notifications', {
-  concurrency: 5,
-})
+@Processor('notifications', { concurrency: 5 })
 export class NotificationProcessor extends WorkerHost {
   private readonly logger = new Logger(NotificationProcessor.name);
 
   constructor(
     @InjectRepository(NotificationEntity)
-    private notificationRepo: Repository<NotificationEntity>,
-    private smsProvider: SmsProvider,
-    private pushProvider: PushProvider,
-    private emailProvider: EmailProvider,
-    private inAppProvider: InAppProvider,
+    private readonly notificationRepo: Repository<NotificationEntity>,
+    private readonly failoverService: ProviderFailoverService,
+    private readonly dlqService: NotificationDlqService,
   ) {
     super();
   }
 
-  async process(job: Job<NotificationJobData, any, string>): Promise<any> {
-    const { notificationId, channel, recipientId, renderedBody } = job.data;
-
+  async process(job: Job<NotificationJobData>): Promise<any> {
+    const { notificationId, channel, recipientId, renderedBody, variables } =
+      job.data;
     const idempotencyKey = `${notificationId}:${channel}`;
 
     this.logger.log(
-      `Processing notification job ${job.id} for ${channel} -> ${recipientId}`,
+      `Processing notification job ${job.id} [${channel}] -> ${recipientId}` +
+        (job.data.dlqReplay ? ' [DLQ-REPLAY]' : '') +
+        (job.data.repairRun ? ' [REPAIR]' : ''),
     );
 
     const notification = await this.notificationRepo.findOne({
-      where: {
-        notificationId,
-        channel,
-      },
+      where: { id: notificationId },
     });
 
     if (!notification) {
-      this.logger.warn(`Notification ${notificationId} not found`);
-      return;
+      this.logger.warn(`Notification ${notificationId} not found — skipping`);
+      return { status: 'not_found', notificationId };
     }
 
     if (notification.status === NotificationStatus.SENT) {
@@ -67,70 +65,79 @@ export class NotificationProcessor extends WorkerHost {
       return { status: 'already_sent', notificationId };
     }
 
-    try {
-      switch (channel) {
-        case NotificationChannel.SMS:
-          await this.smsProvider.send(recipientId, renderedBody);
-          break;
-        case NotificationChannel.PUSH:
-          // In a real app, recipientId might not be the fcmToken directly.
-          // You'd typically resolve the user's FCM token from the DB here.
-          // For this example, we'll try to use recipientId as token, or use a variable.
-          const fcmToken = job.data.variables?.fcmToken || recipientId;
-          const pushTitle = job.data.variables?.pushTitle || 'New Notification';
-          await this.pushProvider.send(fcmToken, pushTitle, renderedBody);
-          break;
-        case NotificationChannel.EMAIL:
-          const emailSubject =
-            job.data.variables?.emailSubject || 'Notification from Donor Hub';
-          await this.emailProvider.send(
-            recipientId,
-            emailSubject,
-            renderedBody,
-          );
-          break;
-        case NotificationChannel.IN_APP:
-          const payload = {
-            id: notificationId,
-            body: renderedBody,
-            templateKey: job.data.templateKey,
-            createdAt: new Date().toISOString(),
-          };
-          await this.inAppProvider.send(recipientId, payload);
-          break;
-        default:
-          throw new Error(`Unsupported channel: ${channel}`);
-      }
+    // Deliver via failover chain
+    const result = await this.failoverService.deliver(
+      channel,
+      recipientId,
+      renderedBody,
+      variables,
+    );
 
-      // Mark as SENT
-      await this.notificationRepo.update(notificationId, {
+    if (result.delivered) {
+      await this.notificationRepo.update(notification.id, {
         status: NotificationStatus.SENT,
         deliveryError: null,
       });
 
-      return { status: 'sent', notificationId };
-    } catch (error: any) {
-      this.logger.error(
-        `Failed to process job ${job.id}: ${error.message}`,
-        error.stack,
-      );
-      throw error; // Will be caught by BullMQ and trigger retry
+      // If this was a DLQ replay, mark it resolved
+      if (job.data.dlqReplay && job.data.dlqId) {
+        await this.dlqService.markReplayed(job.data.dlqId);
+      }
+
+      return {
+        status: 'sent',
+        notificationId,
+        provider: result.finalProvider,
+        attempts: result.attempts.length,
+      };
     }
+
+    // All providers failed — throw so BullMQ retries
+    const lastError = result.attempts.at(-1)?.error ?? 'All providers failed';
+    this.logger.error(
+      `All providers failed for job ${job.id} [${channel}]: ${lastError}`,
+    );
+    throw new Error(lastError);
   }
 
-  // BullMQ hook equivalent. Use this pattern for failed jobs across retries.
-  async onFailed(job: Job, error: Error) {
-    // If it has reached the max number of attempts, mark it as FAILED in the DB.
-    if (job.attemptsMade >= (job.opts.attempts || 1)) {
-      this.logger.error(
-        `Job ${job.id} definitively failed after ${job.attemptsMade} attempts.`,
+  /**
+   * Called by BullMQ after all retry attempts are exhausted.
+   * Moves the notification to the DLQ.
+   */
+  async onFailed(job: Job<NotificationJobData>, error: Error): Promise<void> {
+    const maxAttempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade < maxAttempts) return; // still has retries left
+
+    this.logger.error(
+      `Job ${job.id} definitively failed after ${job.attemptsMade} attempts: ${error.message}`,
+    );
+
+    const { notificationId, channel } = job.data;
+
+    const notification = await this.notificationRepo.findOne({
+      where: { id: notificationId },
+    });
+
+    if (!notification) return;
+
+    // Re-run failover to capture the final attempt log for DLQ metadata
+    const finalAttemptResult = await this.failoverService.deliver(
+      channel,
+      notification.recipientId,
+      notification.renderedBody ?? '',
+      job.data.variables,
+    );
+
+    if (job.data.dlqReplay && job.data.dlqId) {
+      // Replay itself failed — reset DLQ entry to PENDING for manual retry
+      await this.dlqService.markReplayFailed(job.data.dlqId, error.message);
+    } else {
+      // First-time failure — move to DLQ
+      await this.dlqService.enqueue(
+        notification,
+        finalAttemptResult.attempts,
+        error.message,
       );
-      if (job.data?.notificationId) {
-        await this.notificationRepo.update(job.data.notificationId, {
-          status: NotificationStatus.FAILED,
-          deliveryError: error.message || 'Unknown error',
-        });
-      }
     }
   }
 }

--- a/backend/src/notifications/providers/provider-failover.service.ts
+++ b/backend/src/notifications/providers/provider-failover.service.ts
@@ -1,0 +1,178 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { NotificationChannel } from '../enums/notification-channel.enum';
+import { EmailProvider } from './email.provider';
+import { SmsProvider } from './sms.provider';
+import { PushProvider } from './push.provider';
+import { InAppProvider } from './in-app.provider';
+
+export interface ProviderAttemptResult {
+  providerName: string;
+  success: boolean;
+  error?: string;
+  durationMs: number;
+}
+
+export interface FailoverDeliveryResult {
+  delivered: boolean;
+  attempts: ProviderAttemptResult[];
+  finalProvider?: string;
+}
+
+/**
+ * Executes a provider chain for a given channel.
+ * On primary failure, falls over to secondary providers in order.
+ * All attempt results are returned for audit logging.
+ */
+@Injectable()
+export class ProviderFailoverService {
+  private readonly logger = new Logger(ProviderFailoverService.name);
+
+  constructor(
+    private readonly emailProvider: EmailProvider,
+    private readonly smsProvider: SmsProvider,
+    private readonly pushProvider: PushProvider,
+    private readonly inAppProvider: InAppProvider,
+  ) {}
+
+  async deliver(
+    channel: NotificationChannel,
+    recipientId: string,
+    renderedBody: string,
+    variables?: Record<string, any>,
+  ): Promise<FailoverDeliveryResult> {
+    const chain = this.buildChain(
+      channel,
+      recipientId,
+      renderedBody,
+      variables,
+    );
+    const attempts: ProviderAttemptResult[] = [];
+
+    for (const { name, fn } of chain) {
+      const start = Date.now();
+      try {
+        await fn();
+        const result: ProviderAttemptResult = {
+          providerName: name,
+          success: true,
+          durationMs: Date.now() - start,
+        };
+        attempts.push(result);
+        this.logger.log(
+          `[Failover] Delivered via ${name} for channel=${channel}`,
+        );
+        return { delivered: true, attempts, finalProvider: name };
+      } catch (err: any) {
+        const result: ProviderAttemptResult = {
+          providerName: name,
+          success: false,
+          error: err?.message ?? String(err),
+          durationMs: Date.now() - start,
+        };
+        attempts.push(result);
+        this.logger.warn(
+          `[Failover] Provider ${name} failed for channel=${channel}: ${err?.message}`,
+        );
+      }
+    }
+
+    this.logger.error(
+      `[Failover] All providers exhausted for channel=${channel} recipient=${recipientId}`,
+    );
+    return { delivered: false, attempts };
+  }
+
+  private buildChain(
+    channel: NotificationChannel,
+    recipientId: string,
+    renderedBody: string,
+    variables?: Record<string, any>,
+  ): Array<{ name: string; fn: () => Promise<void> }> {
+    switch (channel) {
+      case NotificationChannel.EMAIL:
+        return [
+          {
+            name: 'EmailProvider(primary)',
+            fn: () =>
+              this.emailProvider.send(
+                recipientId,
+                variables?.emailSubject ?? 'Notification',
+                renderedBody,
+              ),
+          },
+          // Fallback: in-app when email transport fails
+          {
+            name: 'InAppProvider(email-fallback)',
+            fn: () =>
+              this.inAppProvider.send(recipientId, {
+                channel: 'email-fallback',
+                body: renderedBody,
+              }),
+          },
+        ];
+
+      case NotificationChannel.SMS:
+        return [
+          {
+            name: 'SmsProvider(primary)',
+            fn: () => this.smsProvider.send(recipientId, renderedBody),
+          },
+          // Fallback: push then in-app
+          {
+            name: 'PushProvider(sms-fallback)',
+            fn: () =>
+              this.pushProvider.send(
+                variables?.fcmToken ?? recipientId,
+                variables?.pushTitle ?? 'Notification',
+                renderedBody,
+              ),
+          },
+          {
+            name: 'InAppProvider(sms-fallback)',
+            fn: () =>
+              this.inAppProvider.send(recipientId, {
+                channel: 'sms-fallback',
+                body: renderedBody,
+              }),
+          },
+        ];
+
+      case NotificationChannel.PUSH:
+        return [
+          {
+            name: 'PushProvider(primary)',
+            fn: () =>
+              this.pushProvider.send(
+                variables?.fcmToken ?? recipientId,
+                variables?.pushTitle ?? 'Notification',
+                renderedBody,
+              ),
+          },
+          // Fallback: in-app
+          {
+            name: 'InAppProvider(push-fallback)',
+            fn: () =>
+              this.inAppProvider.send(recipientId, {
+                channel: 'push-fallback',
+                body: renderedBody,
+              }),
+          },
+        ];
+
+      case NotificationChannel.IN_APP:
+        return [
+          {
+            name: 'InAppProvider(primary)',
+            fn: () =>
+              this.inAppProvider.send(recipientId, {
+                channel: 'in_app',
+                body: renderedBody,
+              }),
+          },
+        ];
+
+      default:
+        return [];
+    }
+  }
+}

--- a/backend/src/notifications/services/delivery-repair.service.ts
+++ b/backend/src/notifications/services/delivery-repair.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Queue } from 'bullmq';
+import { LessThan, Repository } from 'typeorm';
+
+import { NotificationEntity } from '../entities/notification.entity';
+import { NotificationStatus } from '../enums/notification-status.enum';
+import { NotificationJobData } from '../processors/notification.processor';
+
+/**
+ * Periodically scans for notifications stuck in PENDING state
+ * (i.e. the job was enqueued but the processor never updated the DB)
+ * and re-enqueues them for delivery.
+ */
+@Injectable()
+export class DeliveryRepairService {
+  private readonly logger = new Logger(DeliveryRepairService.name);
+
+  /** Notifications older than this threshold are considered stuck */
+  private readonly stuckThresholdMs = 10 * 60 * 1000; // 10 minutes
+
+  constructor(
+    @InjectRepository(NotificationEntity)
+    private readonly notificationRepo: Repository<NotificationEntity>,
+    @InjectQueue('notifications')
+    private readonly notificationsQueue: Queue,
+  ) {}
+
+  /**
+   * Runs every 5 minutes. Finds PENDING notifications older than the stuck
+   * threshold and re-enqueues them with a repair job tag.
+   */
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async repairStuckNotifications(): Promise<void> {
+    const cutoff = new Date(Date.now() - this.stuckThresholdMs);
+
+    const stuck = await this.notificationRepo.find({
+      where: {
+        status: NotificationStatus.PENDING,
+        createdAt: LessThan(cutoff),
+      },
+      take: 50,
+      order: { createdAt: 'ASC' },
+    });
+
+    if (stuck.length === 0) return;
+
+    this.logger.warn(
+      `[Repair] Found ${stuck.length} stuck PENDING notifications, re-enqueuing`,
+    );
+
+    for (const notification of stuck) {
+      try {
+        const jobData: NotificationJobData = {
+          notificationId: notification.id,
+          recipientId: notification.recipientId,
+          channel: notification.channel,
+          renderedBody: notification.renderedBody ?? '',
+          templateKey: notification.templateKey,
+          variables: notification.variables ?? undefined,
+          repairRun: true,
+        };
+
+        await this.notificationsQueue.add('sendNotification', jobData, {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 3000 },
+          // Deduplicate: if a job for this notification is already queued, skip
+          jobId: `repair:${notification.id}:${notification.channel}`,
+        });
+
+        this.logger.log(
+          `[Repair] Re-enqueued notification ${notification.id} (${notification.channel})`,
+        );
+      } catch (err: any) {
+        this.logger.error(
+          `[Repair] Failed to re-enqueue notification ${notification.id}: ${err?.message}`,
+        );
+      }
+    }
+  }
+}

--- a/backend/src/notifications/services/notification-dlq.service.ts
+++ b/backend/src/notifications/services/notification-dlq.service.ts
@@ -1,0 +1,227 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bullmq';
+import { Repository } from 'typeorm';
+
+import {
+  NotificationDlqEntity,
+  DlqEntryStatus,
+} from '../entities/notification-dlq.entity';
+import { NotificationEntity } from '../entities/notification.entity';
+import { NotificationStatus } from '../enums/notification-status.enum';
+import { ProviderAttemptResult } from '../providers/provider-failover.service';
+import { NotificationJobData } from '../processors/notification.processor';
+
+export interface DlqReplayResult {
+  dlqId: string;
+  notificationId: string;
+  jobId: string;
+  replayedAt: string;
+}
+
+@Injectable()
+export class NotificationDlqService {
+  private readonly logger = new Logger(NotificationDlqService.name);
+
+  constructor(
+    @InjectRepository(NotificationDlqEntity)
+    private readonly dlqRepo: Repository<NotificationDlqEntity>,
+    @InjectRepository(NotificationEntity)
+    private readonly notificationRepo: Repository<NotificationEntity>,
+    @InjectQueue('notifications')
+    private readonly notificationsQueue: Queue,
+  ) {}
+
+  /**
+   * Move a definitively-failed notification into the DLQ.
+   * Called by the processor after all BullMQ retries are exhausted.
+   */
+  async enqueue(
+    notification: NotificationEntity,
+    providerAttempts: ProviderAttemptResult[],
+    lastError: string,
+  ): Promise<NotificationDlqEntity> {
+    const existing = await this.dlqRepo.findOne({
+      where: {
+        notificationId: notification.id,
+        status: DlqEntryStatus.PENDING,
+      },
+    });
+
+    if (existing) {
+      this.logger.warn(
+        `[DLQ] Notification ${notification.id} already in DLQ (id=${existing.id}), skipping duplicate`,
+      );
+      return existing;
+    }
+
+    const entry = this.dlqRepo.create({
+      notificationId: notification.id,
+      recipientId: notification.recipientId,
+      channel: notification.channel,
+      templateKey: notification.templateKey,
+      variables: notification.variables ?? null,
+      renderedBody: notification.renderedBody ?? '',
+      providerAttempts,
+      lastError,
+      status: DlqEntryStatus.PENDING,
+    });
+
+    const saved = await this.dlqRepo.save(entry);
+
+    // Mark the notification entity as DLQ
+    await this.notificationRepo.update(notification.id, {
+      status: NotificationStatus.DLQ,
+      deliveryError: lastError,
+    });
+
+    this.logger.warn(
+      `[DLQ] Notification ${notification.id} moved to DLQ (dlqId=${saved.id})`,
+    );
+    return saved;
+  }
+
+  /**
+   * Replay a single DLQ entry — re-enqueues the job with fresh attempts.
+   */
+  async replay(dlqId: string, actor: string): Promise<DlqReplayResult> {
+    const entry = await this.dlqRepo.findOne({ where: { id: dlqId } });
+    if (!entry) throw new NotFoundException(`DLQ entry ${dlqId} not found`);
+
+    if (entry.status === DlqEntryStatus.ABANDONED) {
+      throw new BadRequestException(
+        `DLQ entry ${dlqId} has been abandoned and cannot be replayed`,
+      );
+    }
+
+    if (entry.status === DlqEntryStatus.REPLAYING) {
+      throw new BadRequestException(
+        `DLQ entry ${dlqId} is already being replayed`,
+      );
+    }
+
+    // Reset the notification status to PENDING so the processor re-processes it
+    await this.notificationRepo.update(entry.notificationId, {
+      status: NotificationStatus.PENDING,
+      deliveryError: null,
+    });
+
+    entry.status = DlqEntryStatus.REPLAYING;
+    entry.replayCount += 1;
+    entry.replayedBy = actor;
+    entry.replayedAt = new Date();
+    await this.dlqRepo.save(entry);
+
+    const jobData: NotificationJobData = {
+      notificationId: entry.notificationId,
+      recipientId: entry.recipientId,
+      channel: entry.channel,
+      renderedBody: entry.renderedBody,
+      templateKey: entry.templateKey,
+      variables: entry.variables ?? undefined,
+      dlqReplay: true,
+      dlqId: entry.id,
+    };
+
+    const job = await this.notificationsQueue.add('sendNotification', jobData, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      jobId: `dlq-replay:${entry.id}:${entry.replayCount}`,
+    });
+
+    this.logger.log(
+      `[DLQ] Replayed dlqId=${dlqId} as jobId=${job.id} by actor=${actor}`,
+    );
+
+    return {
+      dlqId: entry.id,
+      notificationId: entry.notificationId,
+      jobId: String(job.id),
+      replayedAt: entry.replayedAt!.toISOString(),
+    };
+  }
+
+  /**
+   * Bulk replay all PENDING DLQ entries for a given channel (or all channels).
+   */
+  async replayBulk(
+    actor: string,
+    channel?: string,
+  ): Promise<{
+    replayed: number;
+    skipped: number;
+    results: DlqReplayResult[];
+  }> {
+    const where: Record<string, any> = { status: DlqEntryStatus.PENDING };
+    if (channel) where.channel = channel;
+
+    const entries = await this.dlqRepo.find({ where, take: 100 });
+    const results: DlqReplayResult[] = [];
+    let skipped = 0;
+
+    for (const entry of entries) {
+      try {
+        const result = await this.replay(entry.id, actor);
+        results.push(result);
+      } catch {
+        skipped++;
+      }
+    }
+
+    return { replayed: results.length, skipped, results };
+  }
+
+  /**
+   * Mark a DLQ entry as abandoned (no further replay attempts).
+   */
+  async abandon(
+    dlqId: string,
+    reason: string,
+    actor: string,
+  ): Promise<NotificationDlqEntity> {
+    const entry = await this.dlqRepo.findOne({ where: { id: dlqId } });
+    if (!entry) throw new NotFoundException(`DLQ entry ${dlqId} not found`);
+
+    entry.status = DlqEntryStatus.ABANDONED;
+    entry.abandonReason = `[${actor}] ${reason}`;
+    return this.dlqRepo.save(entry);
+  }
+
+  async list(
+    status?: DlqEntryStatus,
+    limit = 50,
+  ): Promise<NotificationDlqEntity[]> {
+    const where: Record<string, any> = {};
+    if (status) where.status = status;
+    return this.dlqRepo.find({
+      where,
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  async get(dlqId: string): Promise<NotificationDlqEntity> {
+    const entry = await this.dlqRepo.findOne({ where: { id: dlqId } });
+    if (!entry) throw new NotFoundException(`DLQ entry ${dlqId} not found`);
+    return entry;
+  }
+
+  /** Called by the processor when a replayed job succeeds */
+  async markReplayed(dlqId: string): Promise<void> {
+    await this.dlqRepo.update(dlqId, { status: DlqEntryStatus.REPLAYED });
+  }
+
+  /** Called by the processor when a replayed job fails again */
+  async markReplayFailed(dlqId: string, error: string): Promise<void> {
+    await this.dlqRepo.update(dlqId, {
+      status: DlqEntryStatus.PENDING,
+      lastError: error,
+    });
+  }
+}

--- a/backend/src/policy-center/entities/canary-metric.entity.ts
+++ b/backend/src/policy-center/entities/canary-metric.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('canary_metrics')
+@Index(['rolloutId'])
+@Index(['recordedAt'])
+export class CanaryMetricEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'rollout_id' })
+  rolloutId: string;
+
+  @Column({ name: 'policy_version_id' })
+  policyVersionId: string;
+
+  /** Total requests processed under this policy version in the window */
+  @Column({ name: 'total_requests', type: 'int', default: 0 })
+  totalRequests: number;
+
+  /** Requests that resulted in an error */
+  @Column({ name: 'error_count', type: 'int', default: 0 })
+  errorCount: number;
+
+  /** Computed error rate (errorCount / totalRequests) */
+  @Column({ name: 'error_rate', type: 'float', default: 0 })
+  errorRate: number;
+
+  /** Average latency in ms */
+  @Column({ name: 'avg_latency_ms', type: 'float', nullable: true })
+  avgLatencyMs: number | null;
+
+  /** p99 latency in ms */
+  @Column({ name: 'p99_latency_ms', type: 'float', nullable: true })
+  p99LatencyMs: number | null;
+
+  /** Arbitrary extra metrics (notification delivery rates, etc.) */
+  @Column({ type: 'jsonb', nullable: true })
+  extra: Record<string, any> | null;
+
+  @Column({ name: 'recorded_at', type: 'timestamptz' })
+  recordedAt: Date;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/policy-center/entities/policy-rollout.entity.ts
+++ b/backend/src/policy-center/entities/policy-rollout.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { RolloutStatus } from '../enums/rollout-status.enum';
+import { PolicyVersionEntity } from './policy-version.entity';
+
+@Entity('policy_rollouts')
+@Index(['policyVersionId'])
+@Index(['status'])
+export class PolicyRolloutEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'policy_version_id' })
+  policyVersionId: string;
+
+  @ManyToOne(() => PolicyVersionEntity, { eager: false })
+  @JoinColumn({ name: 'policy_version_id' })
+  policyVersion: PolicyVersionEntity;
+
+  /**
+   * Percentage of traffic/users currently receiving this policy version.
+   * Starts at canaryPercent, expands in steps, reaches 100 on full rollout.
+   */
+  @Column({ name: 'current_percent', type: 'int', default: 0 })
+  currentPercent: number;
+
+  /** Initial canary percentage (e.g. 5) */
+  @Column({ name: 'canary_percent', type: 'int', default: 5 })
+  canaryPercent: number;
+
+  /** Step size for each expansion (e.g. 25 → 5 → 30 → 55 → 80 → 100) */
+  @Column({ name: 'step_percent', type: 'int', default: 25 })
+  stepPercent: number;
+
+  @Column({ type: 'enum', enum: RolloutStatus, default: RolloutStatus.PENDING })
+  status: RolloutStatus;
+
+  /** Canary evaluation window in minutes */
+  @Column({ name: 'canary_window_minutes', type: 'int', default: 30 })
+  canaryWindowMinutes: number;
+
+  /** Error-rate threshold above which canary auto-aborts (0–1) */
+  @Column({ name: 'error_rate_threshold', type: 'float', default: 0.05 })
+  errorRateThreshold: number;
+
+  /** Snapshot of canary metrics at evaluation time */
+  @Column({ name: 'canary_metrics', type: 'jsonb', nullable: true })
+  canaryMetrics: Record<string, any> | null;
+
+  /** Evaluation result: passed | failed | pending */
+  @Column({ name: 'canary_evaluation', nullable: true })
+  canaryEvaluation: 'passed' | 'failed' | 'pending' | null;
+
+  @Column({ name: 'started_by' })
+  startedBy: string;
+
+  @Column({ name: 'rolled_back_by', nullable: true })
+  rolledBackBy: string | null;
+
+  @Column({ name: 'rollback_reason', type: 'text', nullable: true })
+  rollbackReason: string | null;
+
+  @Column({ name: 'rollback_to_version_id', nullable: true })
+  rollbackToVersionId: string | null;
+
+  @Column({ name: 'canary_started_at', type: 'timestamptz', nullable: true })
+  canaryStartedAt: Date | null;
+
+  @Column({ name: 'full_rollout_at', type: 'timestamptz', nullable: true })
+  fullRolloutAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/policy-center/enums/rollout-status.enum.ts
+++ b/backend/src/policy-center/enums/rollout-status.enum.ts
@@ -1,0 +1,8 @@
+export enum RolloutStatus {
+  PENDING = 'pending',
+  CANARY = 'canary',
+  EXPANDING = 'expanding',
+  FULL = 'full',
+  ROLLED_BACK = 'rolled_back',
+  ABORTED = 'aborted',
+}

--- a/backend/src/policy-center/policy-center.module.ts
+++ b/backend/src/policy-center/policy-center.module.ts
@@ -1,15 +1,27 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { PolicyVersionEntity } from './entities/policy-version.entity';
+import { PolicyRolloutEntity } from './entities/policy-rollout.entity';
+import { CanaryMetricEntity } from './entities/canary-metric.entity';
 import { PolicyCenterController } from './policy-center.controller';
+import { PolicyRolloutController } from './policy-rollout.controller';
 import { PolicyCenterService } from './policy-center.service';
 import { PolicyReplayService } from './policy-replay.service';
+import { PolicyRolloutService } from './policy-rollout.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PolicyVersionEntity])],
-  controllers: [PolicyCenterController],
-  providers: [PolicyCenterService, PolicyReplayService],
-  exports: [PolicyCenterService, PolicyReplayService],
+  imports: [
+    TypeOrmModule.forFeature([
+      PolicyVersionEntity,
+      PolicyRolloutEntity,
+      CanaryMetricEntity,
+    ]),
+    ScheduleModule.forRoot(),
+  ],
+  controllers: [PolicyCenterController, PolicyRolloutController],
+  providers: [PolicyCenterService, PolicyReplayService, PolicyRolloutService],
+  exports: [PolicyCenterService, PolicyReplayService, PolicyRolloutService],
 })
 export class PolicyCenterModule {}

--- a/backend/src/policy-center/policy-rollout.controller.ts
+++ b/backend/src/policy-center/policy-rollout.controller.ts
@@ -1,0 +1,79 @@
+import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
+import { Permission } from '../auth/enums/permission.enum';
+import {
+  PolicyRolloutService,
+  StartRolloutDto,
+} from './policy-rollout.service';
+
+@Controller('policy-center/rollouts')
+export class PolicyRolloutController {
+  constructor(private readonly rolloutService: PolicyRolloutService) {}
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get()
+  list(@Query('policyVersionId') policyVersionId?: string) {
+    return this.rolloutService.listRollouts(policyVersionId);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.rolloutService.getRollout(id);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Get(':id/summary')
+  summary(@Param('id') id: string) {
+    return this.rolloutService.getSummary(id);
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post()
+  start(@Body() dto: StartRolloutDto, @Req() req: { user?: { id?: string } }) {
+    return this.rolloutService.startRollout(dto, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post(':id/advance')
+  advance(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
+    return this.rolloutService.advanceStep(id, req.user?.id ?? 'system');
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post(':id/rollback')
+  rollback(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @Req() req: { user?: { id?: string } },
+  ) {
+    return this.rolloutService.emergencyRollback(
+      id,
+      req.user?.id ?? 'system',
+      body.reason,
+    );
+  }
+
+  @RequirePermissions(Permission.ADMIN_ACCESS)
+  @Post(':id/metrics')
+  recordMetric(
+    @Param('id') id: string,
+    @Body()
+    body: {
+      totalRequests: number;
+      errorCount: number;
+      avgLatencyMs?: number;
+      p99LatencyMs?: number;
+      extra?: Record<string, any>;
+    },
+  ) {
+    return this.rolloutService.recordMetric(
+      id,
+      body.totalRequests,
+      body.errorCount,
+      body.avgLatencyMs,
+      body.p99LatencyMs,
+      body.extra,
+    );
+  }
+}

--- a/backend/src/policy-center/policy-rollout.service.ts
+++ b/backend/src/policy-center/policy-rollout.service.ts
@@ -1,0 +1,405 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Repository } from 'typeorm';
+
+import { PolicyVersionEntity } from './entities/policy-version.entity';
+import { PolicyRolloutEntity } from './entities/policy-rollout.entity';
+import { CanaryMetricEntity } from './entities/canary-metric.entity';
+import { RolloutStatus } from './enums/rollout-status.enum';
+import { PolicyVersionStatus } from './enums/policy-version-status.enum';
+import { PolicyReplayService } from './policy-replay.service';
+
+export interface StartRolloutDto {
+  policyVersionId: string;
+  canaryPercent?: number;
+  stepPercent?: number;
+  canaryWindowMinutes?: number;
+  errorRateThreshold?: number;
+}
+
+export interface RolloutSummary {
+  rolloutId: string;
+  policyVersionId: string;
+  status: RolloutStatus;
+  currentPercent: number;
+  canaryEvaluation: string | null;
+  canaryMetrics: Record<string, any> | null;
+}
+
+@Injectable()
+export class PolicyRolloutService {
+  private readonly logger = new Logger(PolicyRolloutService.name);
+
+  constructor(
+    @InjectRepository(PolicyVersionEntity)
+    private readonly policyRepo: Repository<PolicyVersionEntity>,
+    @InjectRepository(PolicyRolloutEntity)
+    private readonly rolloutRepo: Repository<PolicyRolloutEntity>,
+    @InjectRepository(CanaryMetricEntity)
+    private readonly metricsRepo: Repository<CanaryMetricEntity>,
+    private readonly replayService: PolicyReplayService,
+  ) {}
+
+  /**
+   * Begin a staged rollout for a DRAFT policy version.
+   * Sets the version to canary traffic percentage and starts the evaluation window.
+   */
+  async startRollout(
+    dto: StartRolloutDto,
+    actor: string,
+  ): Promise<PolicyRolloutEntity> {
+    const version = await this.policyRepo.findOne({
+      where: { id: dto.policyVersionId },
+    });
+    if (!version)
+      throw new NotFoundException(
+        `Policy version ${dto.policyVersionId} not found`,
+      );
+
+    if (version.status !== PolicyVersionStatus.DRAFT) {
+      throw new BadRequestException(
+        `Only DRAFT versions can be rolled out. Current status: ${version.status}`,
+      );
+    }
+
+    const existing = await this.rolloutRepo.findOne({
+      where: {
+        policyVersionId: dto.policyVersionId,
+        status: RolloutStatus.CANARY,
+      },
+    });
+    if (existing) {
+      throw new BadRequestException(
+        `A canary rollout is already in progress for version ${dto.policyVersionId}`,
+      );
+    }
+
+    const canaryPercent = dto.canaryPercent ?? 5;
+    const rollout = this.rolloutRepo.create({
+      policyVersionId: dto.policyVersionId,
+      canaryPercent,
+      stepPercent: dto.stepPercent ?? 25,
+      canaryWindowMinutes: dto.canaryWindowMinutes ?? 30,
+      errorRateThreshold: dto.errorRateThreshold ?? 0.05,
+      currentPercent: canaryPercent,
+      status: RolloutStatus.CANARY,
+      canaryEvaluation: 'pending',
+      canaryStartedAt: new Date(),
+      startedBy: actor,
+    });
+
+    const saved = await this.rolloutRepo.save(rollout);
+
+    this.logger.log(
+      `[Rollout] Started canary rollout id=${saved.id} for policyVersion=${dto.policyVersionId} at ${canaryPercent}%`,
+    );
+
+    return saved;
+  }
+
+  /**
+   * Record a canary metric snapshot for a rollout.
+   * Called by the application layer (e.g. notification processor, request handlers)
+   * to feed error-rate data into the evaluation window.
+   */
+  async recordMetric(
+    rolloutId: string,
+    totalRequests: number,
+    errorCount: number,
+    avgLatencyMs?: number,
+    p99LatencyMs?: number,
+    extra?: Record<string, any>,
+  ): Promise<CanaryMetricEntity> {
+    const rollout = await this.rolloutRepo.findOne({
+      where: { id: rolloutId },
+    });
+    if (!rollout) throw new NotFoundException(`Rollout ${rolloutId} not found`);
+
+    const errorRate = totalRequests > 0 ? errorCount / totalRequests : 0;
+
+    const metric = this.metricsRepo.create({
+      rolloutId,
+      policyVersionId: rollout.policyVersionId,
+      totalRequests,
+      errorCount,
+      errorRate,
+      avgLatencyMs: avgLatencyMs ?? null,
+      p99LatencyMs: p99LatencyMs ?? null,
+      extra: extra ?? null,
+      recordedAt: new Date(),
+    });
+
+    return this.metricsRepo.save(metric);
+  }
+
+  /**
+   * Evaluate the canary window for all active canary rollouts.
+   * Runs every minute via cron. Promotes or aborts based on error rate.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  async evaluateCanaries(): Promise<void> {
+    const activeCanaries = await this.rolloutRepo.find({
+      where: { status: RolloutStatus.CANARY },
+    });
+
+    for (const rollout of activeCanaries) {
+      await this.evaluateSingleCanary(rollout);
+    }
+  }
+
+  private async evaluateSingleCanary(
+    rollout: PolicyRolloutEntity,
+  ): Promise<void> {
+    if (!rollout.canaryStartedAt) return;
+
+    const windowEnd = new Date(
+      rollout.canaryStartedAt.getTime() + rollout.canaryWindowMinutes * 60_000,
+    );
+
+    if (new Date() < windowEnd) {
+      // Still within the evaluation window — check for early abort
+      await this.checkEarlyAbort(rollout);
+      return;
+    }
+
+    // Window has elapsed — compute aggregate metrics
+    const metrics = await this.metricsRepo.find({
+      where: { rolloutId: rollout.id },
+      order: { recordedAt: 'ASC' },
+    });
+
+    const totalRequests = metrics.reduce((s, m) => s + m.totalRequests, 0);
+    const totalErrors = metrics.reduce((s, m) => s + m.errorCount, 0);
+    const aggregateErrorRate =
+      totalRequests > 0 ? totalErrors / totalRequests : 0;
+
+    const passed = aggregateErrorRate <= rollout.errorRateThreshold;
+
+    rollout.canaryMetrics = {
+      totalRequests,
+      totalErrors,
+      aggregateErrorRate,
+      threshold: rollout.errorRateThreshold,
+      windowMinutes: rollout.canaryWindowMinutes,
+      evaluatedAt: new Date().toISOString(),
+    };
+
+    if (passed) {
+      rollout.canaryEvaluation = 'passed';
+      rollout.status = RolloutStatus.EXPANDING;
+      rollout.currentPercent = Math.min(
+        rollout.currentPercent + rollout.stepPercent,
+        100,
+      );
+      await this.rolloutRepo.save(rollout);
+
+      this.logger.log(
+        `[Rollout] Canary PASSED for rollout=${rollout.id} errorRate=${aggregateErrorRate.toFixed(4)} — expanding to ${rollout.currentPercent}%`,
+      );
+
+      if (rollout.currentPercent >= 100) {
+        await this.promoteToFull(rollout);
+      }
+    } else {
+      rollout.canaryEvaluation = 'failed';
+      await this.rolloutRepo.save(rollout);
+
+      this.logger.warn(
+        `[Rollout] Canary FAILED for rollout=${rollout.id} errorRate=${aggregateErrorRate.toFixed(4)} > threshold=${rollout.errorRateThreshold} — auto-aborting`,
+      );
+
+      await this.emergencyRollback(
+        rollout.id,
+        'system',
+        'Canary evaluation failed: error rate exceeded threshold',
+      );
+    }
+  }
+
+  private async checkEarlyAbort(rollout: PolicyRolloutEntity): Promise<void> {
+    // Compute rolling error rate from the last 5 minutes of metrics
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000);
+    const recent = await this.metricsRepo
+      .createQueryBuilder('m')
+      .where('m.rollout_id = :id', { id: rollout.id })
+      .andWhere('m.recorded_at >= :since', { since: fiveMinutesAgo })
+      .getMany();
+
+    if (recent.length === 0) return;
+
+    const totalRequests = recent.reduce((s, m) => s + m.totalRequests, 0);
+    const totalErrors = recent.reduce((s, m) => s + m.errorCount, 0);
+    const recentErrorRate = totalRequests > 0 ? totalErrors / totalRequests : 0;
+
+    // Early abort if error rate is 3× the threshold
+    if (recentErrorRate > rollout.errorRateThreshold * 3) {
+      this.logger.warn(
+        `[Rollout] Early abort triggered for rollout=${rollout.id} recentErrorRate=${recentErrorRate.toFixed(4)}`,
+      );
+      await this.emergencyRollback(
+        rollout.id,
+        'system',
+        `Early abort: recent error rate ${recentErrorRate.toFixed(4)} exceeded 3× threshold`,
+      );
+    }
+  }
+
+  /**
+   * Manually advance the rollout to the next traffic percentage step.
+   */
+  async advanceStep(
+    rolloutId: string,
+    actor: string,
+  ): Promise<PolicyRolloutEntity> {
+    const rollout = await this.getRollout(rolloutId);
+
+    if (
+      ![RolloutStatus.CANARY, RolloutStatus.EXPANDING].includes(rollout.status)
+    ) {
+      throw new BadRequestException(
+        `Rollout ${rolloutId} is not in an advanceable state`,
+      );
+    }
+
+    rollout.currentPercent = Math.min(
+      rollout.currentPercent + rollout.stepPercent,
+      100,
+    );
+
+    if (rollout.currentPercent >= 100) {
+      await this.promoteToFull(rollout);
+    } else {
+      rollout.status = RolloutStatus.EXPANDING;
+      await this.rolloutRepo.save(rollout);
+    }
+
+    this.logger.log(
+      `[Rollout] Advanced rollout=${rolloutId} to ${rollout.currentPercent}% by actor=${actor}`,
+    );
+
+    return rollout;
+  }
+
+  /**
+   * Emergency rollback: abort the rollout and revert to the previous active policy version.
+   */
+  async emergencyRollback(
+    rolloutId: string,
+    actor: string,
+    reason: string,
+  ): Promise<{
+    rollout: PolicyRolloutEntity;
+    revertedToVersionId: string | null;
+  }> {
+    const rollout = await this.getRollout(rolloutId);
+
+    if (
+      [RolloutStatus.ROLLED_BACK, RolloutStatus.ABORTED].includes(
+        rollout.status,
+      )
+    ) {
+      throw new BadRequestException(
+        `Rollout ${rolloutId} is already ${rollout.status}`,
+      );
+    }
+
+    const targetVersion = await this.policyRepo.findOne({
+      where: { id: rollout.policyVersionId },
+    });
+
+    // Find the previously active version for this policy
+    let revertedToVersionId: string | null = null;
+    if (targetVersion) {
+      const previousActive = await this.policyRepo
+        .createQueryBuilder('p')
+        .where('p.policy_name = :name', { name: targetVersion.policyName })
+        .andWhere('p.status = :status', { status: PolicyVersionStatus.ACTIVE })
+        .andWhere('p.id != :id', { id: targetVersion.id })
+        .orderBy('p.version', 'DESC')
+        .getOne();
+
+      revertedToVersionId = previousActive?.id ?? null;
+    }
+
+    rollout.status = RolloutStatus.ROLLED_BACK;
+    rollout.rolledBackBy = actor;
+    rollout.rollbackReason = reason;
+    rollout.rollbackToVersionId = revertedToVersionId;
+    await this.rolloutRepo.save(rollout);
+
+    this.logger.warn(
+      `[Rollout] Emergency rollback for rollout=${rolloutId} by actor=${actor}: ${reason}`,
+    );
+
+    return { rollout, revertedToVersionId };
+  }
+
+  private async promoteToFull(rollout: PolicyRolloutEntity): Promise<void> {
+    rollout.status = RolloutStatus.FULL;
+    rollout.currentPercent = 100;
+    rollout.fullRolloutAt = new Date();
+    await this.rolloutRepo.save(rollout);
+
+    // Activate the policy version
+    const version = await this.policyRepo.findOne({
+      where: { id: rollout.policyVersionId },
+    });
+    if (version && version.status === PolicyVersionStatus.DRAFT) {
+      // Supersede the current active version
+      const currentActive = await this.policyRepo.findOne({
+        where: {
+          policyName: version.policyName,
+          status: PolicyVersionStatus.ACTIVE,
+        },
+        order: { version: 'DESC' },
+      });
+
+      if (currentActive) {
+        currentActive.status = PolicyVersionStatus.SUPERSEDED;
+        currentActive.effectiveTo = new Date();
+        await this.policyRepo.save(currentActive);
+      }
+
+      version.status = PolicyVersionStatus.ACTIVE;
+      version.activatedAt = new Date();
+      version.activatedBy = rollout.startedBy;
+      await this.replayService.lockSnapshot(version);
+    }
+
+    this.logger.log(
+      `[Rollout] Full rollout complete for rollout=${rollout.id} policyVersion=${rollout.policyVersionId}`,
+    );
+  }
+
+  async getRollout(rolloutId: string): Promise<PolicyRolloutEntity> {
+    const rollout = await this.rolloutRepo.findOne({
+      where: { id: rolloutId },
+    });
+    if (!rollout) throw new NotFoundException(`Rollout ${rolloutId} not found`);
+    return rollout;
+  }
+
+  async listRollouts(policyVersionId?: string): Promise<PolicyRolloutEntity[]> {
+    const where: Record<string, any> = {};
+    if (policyVersionId) where.policyVersionId = policyVersionId;
+    return this.rolloutRepo.find({ where, order: { createdAt: 'DESC' } });
+  }
+
+  async getSummary(rolloutId: string): Promise<RolloutSummary> {
+    const rollout = await this.getRollout(rolloutId);
+    return {
+      rolloutId: rollout.id,
+      policyVersionId: rollout.policyVersionId,
+      status: rollout.status,
+      currentPercent: rollout.currentPercent,
+      canaryEvaluation: rollout.canaryEvaluation,
+      canaryMetrics: rollout.canaryMetrics,
+    };
+  }
+}


### PR DESCRIPTION
Hardened Notification Delivery
ProviderFailoverService — each channel now has a provider chain. Email falls back to in-app, SMS falls back to push then in-app, push falls back to in-app. Every attempt is recorded with timing and error details.

NotificationProcessor (rewritten) — replaced the raw provider switch-case with ProviderFailoverService.deliver(). On success it marks SENT and resolves any DLQ replay. On total failure it throws so BullMQ retries. After all retries are exhausted, onFailed moves the notification to the DLQ.

DeliveryRepairService — cron every 5 minutes scans for PENDING notifications older than 10 minutes (stuck jobs) and re-enqueues them with a deduplication jobId so they can't double-fire.

Dead Letter Queue + Replay Workflow
NotificationDlqEntity — persists failed notifications with full provider attempt history, error message, replay count, actor, and status (pending → replaying → replayed | abandoned).

NotificationDlqService — enqueue(), replay() (single), replayBulk() (by channel), abandon(), markReplayed(), markReplayFailed().

NotificationDlqController — REST endpoints: GET /notifications/dlq, GET /notifications/dlq/:id, POST /notifications/dlq/:id/replay, POST /notifications/dlq/replay/bulk, POST /notifications/dlq/:id/abandon.

Staged Policy Rollout, Canary Evaluation, Emergency Rollback
PolicyRolloutEntity — tracks rollout lifecycle: canary %, step %, evaluation window, error-rate threshold, canary metrics snapshot, rollback metadata.

CanaryMetricEntity — time-series error-rate and latency snapshots fed in during the canary window.

PolicyRolloutService — startRollout() begins at canary %, evaluateCanaries() cron runs every minute to check window expiry and aggregate error rates, early-abort fires at 3× threshold, advanceStep() for manual promotion, emergencyRollback() aborts and records the revert target, promoteToFull() activates the policy version via the existing PolicyReplayService.lockSnapshot().

PolicyRolloutController — POST /policy-center/rollouts, POST /:id/advance, POST /:id/rollback, POST /:id/metrics, GET /:id/summary.


closes #676
closes #563
