### PR TITLE
fix/feat: implement org verification stub, add Swagger to WorkflowController, document blockchain module

### DIFF
--- a/backend/src/blockchain/README.md
+++ b/backend/src/blockchain/README.md
@@ -21,6 +21,7 @@ Submit TX → Idempotency Check → Main Queue → Worker → Soroban Network
 ```
 
 **Features:**
+
 - Async processing with BullMQ
 - Exponential backoff with jitter (1s → 60s max)
 - 5 retry attempts by default
@@ -33,9 +34,11 @@ Submit TX → Idempotency Check → Main Queue → Worker → Soroban Network
 ### Endpoints
 
 #### POST /blockchain/submit-transaction
+
 Submit a Soroban contract transaction to the queue.
 
 **Request:**
+
 ```json
 {
   "contractMethod": "record_donation",
@@ -50,6 +53,7 @@ Submit a Soroban contract transaction to the queue.
 ```
 
 **Response:** `202 Accepted`
+
 ```json
 {
   "jobId": "donation-uuid-123"
@@ -57,12 +61,15 @@ Submit a Soroban contract transaction to the queue.
 ```
 
 **Errors:**
+
 - `400 Bad Request`: Duplicate idempotency key
 
 #### GET /blockchain/job/:jobId
+
 Get status of a queued transaction.
 
 **Response:** `200 OK`
+
 ```json
 {
   "jobId": "donation-uuid-123",
@@ -76,18 +83,22 @@ Get status of a queued transaction.
 ```
 
 **Status Values:**
+
 - `pending`: Queued, not yet processed
 - `completed`: Successfully submitted to Soroban
 - `failed`: Retrying or moved to DLQ
 - `dlq`: Permanently failed, manual intervention needed
 
 #### POST /blockchain/webhook/callback
+
 Process incoming blockchain webhook events from trusted providers.
 
 Headers:
+
 - `X-Webhook-Signature`: HMAC SHA256 (hex) of canonical JSON payload using `BLOCKCHAIN_CALLBACK_SECRET`
 
 Request body:
+
 ```json
 {
   "eventId": "string",
@@ -100,6 +111,7 @@ Request body:
 ```
 
 Response: `200 OK`
+
 ```json
 {
   "success": true
@@ -107,16 +119,19 @@ Response: `200 OK`
 ```
 
 Failures:
+
 - `401 Unauthorized`: invalid or missing signature
 - `400 Bad Request`: stale timestamp or invalid payload schema
 - `409 Conflict`: replayed event
 
 #### GET /blockchain/queue/status
+
 Get queue metrics (admin only).
 
 **Headers:** `Authorization: Bearer <admin_token>`
 
 **Response:** `200 OK`
+
 ```json
 {
   "queueDepth": 42,
@@ -191,7 +206,7 @@ async recordCriticalDonation(donation: Donation) {
 ```typescript
 async checkDonationStatus(donationId: string) {
   const donation = await this.donationRepository.findOne(donationId);
-  
+
   const status = await this.sorobanService.getJobStatus(
     donation.blockchainJobId,
   );
@@ -219,6 +234,7 @@ REDIS_PORT=6379
 ## Data Models
 
 ### SorobanTxJob
+
 ```typescript
 {
   contractMethod: string;        // Smart contract method name
@@ -229,6 +245,7 @@ REDIS_PORT=6379
 ```
 
 ### SorobanTxResult
+
 ```typescript
 {
   jobId: string;
@@ -244,6 +261,7 @@ REDIS_PORT=6379
 ## Queue Configuration
 
 ### Main Queue (soroban-tx-queue)
+
 - **Attempts**: 5 retries
 - **Backoff**: Exponential (1s → 2s → 4s → 8s → 16s)
 - **Jitter**: 0-10% random delay added
@@ -251,6 +269,7 @@ REDIS_PORT=6379
 - **Cleanup**: Completed jobs removed, failed jobs retained
 
 ### Dead Letter Queue (soroban-dlq)
+
 - Receives jobs after 5 failed attempts
 - Requires manual review and resubmission
 - Persisted indefinitely for audit trail
@@ -264,6 +283,7 @@ All transactions require an `idempotencyKey`:
 - **Behavior**: Second submission with same key returns `400 Bad Request`
 
 **Best Practices:**
+
 - Use deterministic keys: `{entity}-{id}` (e.g., `donation-uuid-123`)
 - Include operation type if multiple operations per entity
 - Don't reuse keys across different operations
@@ -321,6 +341,136 @@ npm run test:contracts
 - **Latency**: 2-5 seconds per transaction (network dependent)
 - **Queue Capacity**: Limited by Redis memory
 - **Backpressure**: Implement client-side rate limiting if queue depth > 1000
+
+## Organization Verification Status
+
+`SorobanService.getOrganizationVerificationStatus(organizationId)` queries the on-chain verification state of an organization. It delegates to `soroban/soroban.service.ts`, which owns the Soroban RPC connection and a Redis cache (5-minute TTL).
+
+**Return shape:**
+
+```typescript
+{
+  verified: boolean;
+  verifiedAt?: number;       // Unix timestamp
+  verifiedBy?: string;       // Address that performed verification
+  revokedAt?: number;        // Set if verification was revoked
+  revocationReason?: string;
+  orgId: string;
+} | null
+```
+
+Returns `null` when:
+
+- No Soroban contract is configured (`SOROBAN_CONTRACT_ID` unset)
+- The organization has no on-chain record
+- The contract simulation fails (e.g. contract not deployed)
+
+Throws when:
+
+- The Soroban RPC is unreachable (`RPC unavailable` message)
+- The RPC call times out (`timeout or network error` message)
+- The returned `ScVal` cannot be decoded
+
+**Module wiring:** `BlockchainModule` imports `SorobanModule` via `forwardRef()` to avoid a circular dependency. The `SorobanRpcService` is injected into `SorobanService` (blockchain) with `@Inject(forwardRef(() => SorobanRpcService))`.
+
+---
+
+## Webhook Callback Processing
+
+`processWebhookCallback(callback)` handles inbound blockchain events from a trusted webhook provider. It persists durable state to the `on_chain_tx_states` table and emits domain events **exactly once per milestone** using a bitmask on `emittedEvents`.
+
+### State machine
+
+```
+PENDING → CONFIRMED (accumulating) → FINAL
+        ↘ FAILED
+```
+
+### Event bitmask
+
+Each milestone is guarded by a bit in `TX_EVENT_BIT` so retried webhook deliveries cannot produce duplicate domain events:
+
+| Bit | Constant                 | Domain event emitted      |
+| --- | ------------------------ | ------------------------- |
+| 1   | `TX_EVENT_BIT.PENDING`   | `blockchain.tx.pending`   |
+| 2   | `TX_EVENT_BIT.CONFIRMED` | `blockchain.tx.confirmed` |
+| 4   | `TX_EVENT_BIT.FAILED`    | `blockchain.tx.failed`    |
+| 8   | `TX_EVENT_BIT.FINAL`     | `blockchain.tx.final`     |
+
+`blockchain.tx.final` is only emitted once the confirmation count reaches the finality threshold defined in `ConfirmationService`.
+
+### Listening to domain events
+
+```typescript
+import { OnEvent } from '@nestjs/event-emitter';
+import { TxFinalEvent } from '../events/blockchain-tx.events';
+
+@Injectable()
+export class OrderService {
+  @OnEvent('blockchain.tx.final')
+  async handleTxFinal(event: TxFinalEvent) {
+    // Safe to mark order as settled — fires exactly once
+    await this.orderRepo.markSettled(event.transactionHash);
+  }
+}
+```
+
+---
+
+## DLQ Replay
+
+`replayDlqJobs(options)` resubmits permanently failed jobs from the dead-letter queue back to the main queue. It is an admin-only operation exposed via `BlockchainController`.
+
+**Options:**
+
+| Field       | Type    | Default | Description                    |
+| ----------- | ------- | ------- | ------------------------------ |
+| `dryRun`    | boolean | `false` | Inspect without resubmitting   |
+| `batchSize` | number  | `10`    | Max jobs to process per call   |
+| `offset`    | number  | `0`     | Pagination offset into the DLQ |
+
+**Response:**
+
+```typescript
+{
+  dryRun: boolean;
+  totalInspected: number;
+  replayable: number; // Jobs with valid data
+  replayed: number; // Successfully resubmitted (live run only)
+  skipped: number; // Jobs with missing required fields
+  errors: Array<{ jobId: string; reason: string }>;
+}
+```
+
+**What happens during a live replay:**
+
+1. The old idempotency key is cleared so the job can be resubmitted.
+2. The job is re-enqueued on `soroban-tx-queue` with `replayedFrom` and `replayedAt` added to its metadata.
+3. The original DLQ entry is removed on success.
+
+Always run with `dryRun: true` first to inspect what would be replayed before committing.
+
+---
+
+## Backoff Calculation
+
+`calculateBackoffDelay(attemptNumber)` returns the delay in milliseconds for a given retry attempt. It is used internally by the queue worker but is public for testing and observability.
+
+**Formula:** `min(baseDelay × 2^(attempt−1) + jitter, maxDelay)`
+
+- Base delay: 1 000 ms
+- Max delay: 60 000 ms
+- Jitter: 0–10 % of the exponential component (prevents thundering herd)
+
+| Attempt | Approx. delay |
+| ------- | ------------- |
+| 1       | ~1 s          |
+| 2       | ~2 s          |
+| 3       | ~4 s          |
+| 4       | ~8 s          |
+| 5       | ~16 s         |
+
+---
 
 ## Troubleshooting
 

--- a/backend/src/blockchain/blockchain.module.ts
+++ b/backend/src/blockchain/blockchain.module.ts
@@ -1,9 +1,10 @@
 import { BullModule } from '@nestjs/bullmq';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { CompensationModule } from '../common/compensation/compensation.module';
+import { SorobanModule } from '../soroban/soroban.module';
 
 import { BlockchainController } from './controllers/blockchain.controller';
 import { DlqReplayAuditEntity } from './entities/dlq-replay-audit.entity';
@@ -29,12 +30,19 @@ import { SorobanService } from './services/soroban.service';
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET', 'default-secret'),
-        signOptions: { expiresIn: configService.get<string>('JWT_EXPIRES_IN', '1h') },
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN', '1h'),
+        },
       }),
     }),
     CompensationModule,
+    forwardRef(() => SorobanModule),
     EventEmitterModule.forRoot(),
-    TypeOrmModule.forFeature([DlqReplayAuditEntity, FailedSorobanTxEntity, OnChainTxStateEntity]),
+    TypeOrmModule.forFeature([
+      DlqReplayAuditEntity,
+      FailedSorobanTxEntity,
+      OnChainTxStateEntity,
+    ]),
     BullModule.registerQueueAsync(
       {
         name: 'soroban-tx-queue',

--- a/backend/src/blockchain/services/soroban.service.ts
+++ b/backend/src/blockchain/services/soroban.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from '@nestjs/bullmq';
-import { Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -11,8 +11,13 @@ import {
   TxFinalEvent,
   TxPendingEvent,
 } from '../../events/blockchain-tx.events';
+import { SorobanService as SorobanRpcService } from '../../soroban/soroban.service';
 import { normalizeContractMethod } from '../contracts/lifebank-contracts';
-import { OnChainTxStateEntity, OnChainTxStatus, TX_EVENT_BIT } from '../entities/on-chain-tx-state.entity';
+import {
+  OnChainTxStateEntity,
+  OnChainTxStatus,
+  TX_EVENT_BIT,
+} from '../entities/on-chain-tx-state.entity';
 import { JobDeduplicationPlugin } from '../plugins/job-deduplication.plugin';
 import {
   SorobanTxJob,
@@ -43,6 +48,8 @@ export class SorobanService {
     private eventEmitter: EventEmitter2,
     @InjectRepository(OnChainTxStateEntity)
     private txStateRepo: Repository<OnChainTxStateEntity>,
+    @Inject(forwardRef(() => SorobanRpcService))
+    private sorobanRpcService: SorobanRpcService,
   ) {}
 
   /**
@@ -104,19 +111,25 @@ export class SorobanService {
   }
 
   /**
-   * Get organization verification status from Soroban
-   * Delegates to the soroban module service which owns the RPC connection.
-   * This method is intentionally thin – it exists so blockchain-module
-   * consumers can call it without importing the soroban module directly.
+   * Get organization verification status from Soroban.
+   * Delegates to the soroban module service which owns the RPC connection
+   * and Redis cache. Returns null when no contract is configured or the
+   * organization is not found on-chain.
    */
-  async getOrganizationVerificationStatus(
-    organizationId: string,
-  ): Promise<{ verified: boolean; verifiedAt?: number } | null> {
-    this.logger.debug(`Querying verification status for org: ${organizationId}`);
-    // Actual RPC call is implemented in soroban/soroban.service.ts
-    // This service is in the blockchain module and does not have direct RPC access.
-    // Callers in the organizations module use soroban/soroban.service.ts directly.
-    return null;
+  async getOrganizationVerificationStatus(organizationId: string): Promise<{
+    verified: boolean;
+    verifiedAt?: number;
+    verifiedBy?: string;
+    revokedAt?: number;
+    revocationReason?: string;
+    orgId: string;
+  } | null> {
+    this.logger.debug(
+      `Querying verification status for org: ${organizationId}`,
+    );
+    return this.sorobanRpcService.getOrganizationVerificationStatus(
+      organizationId,
+    );
   }
 
   /**
@@ -315,10 +328,11 @@ export class SorobanService {
     }
 
     // status === 'confirmed'
-    const confirmationState = await this.confirmationService.recordConfirmations(
-      callback.transactionHash,
-      callback.confirmations ?? 1,
-    );
+    const confirmationState =
+      await this.confirmationService.recordConfirmations(
+        callback.transactionHash,
+        callback.confirmations ?? 1,
+      );
 
     txState.confirmations = confirmationState.confirmations;
 


### PR DESCRIPTION
Bug fix — 
soroban.service.ts

getOrganizationVerificationStatus was a permanent stub that always returned null, silently breaking any caller that depended on real on-chain data. Fixed by:

Injecting 
soroban.service.ts
 (aliased as SorobanRpcService) into the blockchain SorobanService via @Inject(forwardRef(() => SorobanRpcService))
Delegating the call to the real implementation, which performs a Soroban RPC simulation, caches results in Redis for 5 minutes, and maps the full ScVal response
Widening the return type from { verified, verifiedAt? } to the full shape the real service returns (verifiedBy, revokedAt, revocationReason, orgId)
Module wiring — 
blockchain.module.ts

Added forwardRef(() => SorobanModule) to BlockchainModule imports so NestJS can resolve the injected SorobanRpcService at runtime without a circular dependency error
Enhancement — 
workflow.controller.ts

Audited the controller against the project's conventions. It already had full Swagger coverage (@ApiTags, @ApiBearerAuth, @ApiOperation, @ApiResponse on every endpoint) and @UseGuards(JwtAuthGuard, PermissionsGuard) at the controller level — no changes needed.

Docs — 
README.md

Added four new sections covering functionality that existed in code but had no documentation:

Organization Verification Status — return shape, null/throw conditions, module wiring explanation
Webhook Callback Processing — PENDING → CONFIRMED → FINAL / FAILED state machine, TX_EVENT_BIT bitmask table, example event listener
DLQ Replay — options, response shape, three-step replay sequence, dry-run guidance
Backoff Calculation — formula, constants, per-attempt delay table
Testing
npx tsc --noEmit passes with no new errors in modified files




closes #778

closes #786

closes #775

closes #784