### PR TITLE
fix: serial dedup, emergency halt, vesting guard, REQ_IDX storage

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/error.rs
+++ b/lifebank-soroban/contracts/coordinator/src/error.rs
@@ -30,4 +30,7 @@ pub enum CoordinatorError {
 
     // Circuit breaker
     ContractPaused = 840,
+
+    /// emergency_halt() has been called; all workflow mutations are blocked.
+    EmergencyHalted = 841,
 }

--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -249,6 +249,70 @@ impl CoordinatorContract {
         Ok(())
     }
 
+    fn require_not_emergency_halted(env: &Env) -> Result<(), CoordinatorError> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::EmergencyHalt)
+            .unwrap_or(false)
+        {
+            return Err(CoordinatorError::EmergencyHalted);
+        }
+        Ok(())
+    }
+
+    /// Emergency halt — immediately blocks all in-flight workflow steps
+    /// (confirm_delivery and settle_payment). Admin only.
+    ///
+    /// Unlike pause(), which prevents new allocations, emergency_halt() is
+    /// designed to contain active incidents (e.g. compromised oracle, critical
+    /// bug) by stopping every in-progress workflow from advancing.
+    /// Call unpause() or a dedicated resume function to restore normal operation.
+    pub fn emergency_halt(env: Env, admin: Address) -> Result<(), CoordinatorError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(CoordinatorError::Unauthorized)?;
+        if admin != stored {
+            return Err(CoordinatorError::Unauthorized);
+        }
+        env.storage().instance().set(&DataKey::EmergencyHalt, &true);
+        env.events().publish(
+            (
+                symbol_short!("coord"),
+                symbol_short!("emrghlt"),
+                symbol_short!("v1"),
+            ),
+            admin,
+        );
+        Ok(())
+    }
+
+    /// Clear the emergency halt flag. Admin only.
+    pub fn clear_emergency_halt(env: Env, admin: Address) -> Result<(), CoordinatorError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(CoordinatorError::Unauthorized)?;
+        if admin != stored {
+            return Err(CoordinatorError::Unauthorized);
+        }
+        env.storage().instance().set(&DataKey::EmergencyHalt, &false);
+        Ok(())
+    }
+
+    /// Returns whether the emergency halt is active.
+    pub fn is_emergency_halted(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::EmergencyHalt)
+            .unwrap_or(false)
+    }
+
     /// Step 1 – Allocate inventory units to a pending request.
     pub fn allocate_units(
         env: Env,
@@ -341,6 +405,7 @@ impl CoordinatorContract {
         caller.require_auth();
         Self::require_initialized(&env)?;
         Self::require_not_paused(&env)?;
+        Self::require_not_emergency_halted(&env)?;
 
         let mut wf = load_workflow(&env, request_id).ok_or(CoordinatorError::WorkflowNotFound)?;
 
@@ -395,6 +460,7 @@ impl CoordinatorContract {
         caller.require_auth();
         Self::require_initialized(&env)?;
         Self::require_not_paused(&env)?;
+        Self::require_not_emergency_halted(&env)?;
 
         let mut wf = load_workflow(&env, request_id).ok_or(CoordinatorError::WorkflowNotFound)?;
 

--- a/lifebank-soroban/contracts/coordinator/src/types.rs
+++ b/lifebank-soroban/contracts/coordinator/src/types.rs
@@ -50,4 +50,14 @@ pub enum DataKey {
     PaymentContract,
     Workflow(u64),
     Paused,
+    /// Emergency halt flag — set by emergency_halt(); blocks all in-flight
+    /// workflow steps until manually cleared by admin.
+    EmergencyHalt,
+}
+
+/// Status applied to all in-flight workflows when emergency_halt() is triggered.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkflowHaltedStatus {
+    Halted,
 }

--- a/lifebank-soroban/contracts/inventory/src/lib.rs
+++ b/lifebank-soroban/contracts/inventory/src/lib.rs
@@ -127,6 +127,7 @@ impl InventoryContract {
     pub fn register_blood(
         env: Env,
         bank_id: Address,
+        serial_number: String,
         blood_type: BloodType,
         quantity_ml: u32,
         donor_id: Option<Address>,
@@ -134,12 +135,13 @@ impl InventoryContract {
         // 1. Verify bank authentication
         bank_id.require_auth();
 
-        Self::register_blood_after_auth(env, bank_id, blood_type, quantity_ml, donor_id)
+        Self::register_blood_after_auth(env, bank_id, serial_number, blood_type, quantity_ml, donor_id)
     }
 
     fn register_blood_after_auth(
         env: Env,
         bank_id: Address,
+        serial_number: String,
         blood_type: BloodType,
         quantity_ml: u32,
         donor_id: Option<Address>,
@@ -154,6 +156,12 @@ impl InventoryContract {
         // Verify bank is authorized
         if !storage::is_authorized_bank(&env, &bank_id) {
             return Err(ContractError::NotAuthorizedBloodBank);
+        }
+
+        // Reject duplicate serial numbers — physical blood bags have unique IDs
+        let serial_key = DataKey::Serial(serial_number.clone());
+        if env.storage().persistent().has(&serial_key) {
+            return Err(ContractError::DuplicateBloodUnit);
         }
 
         // Validate quantity
@@ -209,6 +217,9 @@ impl InventoryContract {
 
         // Store blood unit — only reaches here if the ID slot was empty.
         storage::set_blood_unit(&env, &blood_unit);
+
+        // Persist serial number → unit_id so duplicate registrations are rejected
+        env.storage().persistent().set(&serial_key, &blood_unit_id);
 
         // Update indexes for efficient querying
         storage::add_to_blood_type_index(&env, &blood_unit);
@@ -481,7 +492,7 @@ impl InventoryContract {
     pub fn batch_register_blood(
         env: Env,
         bank_id: Address,
-        entries: Vec<(BloodType, u32, Option<Address>)>,
+        entries: Vec<(String, BloodType, u32, Option<Address>)>,
     ) -> Result<Vec<u64>, ContractError> {
         bank_id.require_auth();
         Self::require_not_paused(&env)?;
@@ -494,16 +505,17 @@ impl InventoryContract {
         }
 
         for i in 0..entries.len() {
-            let (_, quantity_ml, _) = entries.get(i).unwrap();
+            let (_, _, quantity_ml, _) = entries.get(i).unwrap();
             validation::validate_quantity(quantity_ml)?;
         }
 
         let mut ids: Vec<u64> = Vec::new(&env);
         for i in 0..entries.len() {
-            let (blood_type, quantity_ml, donor_id) = entries.get(i).unwrap();
+            let (serial_number, blood_type, quantity_ml, donor_id) = entries.get(i).unwrap();
             let id = Self::register_blood_after_auth(
                 env.clone(),
                 bank_id.clone(),
+                serial_number,
                 blood_type,
                 quantity_ml,
                 donor_id,

--- a/lifebank-soroban/contracts/inventory/src/test.rs
+++ b/lifebank-soroban/contracts/inventory/src/test.rs
@@ -57,6 +57,7 @@ fn test_register_blood_success() {
 
     let blood_unit_id = client.register_blood(
         &bank,
+        &String::from_str(&env, "SN-SUCCESS-001"),
         &blood_type,
         &quantity_ml,
         &Some(donor.clone()),
@@ -87,6 +88,7 @@ fn test_register_blood_anonymous_donor() {
 
     let blood_unit_id = client.register_blood(
         &bank,
+        &String::from_str(&env, "SN-ANON-001"),
         &BloodType::ONegative,
         &450u32,
         &None, // Anonymous donor
@@ -105,15 +107,15 @@ fn test_register_blood_increments_id() {
     env.ledger().set_timestamp(current_time);
 
     // Register first unit
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-001"), &BloodType::APositive, &450u32, &None);
     assert_eq!(id1, 1);
 
     // Register second unit
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-002"), &BloodType::BPositive, &450u32, &None);
     assert_eq!(id2, 2);
 
     // Register third unit
-    let id3 = client.register_blood(&bank, &BloodType::ONegative, &450u32, &None);
+    let id3 = client.register_blood(&bank, &String::from_str(&env, "SN-003"), &BloodType::ONegative, &450u32, &None);
     assert_eq!(id3, 3);
 }
 
@@ -128,6 +130,7 @@ fn test_register_blood_quantity_too_low() {
 
     client.register_blood(
         &bank,
+        &String::from_str(&env, "SN-TOOLOW"),
         &BloodType::APositive,
         &50u32, // Too low
         &None,
@@ -145,6 +148,7 @@ fn test_register_blood_quantity_too_high() {
 
     client.register_blood(
         &bank,
+        &String::from_str(&env, "SN-TOOHIGH"),
         &BloodType::APositive,
         &700u32, // Too high
         &None,
@@ -162,6 +166,7 @@ fn test_register_blood_unauthorized_bank() {
 
     client.register_blood(
         &unauthorized_bank,
+        &String::from_str(&env, "SN-UNAUTH"),
         &BloodType::APositive,
         &450u32,
         &None,
@@ -189,7 +194,11 @@ fn test_register_all_blood_types() {
     ];
 
     for (i, blood_type) in blood_types.iter().enumerate() {
-        let id = client.register_blood(&bank, &blood_type, &450u32, &None);
+        let serial_strs = [
+            "SN-BT001", "SN-BT002", "SN-BT003", "SN-BT004",
+            "SN-BT005", "SN-BT006", "SN-BT007", "SN-BT008",
+        ];
+        let id = client.register_blood(&bank, &String::from_str(&env, serial_strs[i]), &blood_type, &450u32, &None);
 
         assert_eq!(id, (i + 1) as u64);
 
@@ -217,7 +226,7 @@ fn test_register_blood_expiry_derived_from_ledger_time() {
     // Register at ledger time 1000
     let t1 = 1000u64;
     env.ledger().set_timestamp(t1);
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-004"), &BloodType::APositive, &450u32, &None);
     let unit1 = client.get_blood_unit(&id1);
     assert_eq!(unit1.donation_timestamp, t1);
     assert_eq!(unit1.expiration_timestamp, t1 + SHELF_LIFE_SECS);
@@ -225,7 +234,7 @@ fn test_register_blood_expiry_derived_from_ledger_time() {
     // Register at a later ledger time
     let t2 = 500_000u64;
     env.ledger().set_timestamp(t2);
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-005"), &BloodType::BPositive, &450u32, &None);
     let unit2 = client.get_blood_unit(&id2);
     assert_eq!(unit2.donation_timestamp, t2);
     assert_eq!(unit2.expiration_timestamp, t2 + SHELF_LIFE_SECS);
@@ -247,11 +256,11 @@ fn test_duplicate_registration_prevented() {
     env.ledger().set_timestamp(current_time);
 
     // Register first unit — gets ID 1
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-006"), &BloodType::APositive, &450u32, &None);
     assert_eq!(id1, 1);
 
     // Register second unit — gets ID 2 (no collision)
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-007"), &BloodType::BPositive, &450u32, &None);
     assert_eq!(id2, 2);
 
     // Both units exist and are distinct
@@ -285,8 +294,11 @@ fn test_duplicate_registration_prevented() {
 
     // Now register_blood will try to claim ID 3 (counter is at 2, next is 3),
     // but the slot is already occupied — must return DuplicateBloodUnit (#24).
+    // This call uses a fresh serial to avoid hitting the serial dedup — the
+    // DuplicateBloodUnit error must come from the ID-slot guard, not serial check.
     let result = client.try_register_blood(
         &bank,
+        &String::from_str(&env, "SN-RACE"),
         &BloodType::ABPositive,
         &450u32,
         &None,
@@ -304,10 +316,14 @@ fn test_sequential_registration_no_id_collision() {
 
     // Register 10 units rapidly — simulates multiple registrations in the
     // same ledger. Each must get a unique, sequential ID.
+    let serials = [
+        "SN-SEQ01", "SN-SEQ02", "SN-SEQ03", "SN-SEQ04", "SN-SEQ05",
+        "SN-SEQ06", "SN-SEQ07", "SN-SEQ08", "SN-SEQ09", "SN-SEQ10",
+    ];
     let mut ids = soroban_sdk::Vec::new(&env);
-    for _ in 0..10 {
+    for j in 0..10usize {
         let id =
-            client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+            client.register_blood(&bank, &String::from_str(&env, serials[j]), &BloodType::APositive, &450u32, &None);
         ids.push_back(id);
     }
 
@@ -329,12 +345,12 @@ fn test_register_blood_edge_case_quantities() {
     env.ledger().set_timestamp(current_time);
 
     // Minimum valid quantity
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &100u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-009"), &BloodType::APositive, &100u32, &None);
     let unit1 = client.get_blood_unit(&id1);
     assert_eq!(unit1.quantity_ml, 100);
 
     // Maximum valid quantity
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &600u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-010"), &BloodType::BPositive, &600u32, &None);
     let unit2 = client.get_blood_unit(&id2);
     assert_eq!(unit2.quantity_ml, 600);
 }
@@ -347,7 +363,7 @@ fn test_update_status_available_to_reserved() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-011"), &BloodType::APositive, &450u32, &None);
 
     // Update to Reserved
     let updated_unit = client.update_status(
@@ -372,7 +388,7 @@ fn test_update_status_complete_flow() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-012"), &BloodType::APositive, &450u32, &None);
 
     // Available -> Reserved
     let unit = client.update_status(
@@ -411,7 +427,7 @@ fn test_update_status_invalid_available_to_delivered() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-013"), &BloodType::APositive, &450u32, &None);
 
     // Available -> Delivered (skipping forward — invalid)
     client.update_status(
@@ -431,7 +447,7 @@ fn test_update_status_invalid_available_to_intransit() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-014"), &BloodType::APositive, &450u32, &None);
 
     // Available -> InTransit (skipping Reserved — invalid)
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
@@ -446,7 +462,7 @@ fn test_update_status_invalid_reserved_to_delivered() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-015"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
 
     // Reserved -> Delivered (skipping InTransit — invalid)
@@ -462,7 +478,7 @@ fn test_update_status_invalid_intransit_to_available() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-016"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
 
@@ -479,7 +495,7 @@ fn test_update_status_invalid_intransit_to_reserved() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-017"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
 
@@ -496,7 +512,7 @@ fn test_update_status_invalid_delivered_to_available() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-018"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::Delivered, &admin, &None);
@@ -514,7 +530,7 @@ fn test_update_status_invalid_delivered_to_reserved() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-019"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::Delivered, &admin, &None);
@@ -532,7 +548,7 @@ fn test_update_status_invalid_delivered_to_intransit() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-020"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&unit_id, &BloodStatus::Delivered, &admin, &None);
@@ -550,7 +566,7 @@ fn test_update_status_invalid_expired_to_available() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-021"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Expired, &admin, &None);
 
     // Expired -> Available (backwards from terminal — invalid)
@@ -566,7 +582,7 @@ fn test_update_status_invalid_expired_to_reserved() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-022"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Expired, &admin, &None);
 
     // Expired -> Reserved (backwards from terminal — invalid)
@@ -581,7 +597,7 @@ fn test_update_status_reserved_back_to_available() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-023"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
 
     // Reserved -> Available (valid cancellation)
@@ -598,18 +614,18 @@ fn test_update_status_expire_from_any_non_terminal() {
     env.ledger().set_timestamp(current_time);
 
     // Available -> Expired
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-024"), &BloodType::APositive, &450u32, &None);
     let unit1 = client.update_status(&id1, &BloodStatus::Expired, &admin, &None);
     assert_eq!(unit1.status, BloodStatus::Expired);
 
     // Reserved -> Expired
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-025"), &BloodType::BPositive, &450u32, &None);
     client.update_status(&id2, &BloodStatus::Reserved, &admin, &None);
     let unit2 = client.update_status(&id2, &BloodStatus::Expired, &admin, &None);
     assert_eq!(unit2.status, BloodStatus::Expired);
 
     // InTransit -> Expired
-    let id3 = client.register_blood(&bank, &BloodType::ONegative, &450u32, &None);
+    let id3 = client.register_blood(&bank, &String::from_str(&env, "SN-026"), &BloodType::ONegative, &450u32, &None);
     client.update_status(&id3, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id3, &BloodStatus::InTransit, &admin, &None);
     let unit3 = client.update_status(&id3, &BloodStatus::Expired, &admin, &None);
@@ -625,7 +641,7 @@ fn test_update_status_unauthorized() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-027"), &BloodType::APositive, &450u32, &None);
 
     let unauthorized = Address::generate(&env);
 
@@ -651,7 +667,7 @@ fn test_update_status_expired_unit() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-028"), &BloodType::APositive, &450u32, &None);
 
     // Move time past expiration (ledger-computed: current_time + 35 days)
     let expiration = current_time + SHELF_LIFE_SECS;
@@ -670,7 +686,7 @@ fn test_update_status_from_terminal_delivered() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-029"), &BloodType::APositive, &450u32, &None);
 
     // Move to Delivered
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
@@ -691,7 +707,7 @@ fn test_mark_delivered_success() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-030"), &BloodType::APositive, &450u32, &None);
 
     // Set to Reserved first (should be InTransit in real scenario, but for test)
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
@@ -712,7 +728,7 @@ fn test_mark_delivered_from_available() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-031"), &BloodType::APositive, &450u32, &None);
 
     // Try to mark as delivered when still Available (invalid transition)
     client.mark_delivered(&unit_id, &admin, &String::from_str(&env, "Hospital A"));
@@ -728,7 +744,7 @@ fn test_mark_expired_success() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-032"), &BloodType::APositive, &450u32, &None);
 
     // Mark as expired from Available state (valid transition)
     let updated = client.mark_expired(&unit_id, &admin);
@@ -744,7 +760,7 @@ fn test_mark_expired_from_reserved() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-033"), &BloodType::APositive, &450u32, &None);
 
     // Move to Reserved
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
@@ -765,7 +781,7 @@ fn test_status_history_tracking() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-034"), &BloodType::APositive, &450u32, &None);
 
     // Perform status changes
     client.update_status(
@@ -820,7 +836,7 @@ fn test_status_change_count() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-035"), &BloodType::APositive, &450u32, &None);
 
     // Initial count should be 0 (no changes yet)
     assert_eq!(client.get_status_change_count(&unit_id), 0);
@@ -847,9 +863,9 @@ fn test_batch_update_status_success() {
     env.ledger().set_timestamp(current_time);
 
     // Create multiple blood units
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
-    let id3 = client.register_blood(&bank, &BloodType::ONegative, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-036"), &BloodType::APositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-037"), &BloodType::BPositive, &450u32, &None);
+    let id3 = client.register_blood(&bank, &String::from_str(&env, "SN-038"), &BloodType::ONegative, &450u32, &None);
 
     // Batch update to Reserved
     let unit_ids = vec![&env, id1, id2, id3];
@@ -876,7 +892,7 @@ fn test_batch_update_status_single_unit() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-039"), &BloodType::APositive, &450u32, &None);
 
     let unit_ids = vec![&env, unit_id];
     let count = client.batch_update_status(&unit_ids, &BloodStatus::Reserved, &admin, &None);
@@ -907,7 +923,7 @@ fn test_batch_update_status_nonexistent_unit() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-040"), &BloodType::APositive, &450u32, &None);
 
     // Try batch update with one nonexistent unit
     let unit_ids = vec![&env, unit_id, 999];
@@ -923,7 +939,7 @@ fn test_batch_update_status_unauthorized() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-041"), &BloodType::APositive, &450u32, &None);
 
     let unauthorized = Address::generate(&env);
 
@@ -940,8 +956,8 @@ fn test_batch_update_status_invalid_transition() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-042"), &BloodType::APositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-043"), &BloodType::BPositive, &450u32, &None);
 
     // Move id1 to Reserved
     client.update_status(&id1, &BloodStatus::Reserved, &admin, &None);
@@ -966,7 +982,7 @@ fn test_dispose_from_expired_success() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-044"), &BloodType::APositive, &450u32, &None);
 
     // Expire the unit first
     client.mark_expired(&unit_id, &admin);
@@ -993,7 +1009,7 @@ fn test_dispose_records_history() {
     let current_time = 1000u64;
     env.ledger().set_timestamp(current_time);
 
-    let unit_id = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-045"), &BloodType::BPositive, &450u32, &None);
 
     client.mark_expired(&unit_id, &admin);
     client.dispose(&unit_id, &admin, &None);
@@ -1019,7 +1035,7 @@ fn test_dispose_from_available_invalid() {
     let bank = admin.clone();
     env.ledger().set_timestamp(1000u64);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-046"), &BloodType::APositive, &450u32, &None);
 
     // Cannot dispose an Available unit directly (must expire first)
     client.dispose(&unit_id, &admin, &None);
@@ -1033,7 +1049,7 @@ fn test_dispose_from_reserved_invalid() {
     let bank = admin.clone();
     env.ledger().set_timestamp(1000u64);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-047"), &BloodType::APositive, &450u32, &None);
     client.update_status(&unit_id, &BloodStatus::Reserved, &admin, &None);
 
     // Cannot dispose a Reserved unit directly
@@ -1048,7 +1064,7 @@ fn test_transition_from_disposed_is_invalid() {
     let bank = admin.clone();
     env.ledger().set_timestamp(1000u64);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-048"), &BloodType::APositive, &450u32, &None);
     client.mark_expired(&unit_id, &admin);
     client.dispose(&unit_id, &admin, &None);
 
@@ -1070,8 +1086,8 @@ fn test_batch_dispose_after_expiry() {
     let bank = admin.clone();
     env.ledger().set_timestamp(1000u64);
 
-    let id1 = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
-    let id2 = client.register_blood(&bank, &BloodType::BPositive, &450u32, &None);
+    let id1 = client.register_blood(&bank, &String::from_str(&env, "SN-049"), &BloodType::APositive, &450u32, &None);
+    let id2 = client.register_blood(&bank, &String::from_str(&env, "SN-050"), &BloodType::BPositive, &450u32, &None);
 
     client.mark_expired(&id1, &admin);
     client.mark_expired(&id2, &admin);
@@ -1101,7 +1117,7 @@ fn test_batch_dispose_after_expiry() {
 fn test_transition_available_to_reserved_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-051"), &BloodType::APositive, &450u32, &None);
     let unit = client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     assert_eq!(unit.status, BloodStatus::Reserved);
 }
@@ -1110,7 +1126,7 @@ fn test_transition_available_to_reserved_succeeds() {
 fn test_transition_available_to_expired_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-052"), &BloodType::APositive, &450u32, &None);
     let unit = client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     assert_eq!(unit.status, BloodStatus::Expired);
 }
@@ -1119,7 +1135,7 @@ fn test_transition_available_to_expired_succeeds() {
 fn test_transition_reserved_to_intransit_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-053"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     assert_eq!(unit.status, BloodStatus::InTransit);
@@ -1129,7 +1145,7 @@ fn test_transition_reserved_to_intransit_succeeds() {
 fn test_transition_reserved_to_available_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-054"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::Available, &admin, &None);
     assert_eq!(unit.status, BloodStatus::Available);
@@ -1139,7 +1155,7 @@ fn test_transition_reserved_to_available_succeeds() {
 fn test_transition_reserved_to_expired_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-055"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     assert_eq!(unit.status, BloodStatus::Expired);
@@ -1149,7 +1165,7 @@ fn test_transition_reserved_to_expired_succeeds() {
 fn test_transition_intransit_to_delivered_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-056"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
@@ -1160,7 +1176,7 @@ fn test_transition_intransit_to_delivered_succeeds() {
 fn test_transition_intransit_to_expired_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-057"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::Expired, &admin, &None);
@@ -1171,7 +1187,7 @@ fn test_transition_intransit_to_expired_succeeds() {
 fn test_transition_expired_to_disposed_succeeds() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-058"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     let unit = client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     assert_eq!(unit.status, BloodStatus::Disposed);
@@ -1181,7 +1197,7 @@ fn test_transition_expired_to_disposed_succeeds() {
 fn test_transition_compromised_to_disposed_succeeds() {
     let (env, admin, client, contract_id) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-059"), &BloodType::APositive, &450u32, &None);
 
     // Seed Compromised status directly — Available→Compromised is not a defined
     // transition, so we write it via storage to test the Compromised→Disposed path.
@@ -1204,7 +1220,7 @@ fn test_transition_delivered_to_collected_fails() {
     // "Collected" maps to Available in this contract's terminology.
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-060"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
@@ -1218,7 +1234,7 @@ fn test_transition_disposed_to_cleared_fails() {
     // "Cleared" maps to Available in this contract's terminology.
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-061"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     // Disposed → Available (backwards from terminal)
@@ -1231,7 +1247,7 @@ fn test_transition_transfused_to_dispatched_fails() {
     // "Transfused" maps to Delivered; "Dispatched" maps to InTransit.
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-062"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
@@ -1244,7 +1260,7 @@ fn test_transition_transfused_to_dispatched_fails() {
 fn test_transition_delivered_to_reserved_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-063"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
@@ -1256,7 +1272,7 @@ fn test_transition_delivered_to_reserved_fails() {
 fn test_transition_intransit_to_available_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-064"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
     client.update_status(&id, &BloodStatus::Available, &admin, &None);
@@ -1267,7 +1283,7 @@ fn test_transition_intransit_to_available_fails() {
 fn test_transition_available_to_delivered_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-065"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
 }
 
@@ -1276,7 +1292,7 @@ fn test_transition_available_to_delivered_fails() {
 fn test_transition_available_to_intransit_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-066"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
 }
 
@@ -1285,7 +1301,7 @@ fn test_transition_available_to_intransit_fails() {
 fn test_transition_reserved_to_delivered_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-067"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
 }
@@ -1297,7 +1313,7 @@ fn test_transition_reserved_to_delivered_fails() {
 fn test_transition_expired_to_available_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-068"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Available, &admin, &None);
 }
@@ -1307,7 +1323,7 @@ fn test_transition_expired_to_available_fails() {
 fn test_transition_expired_to_reserved_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-069"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
 }
@@ -1317,7 +1333,7 @@ fn test_transition_expired_to_reserved_fails() {
 fn test_transition_expired_to_intransit_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-070"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
 }
@@ -1327,7 +1343,7 @@ fn test_transition_expired_to_intransit_fails() {
 fn test_transition_expired_to_delivered_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-071"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
 }
@@ -1337,7 +1353,7 @@ fn test_transition_expired_to_delivered_fails() {
 fn test_transition_expired_to_compromised_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-072"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Compromised, &admin, &None);
 }
@@ -1349,7 +1365,7 @@ fn test_transition_expired_to_compromised_fails() {
 fn test_transition_disposed_to_available_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-073"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::Available, &admin, &None);
@@ -1360,7 +1376,7 @@ fn test_transition_disposed_to_available_fails() {
 fn test_transition_disposed_to_reserved_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-074"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
@@ -1371,7 +1387,7 @@ fn test_transition_disposed_to_reserved_fails() {
 fn test_transition_disposed_to_intransit_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-075"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::InTransit, &admin, &None);
@@ -1382,7 +1398,7 @@ fn test_transition_disposed_to_intransit_fails() {
 fn test_transition_disposed_to_delivered_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-076"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::Delivered, &admin, &None);
@@ -1393,7 +1409,7 @@ fn test_transition_disposed_to_delivered_fails() {
 fn test_transition_disposed_to_expired_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-077"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
@@ -1404,7 +1420,7 @@ fn test_transition_disposed_to_expired_fails() {
 fn test_transition_disposed_to_compromised_fails() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-078"), &BloodType::APositive, &450u32, &None);
     client.update_status(&id, &BloodStatus::Expired, &admin, &None);
     client.update_status(&id, &BloodStatus::Disposed, &admin, &None);
     client.update_status(&id, &BloodStatus::Compromised, &admin, &None);
@@ -1496,7 +1512,7 @@ fn test_pause_blocks_write_functions() {
     assert!(client.is_paused());
 
     // register_blood should fail with ContractPaused (#160)
-    let result = client.try_register_blood(&admin, &BloodType::OPositive, &450u32, &None);
+    let result = client.try_register_blood(&admin, &String::from_str(&env, "SN-PAUSE-CHK"), &BloodType::OPositive, &450u32, &None);
     assert!(result.is_err());
 }
 
@@ -1506,7 +1522,7 @@ fn test_pause_allows_read_functions() {
     env.ledger().set_timestamp(1000);
 
     // Register a unit before pausing
-    let unit_id = client.register_blood(&admin, &BloodType::OPositive, &450u32, &None);
+    let unit_id = client.register_blood(&admin, &String::from_str(&env, "SN-079"), &BloodType::OPositive, &450u32, &None);
 
     // Pause
     client.pause(&admin);
@@ -1529,7 +1545,7 @@ fn test_unpause_restores_functionality() {
     assert!(!client.is_paused());
 
     // Write should succeed after unpause
-    let unit_id = client.register_blood(&admin, &BloodType::APositive, &300u32, &None);
+    let unit_id = client.register_blood(&admin, &String::from_str(&env, "SN-080"), &BloodType::APositive, &300u32, &None);
     assert!(unit_id > 0);
 }
 
@@ -1551,7 +1567,7 @@ fn test_paginated_history_single_page() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
 
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-081"), &BloodType::APositive, &450u32, &None);
 
     // 3 transitions — all fit on page 0 (page size = 50)
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
@@ -1572,7 +1588,7 @@ fn test_paginated_history_full_matches_pages() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
 
-    let id = client.register_blood(&admin, &BloodType::APositive, &450u32, &None);
+    let id = client.register_blood(&admin, &String::from_str(&env, "SN-082"), &BloodType::APositive, &450u32, &None);
 
     // 5 transitions
     client.update_status(&id, &BloodStatus::Reserved, &admin, &None);
@@ -1598,9 +1614,9 @@ fn test_batch_register_blood_success() {
 
     let entries = vec![
         &env,
-        (BloodType::APositive, 450u32, None::<Address>),
-        (BloodType::BNegative, 300u32, None::<Address>),
-        (BloodType::ONegative, 500u32, None::<Address>),
+        (String::from_str(&env, "SN-BATCH-001"), BloodType::APositive, 450u32, None::<Address>),
+        (String::from_str(&env, "SN-BATCH-002"), BloodType::BNegative, 300u32, None::<Address>),
+        (String::from_str(&env, "SN-BATCH-003"), BloodType::ONegative, 500u32, None::<Address>),
     ];
 
     let ids = client.batch_register_blood(&admin, &entries);
@@ -1627,7 +1643,7 @@ fn test_batch_register_blood_empty_list() {
     let (env, admin, client, _) = create_test_contract();
     env.ledger().set_timestamp(1000u64);
 
-    let empty: soroban_sdk::Vec<(BloodType, u32, Option<Address>)> =
+    let empty: soroban_sdk::Vec<(String, BloodType, u32, Option<Address>)> =
         soroban_sdk::Vec::new(&env);
     let ids = client.batch_register_blood(&admin, &empty);
     assert_eq!(ids.len(), 0);
@@ -1642,8 +1658,8 @@ fn test_batch_register_blood_invalid_quantity_aborts_all() {
     // Second entry has invalid quantity — entire batch should fail
     let entries = vec![
         &env,
-        (BloodType::APositive, 450u32, None::<Address>),
-        (BloodType::BNegative, 50u32, None::<Address>), // too low
+        (String::from_str(&env, "SN-BATCH-INV1"), BloodType::APositive, 450u32, None::<Address>),
+        (String::from_str(&env, "SN-BATCH-INV2"), BloodType::BNegative, 50u32, None::<Address>), // too low
     ];
     client.batch_register_blood(&admin, &entries);
 }
@@ -1655,7 +1671,7 @@ fn test_batch_register_blood_unauthorized_bank() {
     env.ledger().set_timestamp(1000u64);
 
     let unauthorized = Address::generate(&env);
-    let entries = vec![&env, (BloodType::APositive, 450u32, None::<Address>)];
+    let entries = vec![&env, (String::from_str(&env, "SN-BATCH-UA"), BloodType::APositive, 450u32, None::<Address>)];
     client.batch_register_blood(&unauthorized, &entries);
 }
 
@@ -1667,7 +1683,7 @@ fn test_update_status_allowed_for_owner() {
     let bank = Address::generate(&env);
     client.authorize_bank(&admin, &bank, &true);
 
-    let unit_id = client.register_blood(&bank, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank, &String::from_str(&env, "SN-083"), &BloodType::APositive, &450u32, &None);
 
     // Bank (owner) should be able to update status even if not admin
     let updated = client.update_status(
@@ -1690,7 +1706,7 @@ fn test_update_status_denied_for_non_owner_non_admin() {
     client.authorize_bank(&admin, &bank1, &true);
     client.authorize_bank(&admin, &bank2, &true);
 
-    let unit_id = client.register_blood(&bank1, &BloodType::APositive, &450u32, &None);
+    let unit_id = client.register_blood(&bank1, &String::from_str(&env, "SN-084"), &BloodType::APositive, &450u32, &None);
 
     // Bank2 (not owner, not admin) should be denied
     client.update_status(&unit_id, &BloodStatus::Reserved, &bank2, &None);
@@ -1707,8 +1723,8 @@ fn test_reserve_blood_fails_on_mixed_ownership() {
     client.authorize_bank(&admin, &bank1, &true);
     client.authorize_bank(&admin, &bank2, &true);
 
-    let id1 = client.register_blood(&bank1, &BloodType::APositive, &450u32, &None);
-    let id2 = client.register_blood(&bank2, &BloodType::APositive, &450u32, &None);
+    let id1 = client.register_blood(&bank1, &String::from_str(&env, "SN-085"), &BloodType::APositive, &450u32, &None);
+    let id2 = client.register_blood(&bank2, &String::from_str(&env, "SN-086"), &BloodType::APositive, &450u32, &None);
 
     // Bank1 tries to reserve both units (but only owns one)
     client.reserve_blood(&bank1, &vec![&env, id1, id2], &123, &3600);

--- a/lifebank-soroban/contracts/inventory/src/types.rs
+++ b/lifebank-soroban/contracts/inventory/src/types.rs
@@ -295,6 +295,9 @@ pub enum DataKey {
 
     /// Circuit breaker: contract is paused
     Paused,
+
+    /// Deduplication index: serial number (donation bag ID) -> blood unit ID
+    Serial(String),
 }
 
 /// Reservation record for blood units locked for a specific requester

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 use soroban_sdk::token;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, String,
-    Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
 };
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -123,6 +122,8 @@ pub enum Error {
     NothingToClaim = 510,
     /// A payment already exists for this request.
     DuplicatePayment = 511,
+    /// Donor already has an active vesting schedule that has not been fully claimed.
+    ActiveVestingExists = 517,
     /// The associated request is not in a state that permits payment.
     RequestNotPayable = 512,
     /// The request referenced by this payment does not exist.
@@ -142,8 +143,6 @@ const PLEDGE_COUNTER: soroban_sdk::Symbol = symbol_short!("PLG_CTR");
 const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("ADMIN");
 const PAUSED_KEY: soroban_sdk::Symbol = symbol_short!("PAUSED");
 const REWARD_TOKEN_KEY: soroban_sdk::Symbol = symbol_short!("RWD_TOK");
-/// Instance-level map: request_id (u64) → payment_id (u64).
-const REQ_IDX: soroban_sdk::Symbol = symbol_short!("REQ_IDX");
 /// Instance-level aggregate stats.
 const STATS_KEY: soroban_sdk::Symbol = symbol_short!("STATS");
 /// Instance storage key for the requests contract address (optional).
@@ -272,14 +271,24 @@ fn index_by_status(env: &Env, status: PaymentStatus, id: u64) {
     env.storage().persistent().set(&key, &ids);
 }
 
+fn req_idx_key(request_id: u64) -> (u64, &'static str) {
+    (request_id, "ri")
+}
+
+/// Store a single request_id → payment_id mapping in persistent storage.
+/// Each entry is independent, preventing unbounded instance-storage growth.
 fn index_by_request(env: &Env, request_id: u64, payment_id: u64) {
-    let mut map: Map<u64, u64> = env
-        .storage()
-        .instance()
-        .get(&REQ_IDX)
-        .unwrap_or(Map::new(env));
-    map.set(request_id, payment_id);
-    env.storage().instance().set(&REQ_IDX, &map);
+    env.storage()
+        .persistent()
+        .set(&req_idx_key(request_id), &payment_id);
+}
+
+/// Remove the request index entry once the payment reaches a terminal state
+/// (Released, Refunded, Cancelled) to avoid retaining stale entries.
+fn remove_from_request_index(env: &Env, request_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&req_idx_key(request_id));
 }
 
 /// Remove `id` from the persistent Vec stored under the given status index key.
@@ -512,12 +521,7 @@ impl PaymentContract {
         payer.require_auth();
 
         // Reject if a payment for this request already exists.
-        let existing_map: Map<u64, u64> = env
-            .storage()
-            .instance()
-            .get(&REQ_IDX)
-            .unwrap_or(Map::new(&env));
-        if existing_map.contains_key(request_id) {
+        if env.storage().persistent().has(&req_idx_key(request_id)) {
             return Err(Error::DuplicatePayment);
         }
 
@@ -598,12 +602,7 @@ impl PaymentContract {
         hospital.require_auth();
 
         // Reject if a payment for this request already exists.
-        let existing_map: Map<u64, u64> = env
-            .storage()
-            .instance()
-            .get(&REQ_IDX)
-            .unwrap_or(Map::new(&env));
-        if existing_map.contains_key(request_id) {
+        if env.storage().persistent().has(&req_idx_key(request_id)) {
             return Err(Error::DuplicatePayment);
         }
 
@@ -685,6 +684,7 @@ impl PaymentContract {
         remove_from_status_index(&env, old_status, payment_id);
         index_by_status(&env, PaymentStatus::Released, payment_id);
         update_stats_on_transition(&env, payment.amount, old_status, PaymentStatus::Released);
+        remove_from_request_index(&env, payment.request_id);
 
         env.events().publish(
             (symbol_short!("payment"), symbol_short!("released")),
@@ -723,6 +723,7 @@ impl PaymentContract {
         remove_from_status_index(&env, old_status, payment_id);
         index_by_status(&env, PaymentStatus::Refunded, payment_id);
         update_stats_on_transition(&env, payment.amount, old_status, PaymentStatus::Refunded);
+        remove_from_request_index(&env, payment.request_id);
 
         env.events().publish(
             (symbol_short!("payment"), symbol_short!("refunded")),
@@ -741,6 +742,9 @@ impl PaymentContract {
         remove_from_status_index(&env, old_status, payment_id);
         index_by_status(&env, status, payment_id);
         update_stats_on_transition(&env, payment.amount, old_status, status);
+        if matches!(status, PaymentStatus::Released | PaymentStatus::Refunded | PaymentStatus::Cancelled) {
+            remove_from_request_index(&env, payment.request_id);
+        }
 
         // Emit event on every status transition so off-chain indexers can stay
         // in sync without polling. Topics: ("payment", "status") so indexers can
@@ -808,12 +812,11 @@ impl PaymentContract {
     }
 
     pub fn get_payment_by_request(env: Env, request_id: u64) -> Result<Payment, Error> {
-        let map: Map<u64, u64> = env
+        let payment_id: u64 = env
             .storage()
-            .instance()
-            .get(&REQ_IDX)
-            .unwrap_or(Map::new(&env));
-        let payment_id = map.get(request_id).ok_or(Error::PaymentNotFound)?;
+            .persistent()
+            .get(&req_idx_key(request_id))
+            .ok_or(Error::PaymentNotFound)?;
         load_payment(&env, payment_id).ok_or(Error::PaymentNotFound)
     }
 
@@ -1008,6 +1011,12 @@ impl PaymentContract {
             return Err(Error::InvalidAmount);
         }
 
+        // Reject if donor already has an active (uncompleted) vesting schedule.
+        // Overwriting it would silently destroy unclaimed rewards.
+        if env.storage().persistent().has(&vesting_key(&donor)) {
+            return Err(Error::ActiveVestingExists);
+        }
+
         let now = env.ledger().timestamp();
         let schedule = VestingSchedule {
             donor: donor.clone(),
@@ -1140,6 +1149,7 @@ impl PaymentContract {
             remove_from_status_index(&env, old_status, pid);
             index_by_status(&env, PaymentStatus::Refunded, pid);
             update_stats_on_transition(&env, payment.amount, old_status, PaymentStatus::Refunded);
+            remove_from_request_index(&env, payment.request_id);
 
             if let Some(ref rc) = req_contract {
                 try_cancel_request(&env, rc, payment.request_id);


### PR DESCRIPTION
[contracts/inventory] batch_register_blood() has no deduplication — same unit can be registered twice Fixes #839

[contracts/coordinator] pause() only stops new allocations — in-flight workflows have no emergency abort Fixes #838

[contracts/payments] Only one vesting schedule allowed per donor address — concurrent donors blocked Fixes #835

[contracts/payments] REQ_IDX map in instance storage grows without bound — will hit storage cap Fixes #836