### PR TITLE
feat(coordinator): add workflow expiry/timeout mechanism

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/error.rs
+++ b/lifebank-soroban/contracts/coordinator/src/error.rs
@@ -33,4 +33,7 @@ pub enum CoordinatorError {
 
     /// emergency_halt() has been called; all workflow mutations are blocked.
     EmergencyHalted = 841,
+
+    /// expire_workflow() was called but the deadline has not yet elapsed.
+    WorkflowNotExpired = 842,
 }

--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -20,6 +20,12 @@ pub use types::{DataKey, ExcursionSummary, WorkflowRecord, WorkflowStatus};
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
 
+/// Default workflow expiry window: 6 hours expressed in seconds.
+/// After `allocate_units` is called, if `confirm_delivery` is never invoked
+/// within this window, anyone may call `expire_workflow` to roll back the
+/// allocation and free the reserved units and escrowed payment.
+const WORKFLOW_TIMEOUT_SECS: u64 = 6 * 60 * 60;
+
 // ── Minimal interface types mirroring the domain contracts ────────────────────
 // These allow the coordinator to inspect cross-contract return values without
 // importing compiled WASMs. The domain contracts must keep these in sync.
@@ -391,6 +397,7 @@ impl CoordinatorContract {
                 status: WorkflowStatus::Allocated,
                 delivery_confirmed: false,
                 delivery_location: None,
+                expires_at: env.ledger().timestamp() + WORKFLOW_TIMEOUT_SECS,
             },
         );
 
@@ -563,6 +570,87 @@ impl CoordinatorContract {
             (
                 symbol_short!("coord"),
                 symbol_short!("rollbk"),
+                symbol_short!("v1"),
+            ),
+            request_id,
+        );
+
+        Ok(())
+    }
+
+    /// Expire a stale workflow once its deadline has elapsed.
+    ///
+    /// Any caller may invoke this once `ledger.timestamp() >= record.expires_at`.
+    /// The workflow must be in the `Allocated` state (i.e. `confirm_delivery`
+    /// was never called).  On success the workflow is rolled back: reserved
+    /// inventory units are released back to `Available` and the escrowed
+    /// payment is refunded to the payer.
+    ///
+    /// # Errors
+    /// - `WorkflowNotFound`    — no workflow exists for `request_id`
+    /// - `WorkflowNotExpired`  — the expiry deadline has not yet passed
+    /// - `InvalidWorkflowState`— workflow is not in the `Allocated` state
+    ///   (already delivered, settled, or rolled back)
+    pub fn expire_workflow(
+        env: Env,
+        request_id: u64,
+    ) -> Result<(), CoordinatorError> {
+        Self::require_initialized(&env)?;
+
+        let wf = load_workflow(&env, request_id).ok_or(CoordinatorError::WorkflowNotFound)?;
+
+        if env.ledger().timestamp() < wf.expires_at {
+            return Err(CoordinatorError::WorkflowNotExpired);
+        }
+
+        if wf.status != WorkflowStatus::Allocated {
+            return Err(CoordinatorError::InvalidWorkflowState);
+        }
+
+        // Reuse the existing rollback logic to release units and refund payment.
+        // We call `get_admin` only to satisfy the inventory client's admin
+        // parameter — the coordinator itself is authorised to update inventory.
+        let inv_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InventoryContract)
+            .unwrap();
+        let inv_client = InventoryContractClient::new(&env, &inv_addr);
+        let inv_admin = inv_client.get_admin();
+
+        for i in 0..wf.unit_ids.len() {
+            let uid = wf.unit_ids.get(i).unwrap();
+            inv_client
+                .try_update_status(&uid, &BloodStatus::Available, &inv_admin, &None)
+                .map_err(|_| CoordinatorError::InventoryUpdateFailed)?
+                .map_err(|_| CoordinatorError::InventoryUpdateFailed)?;
+        }
+
+        let pay_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentContract)
+            .unwrap();
+        let pay_client = PaymentContractClient::new(&env, &pay_addr);
+        let payment = pay_client
+            .try_get_payment(&wf.payment_id)
+            .map_err(|_| CoordinatorError::PaymentNotFound)?
+            .map_err(|_| CoordinatorError::PaymentNotFound)?;
+        if payment.status == PaymentStatus::Locked {
+            pay_client
+                .try_update_status(&wf.payment_id, &PaymentStatus::Refunded)
+                .map_err(|_| CoordinatorError::PaymentUpdateFailed)?
+                .map_err(|_| CoordinatorError::PaymentUpdateFailed)?;
+        }
+
+        let mut expired_wf = wf;
+        expired_wf.status = WorkflowStatus::RolledBack;
+        save_workflow(&env, &expired_wf);
+
+        env.events().publish(
+            (
+                symbol_short!("coord"),
+                symbol_short!("expired"),
                 symbol_short!("v1"),
             ),
             request_id,

--- a/lifebank-soroban/contracts/coordinator/src/test.rs
+++ b/lifebank-soroban/contracts/coordinator/src/test.rs
@@ -532,3 +532,99 @@ fn test_flag_temperature_breach_blocked_when_paused() {
     let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
     assert_eq!(payment.status, PaymentStatus::Locked);
 }
+
+// ── Workflow expiry tests (issue #855) ────────────────────────────────────────
+
+use soroban_sdk::testutils::Ledger as _;
+
+/// expire_workflow succeeds once the deadline has elapsed, releasing units
+/// and refunding the escrowed payment.
+#[test]
+fn test_expire_workflow_rolls_back_after_deadline() {
+    let h = setup();
+    h.env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    seed_pending_request(&h, 1);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 1);
+
+    h.coord.allocate_units(&1u64, &vec![&h.env, unit_id], &payment_id, &h.admin);
+
+    let wf = h.coord.get_workflow(&1u64);
+    assert_eq!(wf.status, WorkflowStatus::Allocated);
+    // expires_at should be 1_000 + 6 * 3600 = 22_600
+    assert_eq!(wf.expires_at, 1_000 + 6 * 60 * 60);
+
+    // Advance time past the expiry window.
+    h.env.ledger().with_mut(|l| l.timestamp = wf.expires_at + 1);
+
+    h.coord.expire_workflow(&1u64);
+
+    let wf_after = h.coord.get_workflow(&1u64);
+    assert_eq!(wf_after.status, WorkflowStatus::RolledBack, "Expired workflow must be RolledBack");
+
+    let unit = MockInventoryContractClient::new(&h.env, &h.inv_id).get_blood_unit(&unit_id);
+    assert_eq!(unit.status, BloodStatus::Available, "Units must be released after expiry");
+
+    let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
+    assert_eq!(payment.status, PaymentStatus::Refunded, "Payment must be Refunded after expiry");
+}
+
+/// expire_workflow is rejected when the deadline has not yet elapsed.
+#[test]
+fn test_expire_workflow_blocked_before_deadline() {
+    let h = setup();
+    h.env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    seed_pending_request(&h, 2);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 2);
+
+    h.coord.allocate_units(&2u64, &vec![&h.env, unit_id], &payment_id, &h.admin);
+
+    // Time has NOT advanced past expires_at.
+    let result = h.coord.try_expire_workflow(&2u64);
+    assert_eq!(
+        result,
+        Err(Ok(CoordinatorError::WorkflowNotExpired)),
+        "expire_workflow must fail before deadline"
+    );
+
+    // Workflow must remain Allocated.
+    let wf = h.coord.get_workflow(&2u64);
+    assert_eq!(wf.status, WorkflowStatus::Allocated);
+}
+
+/// expire_workflow on a non-existent workflow returns WorkflowNotFound.
+#[test]
+fn test_expire_workflow_not_found() {
+    let h = setup();
+    h.env.ledger().with_mut(|l| l.timestamp = 99_999);
+    let result = h.coord.try_expire_workflow(&9999u64);
+    assert_eq!(result, Err(Ok(CoordinatorError::WorkflowNotFound)));
+}
+
+/// expire_workflow on an already-delivered workflow returns InvalidWorkflowState.
+#[test]
+fn test_expire_workflow_blocked_for_delivered_workflow() {
+    let h = setup();
+    h.env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    seed_pending_request(&h, 3);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 3);
+
+    h.coord.allocate_units(&3u64, &vec![&h.env, unit_id], &payment_id, &h.admin);
+    h.coord.confirm_delivery(&3u64, &h.admin, &String::from_str(&h.env, "Hospital-B"));
+
+    // Advance past expiry.
+    let wf = h.coord.get_workflow(&3u64);
+    h.env.ledger().with_mut(|l| l.timestamp = wf.expires_at + 1);
+
+    let result = h.coord.try_expire_workflow(&3u64);
+    assert_eq!(
+        result,
+        Err(Ok(CoordinatorError::InvalidWorkflowState)),
+        "expire_workflow must fail for a Delivered workflow"
+    );
+}

--- a/lifebank-soroban/contracts/coordinator/src/types.rs
+++ b/lifebank-soroban/contracts/coordinator/src/types.rs
@@ -32,6 +32,9 @@ pub struct WorkflowRecord {
     /// Geographic location or identifier supplied by the confirmer at delivery.
     /// None until confirm_delivery() is called.
     pub delivery_location: Option<String>,
+    /// Unix timestamp after which the workflow may be expired by anyone.
+    /// Set at allocation time: `ledger.timestamp() + WORKFLOW_TIMEOUT_SECS`.
+    pub expires_at: u64,
 }
 
 /// Summary of a sustained temperature excursion (mirrors temperature contract type).


### PR DESCRIPTION
## Summary

Closes #855

Allocated workflows that never advance to `confirm_delivery` can now be automatically expired once a 6-hour deadline has elapsed. Before this change, a stuck workflow would permanently lock blood units as `Reserved` and keep the payment in escrow indefinitely, blocking urgent patients and donors.

## Changes

### `contracts/coordinator/src/types.rs`
- Added `expires_at: u64` to `WorkflowRecord`. This timestamp is set at allocation time and marks the deadline after which the workflow may be forcibly expired.

### `contracts/coordinator/src/error.rs`
- Added `WorkflowNotExpired = 842` error variant returned when `expire_workflow()` is called before the deadline.

### `contracts/coordinator/src/lib.rs`
- Added `WORKFLOW_TIMEOUT_SECS` constant (6 hours = 21 600 seconds).
- `allocate_units()` now stamps `expires_at = env.ledger().timestamp() + WORKFLOW_TIMEOUT_SECS` onto the new `WorkflowRecord`.
- Added `expire_workflow(env, request_id)` public function:
  - Callable by **any address** (no admin required) once the deadline has elapsed.
  - Validates the workflow is in the `Allocated` state.
  - Releases all reserved inventory units back to `Available`.
  - Refunds the escrowed payment to the payer.
  - Transitions the workflow to `RolledBack` and emits a `coord/expired` event.

### `contracts/coordinator/src/test.rs`
- `test_expire_workflow_rolls_back_after_deadline` — happy path: units released + payment refunded after deadline.
- `test_expire_workflow_blocked_before_deadline` — `WorkflowNotExpired` returned when time < `expires_at`.
- `test_expire_workflow_not_found` — `WorkflowNotFound` returned for unknown workflow ID.
- `test_expire_workflow_blocked_for_delivered_workflow` — `InvalidWorkflowState` returned when the workflow has already been delivered.

## Test plan

- [x] `cargo test -p coordinator-contract` — all 21 tests pass (17 existing + 4 new)
- [x] `cargo test -p payment-contract` — all 51 tests continue to pass (unaffected)