### PR TITLE
fix: resolve #814 #815 #816 #817 — payments timeline, index TTL, roll…

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -390,6 +390,7 @@ impl CoordinatorContract {
                 unit_ids,
                 status: WorkflowStatus::Allocated,
                 delivery_confirmed: false,
+                delivery_location: None,
             },
         );
 
@@ -397,10 +398,16 @@ impl CoordinatorContract {
     }
 
     /// Step 2 – Confirm delivery: mark all reserved units as Delivered.
+    ///
+    /// `location` must be a GPS coordinate or facility identifier supplied by
+    /// the confirmer.  It is stored in the workflow record and emitted in the
+    /// event so off-chain auditors and cold-chain compliance tooling can verify
+    /// where delivery occurred.
     pub fn confirm_delivery(
         env: Env,
         request_id: u64,
         caller: Address,
+        location: String,
     ) -> Result<(), CoordinatorError> {
         caller.require_auth();
         Self::require_initialized(&env)?;
@@ -420,7 +427,6 @@ impl CoordinatorContract {
             .unwrap();
         let inv_client = InventoryContractClient::new(&env, &inv_addr);
         let inv_admin = inv_client.get_admin();
-        let location = soroban_sdk::String::from_str(&env, "delivered");
 
         for i in 0..wf.unit_ids.len() {
             let uid = wf.unit_ids.get(i).unwrap();
@@ -437,6 +443,7 @@ impl CoordinatorContract {
 
         wf.status = WorkflowStatus::Delivered;
         wf.delivery_confirmed = true;
+        wf.delivery_location = Some(location.clone());
         save_workflow(&env, &wf);
 
         env.events().publish(
@@ -445,7 +452,7 @@ impl CoordinatorContract {
                 symbol_short!("dlvrd"),
                 symbol_short!("v1"),
             ),
-            request_id,
+            (request_id, location),
         );
 
         Ok(())
@@ -526,7 +533,10 @@ impl CoordinatorContract {
 
         for i in 0..wf.unit_ids.len() {
             let uid = wf.unit_ids.get(i).unwrap();
-            let _ = inv_client.try_update_status(&uid, &BloodStatus::Available, &inv_admin, &None);
+            inv_client
+                .try_update_status(&uid, &BloodStatus::Available, &inv_admin, &None)
+                .map_err(|_| CoordinatorError::InventoryUpdateFailed)?
+                .map_err(|_| CoordinatorError::InventoryUpdateFailed)?;
         }
 
         let pay_addr: Address = env
@@ -535,10 +545,15 @@ impl CoordinatorContract {
             .get(&DataKey::PaymentContract)
             .unwrap();
         let pay_client = PaymentContractClient::new(&env, &pay_addr);
-        if let Ok(Ok(payment)) = pay_client.try_get_payment(&wf.payment_id) {
-            if payment.status == PaymentStatus::Locked {
-                let _ = pay_client.try_update_status(&wf.payment_id, &PaymentStatus::Refunded);
-            }
+        let payment = pay_client
+            .try_get_payment(&wf.payment_id)
+            .map_err(|_| CoordinatorError::PaymentNotFound)?
+            .map_err(|_| CoordinatorError::PaymentNotFound)?;
+        if payment.status == PaymentStatus::Locked {
+            pay_client
+                .try_update_status(&wf.payment_id, &PaymentStatus::Refunded)
+                .map_err(|_| CoordinatorError::PaymentUpdateFailed)?
+                .map_err(|_| CoordinatorError::PaymentUpdateFailed)?;
         }
 
         wf.status = WorkflowStatus::RolledBack;

--- a/lifebank-soroban/contracts/coordinator/src/test.rs
+++ b/lifebank-soroban/contracts/coordinator/src/test.rs
@@ -241,11 +241,12 @@ fn test_full_happy_path() {
     let unit = MockInventoryContractClient::new(&h.env, &h.inv_id).get_blood_unit(&unit_id);
     assert_eq!(unit.status, BloodStatus::Reserved);
 
-    h.coord.confirm_delivery(&1u64, &h.admin);
+    h.coord.confirm_delivery(&1u64, &h.admin, &String::from_str(&h.env, "Hospital-A-GPS"));
 
     let wf = h.coord.get_workflow(&1u64);
     assert_eq!(wf.status, WorkflowStatus::Delivered);
     assert!(wf.delivery_confirmed);
+    assert_eq!(wf.delivery_location, Some(String::from_str(&h.env, "Hospital-A-GPS")));
 
     let unit = MockInventoryContractClient::new(&h.env, &h.inv_id).get_blood_unit(&unit_id);
     assert_eq!(unit.status, BloodStatus::Delivered);
@@ -326,7 +327,7 @@ fn test_settle_blocked_for_pending_payment() {
         .create_payment(&1u64, &PaymentStatus::Pending);
 
     h.coord.allocate_units(&1u64, &vec![&h.env, unit_id], &payment_id, &h.admin);
-    h.coord.confirm_delivery(&1u64, &h.admin);
+    h.coord.confirm_delivery(&1u64, &h.admin, &String::from_str(&h.env, "Hospital-A-GPS"));
 
     let result = h.coord.try_settle_payment(&1u64, &h.admin);
     assert_eq!(result, Err(Ok(CoordinatorError::InvalidPaymentState)));
@@ -335,7 +336,7 @@ fn test_settle_blocked_for_pending_payment() {
 #[test]
 fn test_confirm_delivery_blocked_before_allocation() {
     let h = setup();
-    let result = h.coord.try_confirm_delivery(&99u64, &h.admin);
+    let result = h.coord.try_confirm_delivery(&99u64, &h.admin, &String::from_str(&h.env, "Hospital-A-GPS"));
     assert_eq!(result, Err(Ok(CoordinatorError::WorkflowNotFound)));
 }
 
@@ -387,7 +388,7 @@ fn test_rollback_blocked_after_settlement() {
     let payment_id = create_locked_payment(&h, 1);
 
     h.coord.allocate_units(&1u64, &vec![&h.env, unit_id], &payment_id, &h.admin);
-    h.coord.confirm_delivery(&1u64, &h.admin);
+    h.coord.confirm_delivery(&1u64, &h.admin, &String::from_str(&h.env, "Hospital-A-GPS"));
     h.coord.settle_payment(&1u64, &h.admin);
 
     let result = h.coord.try_rollback(&1u64);

--- a/lifebank-soroban/contracts/coordinator/src/types.rs
+++ b/lifebank-soroban/contracts/coordinator/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Vec};
+use soroban_sdk::{contracttype, String, Vec};
 
 /// Canonical workflow states — shared identifier across all contracts.
 #[contracttype]
@@ -29,6 +29,9 @@ pub struct WorkflowRecord {
     pub unit_ids: Vec<u64>,
     pub status: WorkflowStatus,
     pub delivery_confirmed: bool,
+    /// Geographic location or identifier supplied by the confirmer at delivery.
+    /// None until confirm_delivery() is called.
+    pub delivery_location: Option<String>,
 }
 
 /// Summary of a sustained temperature excursion (mirrors temperature contract type).

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -152,6 +152,12 @@ const DEFAULT_DISPUTE_TIMEOUT_SECS: u64 = 7 * 24 * 3600;
 /// Instance storage key for the dispute timeout override.
 const DISPUTE_TIMEOUT: soroban_sdk::Symbol = symbol_short!("DISP_TO");
 
+/// Persistent storage TTL constants (in ledgers; one ledger ≈ 5 s).
+/// Entries are bumped to PERSISTENT_BUMP_TO whenever their remaining TTL
+/// falls below PERSISTENT_BUMP_THRESHOLD, preventing silent expiry.
+const PERSISTENT_BUMP_THRESHOLD: u32 = 518_400; // ~30 days
+const PERSISTENT_BUMP_TO: u32 = 1_036_800; // ~60 days
+
 fn payment_key(id: u64) -> (u64, &'static str) {
     (id, "pay")
 }
@@ -247,6 +253,9 @@ fn index_by_payer(env: &Env, payer: &Address, id: u64) {
         .unwrap_or(Vec::new(env));
     ids.push_back(id);
     env.storage().persistent().set(&key, &ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_BUMP_TO);
 }
 
 fn index_by_payee(env: &Env, payee: &Address, id: u64) {
@@ -258,6 +267,9 @@ fn index_by_payee(env: &Env, payee: &Address, id: u64) {
         .unwrap_or(Vec::new(env));
     ids.push_back(id);
     env.storage().persistent().set(&key, &ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_BUMP_TO);
 }
 
 fn index_by_status(env: &Env, status: PaymentStatus, id: u64) {
@@ -269,6 +281,9 @@ fn index_by_status(env: &Env, status: PaymentStatus, id: u64) {
         .unwrap_or(Vec::new(env));
     ids.push_back(id);
     env.storage().persistent().set(&key, &ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_BUMP_TO);
 }
 
 fn req_idx_key(request_id: u64) -> (u64, &'static str) {
@@ -289,6 +304,29 @@ fn remove_from_request_index(env: &Env, request_id: u64) {
     env.storage()
         .persistent()
         .remove(&req_idx_key(request_id));
+}
+
+/// Persistent key for the ordered list of payment IDs associated with a request.
+/// Separate from req_idx_key (which maps request → current active payment).
+fn request_timeline_key(request_id: u64) -> (u64, &'static str) {
+    (request_id, "rt")
+}
+
+/// Append `payment_id` to the per-request timeline index.
+/// The list is insertion-ordered; no sort is needed on read because payments
+/// for a given request are appended in creation order.
+fn timeline_append(env: &Env, request_id: u64, payment_id: u64) {
+    let key = request_timeline_key(request_id);
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    ids.push_back(payment_id);
+    env.storage().persistent().set(&key, &ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_BUMP_TO);
 }
 
 /// Remove `id` from the persistent Vec stored under the given status index key.
@@ -554,6 +592,7 @@ impl PaymentContract {
         index_by_payee(&env, &payee, id);
         index_by_status(&env, PaymentStatus::Pending, id);
         index_by_request(&env, request_id, id);
+        timeline_append(&env, request_id, id);
 
         env.events().publish(
             (
@@ -640,6 +679,7 @@ impl PaymentContract {
         index_by_payee(&env, &payee, id);
         index_by_status(&env, PaymentStatus::Locked, id);
         index_by_request(&env, request_id, id);
+        timeline_append(&env, request_id, id);
         update_stats_on_transition(&env, amount, PaymentStatus::Pending, PaymentStatus::Locked);
 
         env.events().publish(
@@ -869,44 +909,36 @@ impl PaymentContract {
         load_stats(&env)
     }
 
-    pub fn get_payment_timeline(env: Env, page: u32, page_size: u32) -> PaymentPage {
-        let page_size = if page_size == 0 { 20 } else { page_size };
-        let total = get_counter(&env);
-
-        let mut all: Vec<Payment> = Vec::new(&env);
-        for id in 1..=total {
-            if let Some(p) = load_payment(&env, id) {
-                all.push_back(p);
-            }
-        }
-
-        let len = all.len();
-        for i in 0..len {
-            for j in 0..len.saturating_sub(i + 1) {
-                let current = all.get(j).unwrap();
-                let next = all.get(j + 1).unwrap();
-                if current.created_at > next.created_at {
-                    all.set(j, next);
-                    all.set(j + 1, current);
-                }
-            }
-        }
-
-        let start = (page as u64) * (page_size as u64);
-        let end = (start + page_size as u64).min(total);
+    /// Returns the ordered payment history for a specific request.
+    ///
+    /// Uses the per-request timeline index written at payment creation — no
+    /// full scan and no sort on the read path.  `offset` is a zero-based item
+    /// index; `limit` caps the number of items returned (clamped to 100).
+    pub fn get_payment_timeline(
+        env: Env,
+        request_id: u64,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Payment> {
+        let limit = limit.min(100).max(1);
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&request_timeline_key(request_id))
+            .unwrap_or(Vec::new(&env));
+        let total = ids.len();
+        let start = offset;
+        let end = (start + limit).min(total);
         let mut items: Vec<Payment> = Vec::new(&env);
         if start < total {
             for i in start..end {
-                items.push_back(all.get(i as u32).unwrap());
+                let id = ids.get(i).unwrap();
+                if let Some(p) = load_payment(&env, id) {
+                    items.push_back(p);
+                }
             }
         }
-
-        PaymentPage {
-            items,
-            total,
-            page,
-            page_size,
-        }
+        items
     }
 
     pub fn get_payment_count(env: Env) -> u64 {

--- a/lifebank-soroban/contracts/payments/src/test.rs
+++ b/lifebank-soroban/contracts/payments/src/test.rs
@@ -412,69 +412,59 @@ fn test_statistics_ignores_pending_cancelled_disputed() {
 
 // ── get_payment_timeline ───────────────────────────────────────────────────────
 
+/// Timeline is per-request and insertion-ordered (no sort on read path).
 #[test]
-fn test_timeline_returns_payments_in_chronological_order() {
+fn test_timeline_returns_payment_for_request() {
     let (env, cid) = setup();
     let client = PaymentContractClient::new(&env, &cid);
-
-    env.ledger().with_mut(|l| l.timestamp = 3000);
-    make_payment(&env, &client, 1, 100);
 
     env.ledger().with_mut(|l| l.timestamp = 1000);
+    make_payment(&env, &client, 1, 100);
+    env.ledger().with_mut(|l| l.timestamp = 2000);
     make_payment(&env, &client, 2, 200);
 
-    env.ledger().with_mut(|l| l.timestamp = 2000);
-    make_payment(&env, &client, 3, 300);
+    let items = client.get_payment_timeline(&1u64, &0u32, &20u32);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items.get(0).unwrap().request_id, 1);
+    assert_eq!(items.get(0).unwrap().created_at, 1000);
 
-    let page = client.get_payment_timeline(&0u32, &20u32);
-    assert_eq!(page.items.len(), 3);
-    assert_eq!(page.items.get(0).unwrap().created_at, 1000);
-    assert_eq!(page.items.get(1).unwrap().created_at, 2000);
-    assert_eq!(page.items.get(2).unwrap().created_at, 3000);
+    let items2 = client.get_payment_timeline(&2u64, &0u32, &20u32);
+    assert_eq!(items2.len(), 1);
+    assert_eq!(items2.get(0).unwrap().request_id, 2);
 }
 
+/// offset and limit slice the per-request Vec without loading uninvolved payments.
 #[test]
-fn test_timeline_pagination() {
+fn test_timeline_offset_limit() {
     let (env, cid) = setup();
     let client = PaymentContractClient::new(&env, &cid);
 
-    for i in 1u64..=5 {
-        env.ledger().with_mut(|l| l.timestamp = i * 1000);
-        make_payment(&env, &client, i, 100);
-    }
+    // Only one payment per request is allowed; test offset beyond the single item.
+    make_payment(&env, &client, 10, 500);
 
-    let page0 = client.get_payment_timeline(&0u32, &2u32);
-    assert_eq!(page0.items.len(), 2);
-    assert_eq!(page0.total, 5);
-    assert_eq!(page0.items.get(0).unwrap().created_at, 1000);
+    let first = client.get_payment_timeline(&10u64, &0u32, &5u32);
+    assert_eq!(first.len(), 1);
 
-    let page1 = client.get_payment_timeline(&1u32, &2u32);
-    assert_eq!(page1.items.len(), 2);
-    assert_eq!(page1.items.get(0).unwrap().created_at, 3000);
-
-    let page2 = client.get_payment_timeline(&2u32, &2u32);
-    assert_eq!(page2.items.len(), 1);
-    assert_eq!(page2.items.get(0).unwrap().created_at, 5000);
+    let empty = client.get_payment_timeline(&10u64, &1u32, &5u32);
+    assert_eq!(empty.len(), 0);
 }
 
 #[test]
-fn test_timeline_empty_when_no_payments() {
+fn test_timeline_empty_when_no_payments_for_request() {
     let (env, cid) = setup();
     let client = PaymentContractClient::new(&env, &cid);
-    let page = client.get_payment_timeline(&0u32, &20u32);
-    assert_eq!(page.items.len(), 0);
-    assert_eq!(page.total, 0);
+    let items = client.get_payment_timeline(&99u64, &0u32, &20u32);
+    assert_eq!(items.len(), 0);
 }
 
 #[test]
-fn test_timeline_out_of_range_page_returns_empty() {
+fn test_timeline_unknown_request_returns_empty() {
     let (env, cid) = setup();
     let client = PaymentContractClient::new(&env, &cid);
     make_payment(&env, &client, 1, 100);
 
-    let page = client.get_payment_timeline(&99u32, &20u32);
-    assert_eq!(page.items.len(), 0);
-    assert_eq!(page.total, 1);
+    let items = client.get_payment_timeline(&999u64, &0u32, &20u32);
+    assert_eq!(items.len(), 0);
 }
 
 // ── update_status ──────────────────────────────────────────────────────────────


### PR DESCRIPTION


closes #814 [payments] Replace O(n²) bubble sort in get_payment_timeline with a per-request persistent index Vec (insertion-ordered, O(1) read path). Signature changed to (request_id, offset, limit) -> Vec<Payment> so callers can page through results without loading every payment in the contract.

closes #815 [payments] Add extend_ttl() calls after every persistent index write (payer, payee, status, and the new timeline index) so entries are never silently evicted by the ledger TTL clock.

closes #816 [coordinator] rollback() now propagates errors from cross-contract calls instead of discarding them with let _ =. A failed inventory release or payment cancellation aborts the whole transaction, preventing partial rollbacks that leave units reserved or escrow open.

closes #817 [coordinator] confirm_delivery() accepts a real location: String parameter supplied by the caller. The value is passed to mark_delivered(), stored in WorkflowRecord.delivery_location, and included in the on-chain event so cold-chain audits have a verifiable delivery location.