### PR TITLE
Add pagination to SLA breaches query

### DIFF
--- a/backend/src/sla/dto/sla-breach-query.dto.ts
+++ b/backend/src/sla/dto/sla-breach-query.dto.ts
@@ -1,4 +1,5 @@
-import { IsEnum, IsOptional, IsString, IsDateString } from 'class-validator';
+import { IsEnum, IsOptional, IsString, IsDateString, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
 import { SlaStage } from '../enums/sla-stage.enum';
 
 export class SlaBreachQueryDto {
@@ -29,4 +30,24 @@ export class SlaBreachQueryDto {
   @IsOptional()
   @IsDateString()
   endDate?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageSize?: number;
+}
+
+export class SlaBreachResponseDto {
+  data: any[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
 }

--- a/backend/src/sla/sla.service.ts
+++ b/backend/src/sla/sla.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SlaRecordEntity } from './entities/sla-record.entity';
 import { SlaStage } from './enums/sla-stage.enum';
-import { SlaBreachQueryDto } from './dto/sla-breach-query.dto';
+import { SlaBreachQueryDto, SlaBreachResponseDto } from './dto/sla-breach-query.dto';
 
 /** SLA budgets in seconds per stage per urgency tier */
 const SLA_BUDGETS: Record<string, Record<SlaStage, number>> = {
@@ -133,8 +133,12 @@ export class SlaService {
     };
   }
 
-  /** Query breached records with optional filters */
-  async queryBreaches(query: SlaBreachQueryDto): Promise<SlaRecordEntity[]> {
+  /** Query breached records with optional filters and pagination */
+  async queryBreaches(query: SlaBreachQueryDto): Promise<SlaBreachResponseDto> {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 25;
+    const skip = (page - 1) * pageSize;
+
     const qb = this.slaRepo.createQueryBuilder('sla').where('sla.breached = true');
 
     if (query.hospitalId) qb.andWhere('sla.hospitalId = :hospitalId', { hospitalId: query.hospitalId });
@@ -145,7 +149,19 @@ export class SlaService {
     if (query.startDate) qb.andWhere('sla.startedAt >= :startDate', { startDate: query.startDate });
     if (query.endDate) qb.andWhere('sla.startedAt <= :endDate', { endDate: query.endDate });
 
-    return qb.orderBy('sla.startedAt', 'DESC').getMany();
+    const [data, total] = await qb
+      .orderBy('sla.startedAt', 'DESC')
+      .skip(skip)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
   }
 
   /** Aggregate breach rate grouped by a dimension (hospital | bloodBank | rider | urgencyTier) */


### PR DESCRIPTION
# Add Pagination to SLA Breaches Query
close #769
## Problem
The `queryBreaches()` method in `SlaService` returns an unbounded result set with no pagination, risking out-of-memory errors and timeouts for production systems with thousands of SLA breach records.

## Solution
Implemented pagination support with configurable page and pageSize parameters:
- Default page size: 25 records
- Minimum page size: 1
- Clients can override via query parameters: `?page=2&pageSize=50`
- Response includes pagination metadata for UI navigation

## Changes
- **`backend/src/sla/dto/sla-breach-query.dto.ts`**
  - Added `page` field (optional, min 1)
  - Added `pageSize` field (optional, min 1)
  - Created `SlaBreachResponseDto` with pagination metadata

- **`backend/src/sla/sla.service.ts`**
  - Updated `queryBreaches()` to use `.skip()` and `.take()`
  - Changed return type from `SlaRecordEntity[]` to `SlaBreachResponseDto`
  - Added pagination calculation: `totalPages: Math.ceil(total / pageSize)`

## Response Format
```json
{
  "data": [...],
  "total": 1000,
  "page": 1,
  "pageSize": 25,
  "totalPages": 40
}