### PR TITLE
test(payments): add pledge amount validation tests

### DIFF
--- a/lifebank-soroban/contracts/payments/src/test.rs
+++ b/lifebank-soroban/contracts/payments/src/test.rs
@@ -533,6 +533,30 @@ fn test_create_pledge_rejects_zero_interval() {
     assert!(r.is_err());
 }
 
+#[test]
+fn test_create_pledge_rejects_zero_amount() {
+    let (env, cid) = setup();
+    let client = PaymentContractClient::new(&env, &cid);
+    let donor = Address::generate(&env);
+    let pool = soroban_sdk::String::from_str(&env, "pool");
+    let cause = soroban_sdk::String::from_str(&env, "c");
+    let region = soroban_sdk::String::from_str(&env, "r");
+    let result = client.try_create_pledge(&donor, &0i128, &86_400u64, &pool, &cause, &region, &false);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)), "Zero amount pledge must be rejected");
+}
+
+#[test]
+fn test_create_pledge_rejects_negative_amount() {
+    let (env, cid) = setup();
+    let client = PaymentContractClient::new(&env, &cid);
+    let donor = Address::generate(&env);
+    let pool = soroban_sdk::String::from_str(&env, "pool");
+    let cause = soroban_sdk::String::from_str(&env, "c");
+    let region = soroban_sdk::String::from_str(&env, "r");
+    let result = client.try_create_pledge(&donor, &-500i128, &86_400u64, &pool, &cause, &region, &false);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)), "Negative amount pledge must be rejected");
+}
+
 // ── Circuit breaker tests ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #852

The `create_pledge` function already guards against zero and negative `amount_per_period` values via an `InvalidAmount` error check, but there were no tests exercising this validation path. This PR adds two explicit unit tests:

- `test_create_pledge_rejects_zero_amount` — verifies that a pledge with `amount_per_period = 0` returns `Error::InvalidAmount`
- `test_create_pledge_rejects_negative_amount` — verifies that a pledge with `amount_per_period = -500` returns `Error::InvalidAmount`

These tests complement the existing `test_create_pledge_rejects_zero_interval` test and ensure zero-amount pledges cannot pollute pledge storage, and that negative i128 amounts (which could enable subtraction attacks on token balances) are fully guarded.

## Test plan

- [x] `cargo test -p payment-contract` — all 48 tests pass
- [x] New tests `test_create_pledge_rejects_zero_amount` and `test_create_pledge_rejects_negative_amount` both pass