### PR TITLE
Fix critical security and infrastructure issues in Soroban contracts

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -149,15 +149,37 @@ fn get_admin(env: &Env) -> Address {
 }
 
 fn load_workflow(env: &Env, request_id: u64) -> Option<WorkflowRecord> {
+    const WORKFLOW_TTL_LEDGERS: u32 = 535_680; // ~30 days at 5s/ledger
+    
+    let key = DataKey::Workflow(request_id);
+    
+    // Extend TTL on every read
+    env.storage().persistent().extend_ttl(
+        &key,
+        WORKFLOW_TTL_LEDGERS,
+        WORKFLOW_TTL_LEDGERS,
+    );
+    
     env.storage()
         .persistent()
-        .get(&DataKey::Workflow(request_id))
+        .get(&key)
 }
 
 fn save_workflow(env: &Env, wf: &WorkflowRecord) {
+    const WORKFLOW_TTL_LEDGERS: u32 = 535_680; // ~30 days at 5s/ledger
+    
+    let key = DataKey::Workflow(wf.request_id);
+    
     env.storage()
         .persistent()
-        .set(&DataKey::Workflow(wf.request_id), wf);
+        .set(&key, wf);
+        
+    // Extend TTL on every write
+    env.storage().persistent().extend_ttl(
+        &key,
+        WORKFLOW_TTL_LEDGERS,
+        WORKFLOW_TTL_LEDGERS,
+    );
 }
 
 // ── Contract ───────────────────────────────────────────────────────────────────
@@ -637,6 +659,28 @@ impl CoordinatorContract {
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(CoordinatorError::NotInitialized);
         }
+        Ok(())
+    }
+
+    /// Upgrade the contract to a new WASM hash. Only admin can call this.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address that must authorize the upgrade
+    /// * `new_wasm_hash` - Hash of the new WASM code to upgrade to
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller is not the admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), CoordinatorError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(CoordinatorError::Unauthorized)?;
+        if admin != stored {
+            return Err(CoordinatorError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
 }

--- a/lifebank-soroban/contracts/inventory/src/lib.rs
+++ b/lifebank-soroban/contracts/inventory/src/lib.rs
@@ -580,6 +580,7 @@ impl InventoryContract {
         let reservation = Reservation {
             unit_ids: unit_ids.clone(),
             requester: requester.clone(),
+            reserved_by: requester.clone(),
             created_timestamp: current_time,
             expiration_timestamp: expiration,
             request_id,
@@ -605,16 +606,27 @@ impl InventoryContract {
 
     /// Release a reservation, returning all units to `Available`.
     ///
-    /// Can be called by anyone — the reservation record is the authority.
+    /// Can only be called by the original reserver or admin.
     /// If the reservation has already expired (ledger time > expiration_timestamp)
     /// the call still succeeds so callers can clean up stale reservations.
     ///
     /// Records a status history entry and emits a status-change event for every
     /// unit that transitions Reserved → Available, preserving the full audit trail.
-    pub fn release_reservation(env: Env, reservation_id: u64) -> Result<(), ContractError> {
+    pub fn release_reservation(env: Env, caller: Address, reservation_id: u64) -> Result<(), ContractError> {
+        caller.require_auth();
         Self::require_not_paused(&env)?;
+        
         let reservation = storage::get_reservation(&env, reservation_id)
             .ok_or(ContractError::ReservationNotFound)?;
+
+        // Verify caller is either the original reserver or admin
+        if caller != reservation.reserved_by {
+            // Allow admin to release any reservation
+            let admin = storage::get_admin(&env);
+            if caller != admin {
+                return Err(ContractError::Unauthorized);
+            }
+        }
 
         for i in 0..reservation.unit_ids.len() {
             let unit_id = reservation.unit_ids.get(i).ok_or(ContractError::NotFound)?;
@@ -689,6 +701,24 @@ impl InventoryContract {
         }
 
         Ok(reservation_ids)
+    }
+
+    /// Upgrade the contract to a new WASM hash. Only admin can call this.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address that must authorize the upgrade
+    /// * `new_wasm_hash` - Hash of the new WASM code to upgrade to
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller is not the admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }
 

--- a/lifebank-soroban/contracts/inventory/src/types.rs
+++ b/lifebank-soroban/contracts/inventory/src/types.rs
@@ -306,6 +306,7 @@ pub enum DataKey {
 pub struct Reservation {
     pub unit_ids: Vec<u64>,
     pub requester: Address,
+    pub reserved_by: Address,
     pub created_timestamp: u64,
     pub expiration_timestamp: u64,
     pub request_id: u64,

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -1227,6 +1227,28 @@ impl PaymentContract {
             page_size,
         }
     }
+
+    /// Upgrade the contract to a new WASM hash. Only admin can call this.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address that must authorize the upgrade
+    /// * `new_wasm_hash` - Hash of the new WASM code to upgrade to
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller is not the admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN_KEY)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
+    }
 }
 
 mod test;

--- a/lifebank-soroban/contracts/requests/src/lib.rs
+++ b/lifebank-soroban/contracts/requests/src/lib.rs
@@ -19,11 +19,11 @@ mod validation;
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 mod inventory_client {
-    use soroban_sdk::{contractclient, Env};
+    use soroban_sdk::{contractclient, Address, Env};
 
     #[contractclient(name = "InventoryContractClient")]
     pub trait InventoryContractInterface {
-        fn release_reservation(env: Env, reservation_id: u64);
+        fn release_reservation(env: Env, caller: Address, reservation_id: u64);
     }
 }
 
@@ -69,7 +69,8 @@ impl RequestContract {
         if let Some(res_id) = request.reservation_id {
             let inventory_addr = storage::get_inventory_contract(env);
             let inv_client = InventoryContractClient::new(env, &inventory_addr);
-            inv_client.release_reservation(&res_id);
+            let admin = storage::get_admin(env);
+            inv_client.release_reservation(&admin, &res_id);
             request.reservation_id = None;
             true
         } else {
@@ -490,5 +491,24 @@ impl RequestContract {
 
     pub fn is_initialized(env: Env) -> bool {
         storage::is_initialized(&env)
+    }
+
+    /// Upgrade the contract to a new WASM hash. Only admin can call this.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address that must authorize the upgrade
+    /// * `new_wasm_hash` - Hash of the new WASM code to upgrade to
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller is not the admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ContractError> {
+        admin.require_auth();
+        storage::require_initialized(&env)?;
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 }

--- a/lifebank-soroban/contracts/temperature/src/lib.rs
+++ b/lifebank-soroban/contracts/temperature/src/lib.rs
@@ -449,6 +449,24 @@ impl TemperatureContract {
 
         Ok(())
     }
+
+    /// Upgrade the contract to a new WASM hash. Only admin can call this.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address that must authorize the upgrade
+    /// * `new_wasm_hash` - Hash of the new WASM code to upgrade to
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller is not the admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #857: [contracts/inventory] Fix release_reservation() authorization vulnerability
- Added reserved_by field to Reservation struct to track original reserver
- Modified release_reservation() to verify caller is original reserver or admin
- Updated requests contract to pass admin address when releasing reservations
- Prevents malicious actors from releasing other parties' reservations

Closes #819: [contracts/coordinator] Fix WorkflowRecord TTL expiration issue
- Added TTL extension logic to load_workflow() and save_workflow() functions
- Set TTL to 535,680 ledgers (~30 days at 5s/ledger) on every read/write
- Prevents active workflow records from silently expiring from storage
- Ensures audit trail persistence for completed workflows

Closes #829: [contracts] Add upgrade/migration path for all contracts
- Implemented upgrade() function in inventory, coordinator, payments, requests, and temperature contracts
- Each upgrade() function requires admin authorization and uses env.deployer().update_current_contract_wasm()
- Enables post-deployment bug fixes and feature updates without breaking integrations
- Maintains existing contract addresses and storage state during upgrades