### PR TITLE
docs(soroban): add full contract documentation suite

### DIFF
--- a/lifebank-soroban/ARCHITECTURE.md
+++ b/lifebank-soroban/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+# Architecture
+
+## Contract dependency graph
+
+```
+                        ┌─────────────────────────────────────────────────────┐
+                        │                   COORDINATOR                        │
+                        │  Enforces workflow state machine.                    │
+                        │  Holds addresses of requests, inventory, payments.   │
+                        └──────────┬──────────────┬──────────────┬────────────┘
+                                   │              │              │
+                    calls          │              │              │          calls
+              get_request()        │              │   update_status()      get_payment()
+              (read-only)          │              │   mark_delivered()     update_status()
+                                   ▼              ▼              ▼         record_dispute()
+                          ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+                          │   REQUESTS   │ │  INVENTORY   │ │   PAYMENTS   │
+                          │              │ │              │ │              │
+                          │ Hospital     │ │ Blood unit   │ │ Escrow,      │
+                          │ blood        │ │ lifecycle,   │ │ pledges,     │
+                          │ requests     │ │ reservations │ │ disputes     │
+                          └──────────────┘ └──────┬───────┘ └──────────────┘
+                                                  │
+                                          reads unit index
+                                                  │
+                                                  ▼
+                          ┌──────────────┐ ┌──────────────┐
+                          │   MATCHING   │ │ TEMPERATURE  │──────────────────┐
+                          │              │ │              │                  │
+                          │ ABO/Rh       │ │ IoT readings,│  flag_temperature│
+                          │ compatibility│ │ excursion    │  _breach()       │
+                          │ + FIFO sort  │ │ detection    │──────────────────┘
+                          └──────────────┘ └──────────────┘     calls coordinator
+                                                                 when 3 consecutive
+                                                                 violations detected
+
+          ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+          │   IDENTITY   │ │  REPUTATION  │ │  ANALYTICS   │
+          │              │ │              │ │              │
+          │ Org registry,│ │ Weighted     │ │ Periodic     │
+          │ roles, badges│ │ score with   │ │ metrics      │
+          │ delivery     │ │ decay +      │ │ snapshots    │
+          │ verification │ │ penalties    │ │              │
+          └──────────────┘ └──────────────┘ └──────────────┘
+
+          ┌──────────────┐
+          │   DELIVERY   │
+          │              │
+          │ Compliance   │
+          │ attestation  │
+          │ hashes       │
+          └──────────────┘
+```
+
+## Core workflow: blood delivery lifecycle
+
+The coordinator enforces a strict three-step state machine. Each step is a separate transaction; the coordinator rejects any step that arrives out of order.
+
+```
+Hospital creates request          Blood bank creates escrow payment
+        │                                       │
+        ▼                                       ▼
+  RequestStatus::Pending              PaymentStatus::Locked
+        │                                       │
+        └──────────────────┬────────────────────┘
+                           │
+                    Step 1: allocate_units()
+                    ─────────────────────────
+                    • Verifies request is Pending
+                    • Marks each blood unit Reserved
+                    • Creates WorkflowRecord (Allocated)
+                           │
+                           ▼
+                  WorkflowStatus::Allocated
+                  BloodStatus::Reserved (all units)
+                           │
+                    Step 2: confirm_delivery()
+                    ──────────────────────────
+                    • Transitions units: Reserved → InTransit → Delivered
+                    • Records delivery location
+                    • Sets delivery_confirmed = true
+                           │
+                           ▼
+                  WorkflowStatus::Delivered
+                  BloodStatus::Delivered (all units)
+                           │
+                    Step 3: settle_payment()
+                    ──────────────────────────
+                    • Requires delivery_confirmed == true
+                    • Transitions payment: Locked → Released
+                           │
+                           ▼
+                  WorkflowStatus::Settled
+                  PaymentStatus::Released
+```
+
+### Rollback path
+
+Admin can call `rollback()` on any workflow that has not yet reached `Settled`:
+
+```
+rollback()
+  • Returns all units to Available
+  • If payment is Locked → transitions to Refunded
+  • WorkflowStatus → RolledBack
+```
+
+### Temperature excursion path
+
+```
+IoT oracle / admin calls temperature.report_excursion_to_coordinator()
+  │
+  ▼
+temperature contract calls coordinator.flag_temperature_breach()
+  │
+  ▼
+coordinator calls payments.record_dispute(TemperatureExcursion)
+  │
+  ▼
+PaymentStatus → Disputed
+```
+
+## Storage tiers
+
+Soroban has three storage tiers. Each contract uses them as follows:
+
+| Tier | TTL | Used for |
+|---|---|---|
+| **Instance** | Tied to contract instance | Admin address, contract addresses, counters, config |
+| **Persistent** | Explicit TTL bump required | Blood units, payments, requests, history, indexes |
+| **Temporary** | Auto-expires | Reservations (inventory contract) |
+
+Persistent entries in the payments contract are bumped to ~60 days whenever their remaining TTL falls below ~30 days (`PERSISTENT_BUMP_THRESHOLD = 518_400 ledgers`, `PERSISTENT_BUMP_TO = 1_036_800 ledgers`).
+
+## Circuit breakers
+
+Every contract exposes `pause()` / `unpause()` (admin only). The coordinator additionally has `emergency_halt()` / `clear_emergency_halt()`:
+
+- `pause()` — blocks new allocations and state mutations
+- `emergency_halt()` — blocks `confirm_delivery` and `settle_payment` on all in-flight workflows without blocking new allocations; designed for active incident containment
+
+## Cross-contract call pattern
+
+The coordinator defines minimal proxy types (`BloodRequest {id, status}`, `BloodUnit {id, status}`, `Payment {id, request_id, status}`) that mirror only the fields it needs. Domain contracts must keep these fields in sync. This avoids importing compiled WASMs and keeps the coordinator's footprint small.
+
+All cross-contract calls use `try_*` variants so failures return typed errors rather than panicking.

--- a/lifebank-soroban/README.md
+++ b/lifebank-soroban/README.md
@@ -1,44 +1,83 @@
 # Lifebank Soroban Contracts
 
-This workspace contains the Lifebank Soroban smart contracts used by Health-chain.
+On-chain smart contract layer for the HealthChain blood supply platform, built with [Soroban](https://soroban.stellar.org/) on Stellar.
 
-## Project structure
+## What's here
 
-The repository uses a Cargo workspace with contract crates located under `contracts/*`.
+Ten contracts that together manage the full blood donation lifecycle — from registration through delivery and payment settlement:
 
-Existing contract directories include:
+| Contract | Purpose |
+|---|---|
+| **coordinator** | Orchestrates the three-step delivery workflow across inventory, payments, and requests |
+| **inventory** | Registers blood units, tracks status transitions, manages reservations |
+| **requests** | Hospital blood requests with approval workflow and history |
+| **payments** | Escrow-backed payments, dispute handling, donation pledges |
+| **temperature** | IoT cold-chain monitoring with automatic excursion escalation |
+| **matching** | ABO/Rh compatibility matching with FIFO expiration-aware selection |
+| **identity** | Organization registry, role-based access, badges, delivery verification |
+| **reputation** | Weighted reputation scoring with decay, fraud penalties, and violation tracking |
+| **analytics** | Periodic metrics snapshots and lifetime counters |
+| **delivery** | Compliance attestation hashes for completed deliveries |
 
-- `analytics`
-- `coordinator`
-- `delivery`
-- `identity`
-- `inventory`
-- `matching`
-- `payments`
-- `reputation`
-- `requests`
-- `temperature`
+The coordinator is the integration point. It holds references to inventory, payments, and requests, and enforces the canonical three-step workflow: `allocate_units → confirm_delivery → settle_payment`.
 
-Each contract directory contains its own `Cargo.toml` and source files, while the top-level `Cargo.toml` provides shared workspace dependency definitions.
+## Prerequisites
 
-## Running tests
-
-From the repository root:
+- Rust toolchain with `wasm32-unknown-unknown` target
+- Soroban CLI (`cargo install --locked soroban-cli`)
+- A funded Stellar testnet account (use `soroban keys generate` or Stellar Laboratory)
 
 ```bash
-cargo test
+# Add the WASM target if you haven't already
+rustup target add wasm32-unknown-unknown
 ```
 
-## Contract development
+## Build
 
-- Add new contracts under `contracts/<contract-name>`.
-- Each contract must include its own `Cargo.toml`.
-- Shared dependencies are declared in the top-level workspace `Cargo.toml`.
+```bash
+# From the lifebank-soroban directory
+cargo build --release --target wasm32-unknown-unknown
 
-## Environment
+# Or use the helper script
+./scripts/build-all.sh
+```
 
-This workspace does not require any `.env` variables by default. If your local Soroban toolchain or contract scripts need environment variables, add them to a `.env` file and keep it out of source control.
+WASM artifacts land in `target/wasm32-unknown-unknown/release/`.
 
-## Notes
+## Test
 
-This repository no longer uses the starter `hello_world` template. Use the contracts already present under `contracts/`.
+```bash
+# Run all unit and integration tests
+cargo test
+
+# Run only the cross-contract integration tests
+cargo test --package tests
+
+# Run tests for a single contract
+cargo test --package inventory-contract
+```
+
+The integration tests in `tests/integration_test.rs` exercise the full coordinator workflow using lightweight mock contracts. See [ARCHITECTURE.md](ARCHITECTURE.md) for what each test covers.
+
+## Deploy
+
+See [docs/deployment.md](docs/deployment.md) for step-by-step testnet and mainnet deployment instructions.
+
+A quick testnet deploy:
+
+```bash
+./scripts/deploy-testnet.sh
+```
+
+Contract addresses are written to `.contract-ids.json` after deployment.
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — contract dependency graph and data flow
+- [docs/contracts/coordinator.md](docs/contracts/coordinator.md) — coordinator function reference
+- [docs/contracts/inventory.md](docs/contracts/inventory.md) — inventory function reference
+- [docs/contracts/payments.md](docs/contracts/payments.md) — payments function reference
+- [docs/contracts/temperature.md](docs/contracts/temperature.md) — temperature monitoring reference
+- [docs/contracts/requests.md](docs/contracts/requests.md) — requests function reference
+- [docs/deployment.md](docs/deployment.md) — deployment guide
+- [docs/indexing.md](docs/indexing.md) — event schema for off-chain indexers

--- a/lifebank-soroban/docs/contracts/coordinator.md
+++ b/lifebank-soroban/docs/contracts/coordinator.md
@@ -1,0 +1,266 @@
+# Coordinator Contract
+
+The coordinator is the integration hub. It holds references to the requests, inventory, and payments contracts and enforces the canonical three-step delivery workflow. No blood unit can be delivered and no payment can be released without passing through this contract.
+
+## State machine
+
+```
+                    ┌─────────┐
+                    │ Pending │  (implicit — no WorkflowRecord yet)
+                    └────┬────┘
+                         │ allocate_units()
+                         ▼
+                   ┌───────────┐
+                   │ Allocated │
+                   └─────┬─────┘
+                         │ confirm_delivery()
+                         ▼
+                   ┌───────────┐
+                   │ Delivered │
+                   └─────┬─────┘
+                         │ settle_payment()
+                         ▼
+                    ┌─────────┐
+                    │ Settled │  (terminal)
+                    └─────────┘
+
+  Any non-Settled state ──► rollback() ──► RolledBack (terminal)
+```
+
+## Public functions
+
+### initialize
+
+```rust
+pub fn initialize(
+    env: Env,
+    admin: Address,
+    request_contract: Address,
+    inventory_contract: Address,
+    payment_contract: Address,
+) -> Result<(), CoordinatorError>
+```
+
+One-time setup. Stores the admin address and the three domain contract addresses. Emits `(coord, init, v1)` event. Returns `AlreadyInitialized` if called again.
+
+---
+
+### allocate_units
+
+```rust
+pub fn allocate_units(
+    env: Env,
+    request_id: u64,
+    unit_ids: Vec<u64>,
+    payment_id: u64,
+    caller: Address,
+) -> Result<(), CoordinatorError>
+```
+
+Step 1 of the workflow.
+
+- Requires `caller` auth.
+- Verifies the request exists and is `Pending`.
+- Verifies each blood unit exists and is `Available`, then marks it `Reserved`.
+- Creates a `WorkflowRecord` with status `Allocated`.
+- Emits `(coord, alloc, v1)` with `(request_id, unit_count)`.
+
+Fails if the contract is paused or a workflow for this `request_id` already exists in a non-Pending state.
+
+---
+
+### confirm_delivery
+
+```rust
+pub fn confirm_delivery(
+    env: Env,
+    request_id: u64,
+    caller: Address,
+    location: String,
+) -> Result<(), CoordinatorError>
+```
+
+Step 2 of the workflow.
+
+- Requires `caller` auth.
+- Workflow must be `Allocated`.
+- Transitions each unit: `Reserved → InTransit`, then `InTransit → Delivered` (via `mark_delivered`).
+- Sets `delivery_confirmed = true` and stores `delivery_location`.
+- Emits `(coord, dlvrd, v1)` with `(request_id, location)`.
+
+Blocked by both `pause()` and `emergency_halt()`.
+
+---
+
+### settle_payment
+
+```rust
+pub fn settle_payment(
+    env: Env,
+    request_id: u64,
+    caller: Address,
+) -> Result<(), CoordinatorError>
+```
+
+Step 3 of the workflow.
+
+- Requires `caller` auth.
+- Workflow must be `Delivered` with `delivery_confirmed == true`.
+- Payment must be `Locked`; transitions it to `Released`.
+- Emits `(coord, settld, v1)` with `(request_id, payment_id)`.
+
+Blocked by both `pause()` and `emergency_halt()`.
+
+---
+
+### rollback
+
+```rust
+pub fn rollback(env: Env, request_id: u64) -> Result<(), CoordinatorError>
+```
+
+Admin-only. Reverses an in-flight workflow.
+
+- Returns all allocated units to `Available`.
+- If the payment is `Locked`, transitions it to `Refunded`. Other payment states are left unchanged.
+- Sets workflow status to `RolledBack`.
+- Emits `(coord, rollbk, v1)` with `request_id`.
+
+Returns `CannotRollbackSettled` if the workflow has already settled.
+
+---
+
+### flag_temperature_breach
+
+```rust
+pub fn flag_temperature_breach(
+    env: Env,
+    caller: Address,
+    payment_id: u64,
+    excursion_summary: ExcursionSummary,
+) -> Result<(), CoordinatorError>
+```
+
+Called by the temperature contract when a sustained excursion is detected.
+
+- Requires `caller` auth (must be a whitelisted oracle or admin on the temperature contract side).
+- Payment must be `Locked`; calls `payments.record_dispute(TemperatureExcursion)`.
+- Emits `(coord, tmp_brch)` with `(payment_id, unit_id, timestamp)`.
+
+---
+
+### pause / unpause
+
+```rust
+pub fn pause(env: Env, admin: Address) -> Result<(), CoordinatorError>
+pub fn unpause(env: Env, admin: Address) -> Result<(), CoordinatorError>
+pub fn is_paused(env: Env) -> bool
+```
+
+Admin-only circuit breaker. Blocks `allocate_units`, `confirm_delivery`, `settle_payment`, and `rollback`.
+
+---
+
+### emergency_halt / clear_emergency_halt
+
+```rust
+pub fn emergency_halt(env: Env, admin: Address) -> Result<(), CoordinatorError>
+pub fn clear_emergency_halt(env: Env, admin: Address) -> Result<(), CoordinatorError>
+pub fn is_emergency_halted(env: Env) -> bool
+```
+
+Admin-only. Unlike `pause()`, the emergency halt only blocks `confirm_delivery` and `settle_payment` — it does not block new allocations. Designed for active incident containment (e.g. compromised oracle). Emits `(coord, emrghlt, v1)` on activation.
+
+---
+
+### get_workflow
+
+```rust
+pub fn get_workflow(env: Env, request_id: u64) -> Result<WorkflowRecord, CoordinatorError>
+```
+
+Returns the `WorkflowRecord` for a request. Returns `WorkflowNotFound` if no workflow exists.
+
+---
+
+### is_initialized
+
+```rust
+pub fn is_initialized(env: Env) -> bool
+```
+
+Returns `true` if `initialize()` has been called.
+
+## Types
+
+### WorkflowRecord
+
+```rust
+pub struct WorkflowRecord {
+    pub request_id: u64,
+    pub payment_id: u64,
+    pub unit_ids: Vec<u64>,
+    pub status: WorkflowStatus,
+    pub delivery_confirmed: bool,
+    pub delivery_location: Option<String>,
+}
+```
+
+### WorkflowStatus
+
+```rust
+pub enum WorkflowStatus {
+    Pending,
+    Allocated,
+    Delivered,
+    Settled,
+    RolledBack,
+}
+```
+
+### ExcursionSummary
+
+```rust
+pub struct ExcursionSummary {
+    pub unit_id: u64,
+    pub violation_count: u32,
+    pub peak_celsius_x100: i32,
+    pub detected_at: u64,
+}
+```
+
+## Storage keys
+
+| Key | Storage tier | Type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Admin address |
+| `DataKey::RequestContract` | Instance | `Address` | Requests contract address |
+| `DataKey::InventoryContract` | Instance | `Address` | Inventory contract address |
+| `DataKey::PaymentContract` | Instance | `Address` | Payments contract address |
+| `DataKey::Paused` | Instance | `bool` | Pause flag |
+| `DataKey::EmergencyHalt` | Instance | `bool` | Emergency halt flag |
+| `DataKey::Workflow(request_id)` | Persistent | `WorkflowRecord` | Per-request workflow state |
+
+## Error codes
+
+| Code | Value | Meaning |
+|---|---|---|
+| `AlreadyInitialized` | 800 | `initialize()` called twice |
+| `NotInitialized` | 801 | Contract not yet initialized |
+| `Unauthorized` | 802 | Caller is not admin |
+| `WorkflowNotFound` | 810 | No workflow for this request_id |
+| `WorkflowAlreadyStarted` | 811 | Workflow exists and is not Pending |
+| `InvalidWorkflowState` | 812 | Wrong workflow state for this step |
+| `CannotRollbackSettled` | 813 | Workflow already settled |
+| `RequestNotFound` | 820 | Cross-contract: request not found |
+| `InvalidRequestState` | 821 | Request is not Pending |
+| `UnitNotFound` | 822 | Cross-contract: blood unit not found |
+| `UnitNotAvailable` | 823 | Blood unit is not Available |
+| `PaymentNotFound` | 824 | Cross-contract: payment not found |
+| `InvalidPaymentState` | 825 | Payment is not in expected state |
+| `DeliveryNotConfirmed` | 826 | settle_payment called before confirm_delivery |
+| `InventoryUpdateFailed` | 830 | Cross-contract call to inventory failed |
+| `PaymentUpdateFailed` | 831 | Cross-contract call to payments failed |
+| `PaymentFlagFailed` | 832 | Cross-contract dispute recording failed |
+| `ContractPaused` | 840 | Contract is paused |
+| `EmergencyHalted` | 841 | Emergency halt is active |

--- a/lifebank-soroban/docs/contracts/inventory.md
+++ b/lifebank-soroban/docs/contracts/inventory.md
@@ -1,0 +1,333 @@
+# Inventory Contract
+
+Manages the full lifecycle of blood units from donation registration through delivery or disposal. Maintains indexes for efficient querying by blood type, bank, status, and donor. Supports time-bounded reservations stored in temporary storage.
+
+## Blood unit lifecycle
+
+```
+register_blood()
+      │
+      ▼
+  Available ──► Reserved ──► InTransit ──► Delivered  (terminal)
+      │             │             │
+      ▼             ▼             ▼
+  Expired       Expired       Expired ──► Disposed    (terminal)
+      │
+      ▼
+  Disposed    (terminal)
+
+  Available / Reserved / InTransit ──► Compromised ──► Disposed (terminal)
+
+  Reserved ──► Available  (via release_reservation or rollback)
+```
+
+All other transitions are rejected. Backwards transitions (e.g. `Delivered → Available`) are explicitly forbidden to preserve the on-chain audit trail.
+
+## Public functions
+
+### initialize
+
+```rust
+pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError>
+```
+
+One-time setup. Sets the admin and authorizes the admin address as the first blood bank. Returns `AlreadyInitialized` if called again.
+
+---
+
+### authorize_bank / is_authorized_bank
+
+```rust
+pub fn authorize_bank(env: Env, admin: Address, bank: Address, authorized: bool) -> Result<(), ContractError>
+pub fn is_authorized_bank(env: Env, bank: Address) -> bool
+```
+
+Admin-only. Grants or revokes blood bank authorization. Only authorized banks can register blood units and create reservations.
+
+---
+
+### register_blood
+
+```rust
+pub fn register_blood(
+    env: Env,
+    bank_id: Address,
+    serial_number: String,
+    blood_type: BloodType,
+    quantity_ml: u32,
+    donor_id: Option<Address>,
+) -> Result<u64, ContractError>
+```
+
+Registers a new blood unit. `bank_id` must be authorized.
+
+- `serial_number` must be unique (physical bag ID); duplicate serials are rejected.
+- `quantity_ml` must be 100–600 ml.
+- Timestamps are derived from ledger time: `donation_timestamp = now`, `expiration_timestamp = now + 35 days`.
+- Returns the new blood unit ID.
+- Emits `blood_registered` event.
+
+---
+
+### batch_register_blood
+
+```rust
+pub fn batch_register_blood(
+    env: Env,
+    bank_id: Address,
+    entries: Vec<(String, BloodType, u32, Option<Address>)>,
+) -> Result<Vec<u64>, ContractError>
+```
+
+Registers multiple units in a single transaction. Each tuple is `(serial_number, blood_type, quantity_ml, donor_id)`. Returns IDs in input order. All-or-nothing: if any entry fails validation, the entire batch is rejected.
+
+---
+
+### get_blood_unit
+
+```rust
+pub fn get_blood_unit(env: Env, blood_unit_id: u64) -> Result<BloodUnit, ContractError>
+```
+
+Returns the full `BloodUnit` record. Returns `NotFound` if the ID does not exist.
+
+---
+
+### update_status
+
+```rust
+pub fn update_status(
+    env: Env,
+    unit_id: u64,
+    new_status: BloodStatus,
+    authorized_by: Address,
+    reason: Option<String>,
+) -> Result<BloodUnit, ContractError>
+```
+
+Transitions a blood unit to a new status. `authorized_by` must be the admin or the unit's owning bank.
+
+- Validates the transition against the allowed transition matrix.
+- Blocks supply-chain transitions on expired units (only `→ Expired` and `→ Disposed` are allowed past shelf life).
+- Records a `StatusChangeHistory` entry and emits `status_changed` and `bld_unit_chg` events.
+
+---
+
+### mark_delivered
+
+```rust
+pub fn mark_delivered(
+    env: Env,
+    unit_id: u64,
+    authorized_by: Address,
+    delivery_location: String,
+) -> Result<BloodUnit, ContractError>
+```
+
+Convenience wrapper for `update_status(InTransit → Delivered)`. The `delivery_location` is stored as the reason. Called by the coordinator during `confirm_delivery`.
+
+---
+
+### mark_expired / dispose
+
+```rust
+pub fn mark_expired(env: Env, unit_id: u64, authorized_by: Address) -> Result<BloodUnit, ContractError>
+pub fn dispose(env: Env, unit_id: u64, authorized_by: Address, reason: Option<String>) -> Result<BloodUnit, ContractError>
+```
+
+Explicit expiry and disposal transitions. `dispose` requires the unit to be in `Expired` or `Compromised` state.
+
+---
+
+### batch_update_status
+
+```rust
+pub fn batch_update_status(
+    env: Env,
+    unit_ids: Vec<u64>,
+    new_status: BloodStatus,
+    authorized_by: Address,
+    reason: Option<String>,
+) -> Result<u64, ContractError>
+```
+
+Updates multiple units to the same status atomically. Validates all units first; if any validation fails, no updates are applied. Returns the count of updated units.
+
+---
+
+### reserve_blood
+
+```rust
+pub fn reserve_blood(
+    env: Env,
+    requester: Address,
+    unit_ids: Vec<u64>,
+    request_id: u64,
+    duration_seconds: u64,
+) -> Result<u64, ContractError>
+```
+
+Creates a time-bounded reservation for a set of blood units. `requester` must be an authorized bank and must own all specified units.
+
+- All units must be `Available` and not expired.
+- Transitions all units to `Reserved`.
+- Stores a `Reservation` record in **temporary storage** (auto-expires after `duration_seconds`).
+- Returns the reservation ID.
+- Emits `blood_reserved` event.
+
+---
+
+### release_reservation
+
+```rust
+pub fn release_reservation(env: Env, reservation_id: u64) -> Result<(), ContractError>
+```
+
+Releases a reservation, returning all `Reserved` units to `Available`. Can be called by anyone — the reservation record is the authority. Succeeds even if the reservation has already expired (allows cleanup of stale entries). Emits `reservation_released` event.
+
+---
+
+### batch_reserve_blood
+
+```rust
+pub fn batch_reserve_blood(
+    env: Env,
+    requester: Address,
+    batch: Vec<(Vec<u64>, u64, u64)>,
+) -> Result<Vec<u64>, ContractError>
+```
+
+Creates multiple reservations in a single transaction. Each tuple is `(unit_ids, request_id, duration_seconds)`. Returns reservation IDs in input order.
+
+---
+
+### get_reservation
+
+```rust
+pub fn get_reservation(env: Env, reservation_id: u64) -> Result<Reservation, ContractError>
+```
+
+Returns the `Reservation` record. Returns `ReservationNotFound` if expired or not found.
+
+---
+
+### get_status_history / get_status_history_page
+
+```rust
+pub fn get_status_history(env: Env, unit_id: u64) -> Vec<StatusChangeHistory>
+pub fn get_status_history_page(env: Env, unit_id: u64, page: u32) -> Vec<StatusChangeHistory>
+pub fn get_history_page_count(env: Env, unit_id: u64) -> u32
+pub fn get_status_change_count(env: Env, unit_id: u64) -> u64
+```
+
+History is stored in pages of 50 entries. Use `get_status_history_page` for O(1) reads; `get_status_history` iterates all pages.
+
+---
+
+### pause / unpause / is_paused
+
+```rust
+pub fn pause(env: Env, admin: Address) -> Result<(), ContractError>
+pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError>
+pub fn is_paused(env: Env) -> bool
+```
+
+Admin-only circuit breaker.
+
+## Types
+
+### BloodUnit
+
+```rust
+pub struct BloodUnit {
+    pub id: u64,
+    pub blood_type: BloodType,
+    pub quantity_ml: u32,
+    pub bank_id: Address,
+    pub donor_id: Option<Address>,
+    pub donation_timestamp: u64,
+    pub expiration_timestamp: u64,
+    pub status: BloodStatus,
+    pub metadata: Map<Symbol, String>,
+}
+```
+
+### BloodType
+
+`APositive | ANegative | BPositive | BNegative | ABPositive | ABNegative | OPositive | ONegative`
+
+### BloodStatus
+
+`Available | Reserved | InTransit | Delivered | Expired | Compromised | Disposed`
+
+### Reservation
+
+```rust
+pub struct Reservation {
+    pub unit_ids: Vec<u64>,
+    pub requester: Address,
+    pub created_timestamp: u64,
+    pub expiration_timestamp: u64,
+    pub request_id: u64,
+}
+```
+
+### StatusChangeHistory
+
+```rust
+pub struct StatusChangeHistory {
+    pub id: u64,
+    pub blood_unit_id: u64,
+    pub from_status: BloodStatus,
+    pub to_status: BloodStatus,
+    pub authorized_by: Address,
+    pub changed_at: u64,
+    pub reason: Option<String>,
+}
+```
+
+## Storage keys
+
+| Key | Storage tier | Type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Admin address |
+| `DataKey::BloodUnitCounter` | Instance | `u64` | Auto-increment ID counter |
+| `DataKey::StatusHistoryCounter` | Instance | `u64` | Global history entry counter |
+| `DataKey::ReservationCounter` | Instance | `u64` | Auto-increment reservation ID |
+| `DataKey::Paused` | Instance | `bool` | Pause flag |
+| `DataKey::BloodUnit(id)` | Persistent | `BloodUnit` | Blood unit record |
+| `DataKey::BloodTypeIndex(BloodType)` | Persistent | `Vec<u64>` | Unit IDs by blood type |
+| `DataKey::BankIndex(Address)` | Persistent | `Vec<u64>` | Unit IDs by bank |
+| `DataKey::StatusIndex(BloodStatus)` | Persistent | `Vec<u64>` | Unit IDs by status |
+| `DataKey::DonorIndex(Address)` | Persistent | `Vec<u64>` | Unit IDs by donor |
+| `DataKey::AuthorizedBank(Address)` | Persistent | `bool` | Bank authorization flag |
+| `DataKey::Serial(String)` | Persistent | `u64` | Serial number → unit ID dedup index |
+| `DataKey::StatusHistory(unit_id)` | Persistent | `u32` | Current history page number |
+| `DataKey::StatusHistoryPage(unit_id, page)` | Persistent | `Vec<StatusChangeHistory>` | History page (50 entries max) |
+| `DataKey::BloodUnitStatusChangeCount(unit_id)` | Persistent | `u64` | Total status changes for a unit |
+| `DataKey::Reservation(id)` | **Temporary** | `Reservation` | Time-bounded reservation record |
+
+## Error codes
+
+| Code | Value | Meaning |
+|---|---|---|
+| `AlreadyInitialized` | 100 | Contract already initialized |
+| `NotInitialized` | 101 | Contract not initialized |
+| `Unauthorized` | 102 | Caller not authorized |
+| `InvalidQuantity` | 116 | quantity_ml outside 100–600 range |
+| `InvalidTimestamp` | 115 | Timestamp validation failed |
+| `NotFound` | 121 | Blood unit not found |
+| `BloodUnitExpired` | 123 | Unit is past shelf life |
+| `DuplicateBloodUnit` | 124 | Serial number already registered |
+| `NotAuthorizedBloodBank` | 132 | Bank not authorized |
+| `NotUnitOwner` | 133 | Requester does not own the unit |
+| `BloodUnitNotAvailable` | 140 | Unit is not in Available status |
+| `InvalidStatusTransition` | 141 | Transition not in allowed matrix |
+| `ReservationNotFound` | 150 | Reservation not found or expired |
+| `ContractPaused` | 160 | Contract is paused |
+
+## Constants
+
+- Shelf life: **35 days** (`BLOOD_SHELF_LIFE_DAYS`)
+- History page size: **50 entries** per page
+- Valid quantity range: **100–600 ml**

--- a/lifebank-soroban/docs/contracts/payments.md
+++ b/lifebank-soroban/docs/contracts/payments.md
@@ -1,0 +1,309 @@
+# Payments Contract
+
+Handles escrow-backed payments, donation pledges, vesting schedules, and dispute management. Integrates with the requests contract to validate request state before accepting payments.
+
+## Payment lifecycle
+
+```
+create_payment()          create_escrow()
+      │                         │
+      ▼                         ▼
+  Pending                    Locked  ◄── funds held in contract
+      │                         │
+      │ update_status()         │ settle_payment() via coordinator
+      ▼                         ▼
+  Locked                    Released  ──► funds transferred to payee
+      │
+      │ record_dispute()
+      ▼
+  Disputed
+      │
+      │ resolve_dispute()
+      ▼
+  (stays Disputed, dispute_resolved = true)
+
+  Locked ──► Refunded  (via rollback or refund_escrow)
+  Any    ──► Cancelled
+```
+
+## Public functions
+
+### initialize
+
+```rust
+pub fn initialize(
+    env: Env,
+    admin: Address,
+    requests_contract: Option<Address>,
+) -> Result<(), Error>
+```
+
+One-time setup. Optionally links the requests contract for payment creation validation. If `requests_contract` is provided, `create_payment` and `create_escrow` will verify the request is in `Pending` or `Approved` state before accepting.
+
+---
+
+### create_payment
+
+```rust
+pub fn create_payment(
+    env: Env,
+    request_id: u64,
+    payer: Address,
+    payee: Address,
+    amount: i128,
+) -> Result<u64, Error>
+```
+
+Creates a non-escrow payment record in `Pending` status. `payer` must sign. `amount` must be positive and `payer != payee`. Only one payment per `request_id` is allowed (`DuplicatePayment` otherwise). Returns the new payment ID.
+
+---
+
+### batch_create_payments
+
+```rust
+pub fn batch_create_payments(
+    env: Env,
+    payments: Vec<(u64, Address, Address, i128)>,
+) -> Result<Vec<u64>, Error>
+```
+
+Creates multiple payments in a single transaction. Each tuple is `(request_id, payer, payee, amount)`. Returns IDs in input order.
+
+---
+
+### create_escrow
+
+```rust
+pub fn create_escrow(
+    env: Env,
+    request_id: u64,
+    hospital: Address,
+    payee: Address,
+    amount: i128,
+    token: Address,
+) -> Result<u64, Error>
+```
+
+Creates an escrow-backed payment. Transfers `amount` of `token` from `hospital` into the contract immediately. The payment starts in `Locked` status. If the token transfer fails, no payment record is written. Returns the new payment ID.
+
+---
+
+### release_escrow
+
+```rust
+pub fn release_escrow(env: Env, caller: Address, payment_id: u64) -> Result<(), Error>
+```
+
+Admin-only. Transfers the locked amount from the contract to the payee and marks the payment `Released`. Payment must be `Locked` and must have a token address (`NotEscrowPayment` otherwise).
+
+---
+
+### refund_escrow
+
+```rust
+pub fn refund_escrow(env: Env, caller: Address, payment_id: u64) -> Result<(), Error>
+```
+
+Admin-only. Transfers the locked amount back to the payer and marks the payment `Refunded`. Same preconditions as `release_escrow`.
+
+---
+
+### update_status
+
+```rust
+pub fn update_status(env: Env, payment_id: u64, status: PaymentStatus) -> Result<(), Error>
+```
+
+Transitions a payment to any status. Called by the coordinator during `settle_payment` (→ `Released`) and `rollback` (→ `Refunded`). Updates status indexes and aggregate stats. Emits `(payment, status)` event with `(payment_id, old_status, new_status)`.
+
+---
+
+### record_dispute
+
+```rust
+pub fn record_dispute(
+    env: Env,
+    payment_id: u64,
+    reason: DisputeReason,
+    case_id: String,
+) -> Result<(), Error>
+```
+
+Transitions the payment to `Disputed` and records the reason code and case ID. Called by the coordinator when a temperature excursion is detected. Emits `(payment, disputed, v1)` event.
+
+---
+
+### resolve_dispute
+
+```rust
+pub fn resolve_dispute(env: Env, payment_id: u64) -> Result<(), Error>
+```
+
+Marks `dispute_resolved = true` on the payment. Does not change the payment status — the payment remains `Disputed` until explicitly transitioned.
+
+---
+
+### get_payment
+
+```rust
+pub fn get_payment(env: Env, payment_id: u64) -> Result<Payment, Error>
+```
+
+Returns the full `Payment` record.
+
+---
+
+### get_payment_by_request
+
+```rust
+pub fn get_payment_by_request(env: Env, request_id: u64) -> Result<Payment, Error>
+```
+
+Looks up the active payment for a request via the request index. Returns `PaymentNotFound` if no active payment exists (index is removed when payment reaches a terminal state).
+
+---
+
+### get_payments_by_payer / get_payments_by_payee / get_payments_by_status
+
+```rust
+pub fn get_payments_by_payer(env: Env, payer: Address, page: u32, page_size: u32) -> PaymentPage
+pub fn get_payments_by_payee(env: Env, payee: Address, page: u32, page_size: u32) -> PaymentPage
+pub fn get_payments_by_status(env: Env, status: PaymentStatus, page: u32, page_size: u32) -> PaymentPage
+```
+
+Paginated queries. `page` is zero-indexed. `page_size` defaults to 20 if 0 is passed.
+
+---
+
+### get_stats
+
+```rust
+pub fn get_stats(env: Env) -> PaymentStats
+```
+
+Returns aggregate stats: total locked/released/refunded amounts and counts.
+
+---
+
+### pause / unpause / is_paused
+
+```rust
+pub fn pause(env: Env, admin: Address) -> Result<(), Error>
+pub fn unpause(env: Env, admin: Address) -> Result<(), Error>
+pub fn is_paused(env: Env) -> bool
+```
+
+Admin-only circuit breaker.
+
+## Types
+
+### Payment
+
+```rust
+pub struct Payment {
+    pub id: u64,
+    pub request_id: u64,
+    pub payer: Address,
+    pub payee: Address,
+    pub amount: i128,
+    pub status: PaymentStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub dispute_reason_code: Option<u32>,
+    pub dispute_case_id: Option<String>,
+    pub dispute_resolved: bool,
+    pub token: Option<Address>,  // set only for escrow payments
+}
+```
+
+### PaymentStatus
+
+`Pending | Locked | Released | Refunded | Disputed | Cancelled`
+
+### DisputeReason
+
+| Variant | Code |
+|---|---|
+| `FailedDelivery` | 1 |
+| `TemperatureExcursion` | 2 |
+| `PaymentContested` | 3 |
+| `WrongItem` | 4 |
+| `DamagedGoods` | 5 |
+| `LateDelivery` | 6 |
+| `Other` | 7 |
+
+### PaymentStats
+
+```rust
+pub struct PaymentStats {
+    pub total_locked: i128,
+    pub total_released: i128,
+    pub total_refunded: i128,
+    pub count_locked: u32,
+    pub count_released: u32,
+    pub count_refunded: u32,
+}
+```
+
+### PaymentPage
+
+```rust
+pub struct PaymentPage {
+    pub items: Vec<Payment>,
+    pub total: u64,
+    pub page: u32,
+    pub page_size: u32,
+}
+```
+
+## Storage keys
+
+| Key | Storage tier | Type | Description |
+|---|---|---|---|
+| `PAY_CTR` (symbol) | Instance | `u64` | Payment ID counter |
+| `PLG_CTR` (symbol) | Instance | `u64` | Pledge ID counter |
+| `ADMIN` (symbol) | Instance | `Address` | Admin address |
+| `PAUSED` (symbol) | Instance | `bool` | Pause flag |
+| `RWD_TOK` (symbol) | Instance | `Address` | Reward token address |
+| `STATS` (symbol) | Instance | `PaymentStats` | Aggregate stats |
+| `REQ_CTR` (symbol) | Instance | `Address` | Requests contract address |
+| `DISP_TO` (symbol) | Instance | `u64` | Dispute timeout override (seconds) |
+| `(id, "pay")` | Persistent | `Payment` | Payment record |
+| `(id, "plg")` | Persistent | `DonationPledge` | Pledge record |
+| `(payer, "pi")` | Persistent | `Vec<u64>` | Payment IDs by payer |
+| `(payee, "pyi")` | Persistent | `Vec<u64>` | Payment IDs by payee |
+| `(status_code, "si")` | Persistent | `Vec<u64>` | Payment IDs by status |
+| `(request_id, "ri")` | Persistent | `u64` | Active payment ID for a request |
+| `(request_id, "rt")` | Persistent | `Vec<u64>` | All payment IDs for a request (timeline) |
+| `(donor, "vest")` | Persistent | `VestingSchedule` | Donor vesting schedule |
+
+TTL bump: persistent entries are extended to ~60 days whenever remaining TTL falls below ~30 days.
+
+## Error codes
+
+| Code | Value | Meaning |
+|---|---|---|
+| `PaymentNotFound` | 500 | Payment not found |
+| `InvalidAmount` | 501 | Amount ≤ 0 |
+| `SamePayerPayee` | 502 | Payer and payee are the same address |
+| `InvalidPage` | 503 | Invalid pagination parameters |
+| `NotPledgeDonor` | 504 | Caller is not the pledge donor |
+| `InsufficientEscrowFunds` | 505 | Contract balance too low |
+| `Unauthorized` | 506 | Caller not authorized |
+| `ContractPaused` | 507 | Contract is paused |
+| `CliffNotReached` | 508 | Vesting cliff not yet reached |
+| `VestingNotFound` | 509 | No vesting schedule for this donor |
+| `NothingToClaim` | 510 | No vested tokens available |
+| `DuplicatePayment` | 511 | Payment already exists for this request |
+| `RequestNotPayable` | 512 | Request is not in Pending or Approved state |
+| `RequestNotFound` | 513 | Request not found in requests contract |
+| `NotEscrowPayment` | 514 | Payment has no token — not an escrow payment |
+| `PaymentNotLocked` | 515 | Payment is not Locked |
+| `DisputeNotExpired` | 516 | Dispute timeout has not elapsed |
+| `ActiveVestingExists` | 517 | Donor already has an unclaimed vesting schedule |
+
+## Constants
+
+- Default dispute auto-refund timeout: **7 days**
+- Persistent TTL bump threshold: **518,400 ledgers** (~30 days)
+- Persistent TTL bump target: **1,036,800 ledgers** (~60 days)

--- a/lifebank-soroban/docs/contracts/requests.md
+++ b/lifebank-soroban/docs/contracts/requests.md
@@ -1,0 +1,299 @@
+# Requests Contract
+
+Manages hospital blood requests from creation through fulfillment or cancellation. Maintains a full history of every status transition with actor, reason, and accounting details. Integrates with the inventory contract to release reservations on cancellation or rejection.
+
+## Request lifecycle
+
+```
+create_request()
+      │
+      ▼
+  Pending ──► Approved ──► InProgress ──► Fulfilled  (terminal)
+      │           │
+      │           │ partial_fulfill_request()
+      │           ▼
+      │       InProgress ──► Fulfilled  (terminal)
+      │
+      ├──► Rejected  (terminal, from Pending or Approved)
+      │
+      └──► Cancelled (terminal, from Pending, Approved, or InProgress)
+```
+
+Only authorized hospitals can create requests. Only the admin can approve, reject, or fulfill. Either the owning hospital or the admin can cancel.
+
+## Public functions
+
+### initialize
+
+```rust
+pub fn initialize(
+    env: Env,
+    admin: Address,
+    inventory_contract: Address,
+) -> Result<(), ContractError>
+```
+
+One-time setup. Sets the admin, links the inventory contract, initializes the request counter, and authorizes the admin as the first hospital. Returns `AlreadyInitialized` if called again.
+
+---
+
+### authorize_hospital / revoke_hospital
+
+```rust
+pub fn authorize_hospital(env: Env, hospital: Address) -> Result<(), ContractError>
+pub fn revoke_hospital(env: Env, hospital: Address) -> Result<(), ContractError>
+```
+
+Admin-only. Grants or revokes hospital authorization. Only authorized hospitals can create requests.
+
+---
+
+### create_request
+
+```rust
+pub fn create_request(
+    env: Env,
+    hospital: Address,
+    blood_type: BloodType,
+    component: BloodComponent,
+    quantity_ml: u32,
+    urgency: Urgency,
+    required_by_timestamp: u64,
+) -> Result<u64, ContractError>
+```
+
+Creates a new blood request in `Pending` status. `hospital` must be authorized.
+
+- `required_by_timestamp` must be in the future.
+- `quantity_ml` must be positive.
+- Records an initial history entry.
+- Returns the new request ID.
+- Emits `request_created` event.
+
+---
+
+### batch_create_requests
+
+```rust
+pub fn batch_create_requests(
+    env: Env,
+    hospital: Address,
+    entries: Vec<(BloodType, BloodComponent, u32, Urgency, u64)>,
+) -> Result<Vec<u64>, ContractError>
+```
+
+Creates multiple requests in a single transaction. Each tuple is `(blood_type, component, quantity_ml, urgency, required_by_timestamp)`. Returns IDs in input order.
+
+---
+
+### cancel_request
+
+```rust
+pub fn cancel_request(
+    env: Env,
+    caller: Address,
+    request_id: u64,
+    reason: String,
+) -> Result<(), ContractError>
+```
+
+Cancels a request. `caller` must be the owning hospital or the admin. Request must be in `Pending`, `Approved`, or `InProgress` state. `reason` must be non-empty.
+
+- If a reservation exists on the inventory contract, it is released automatically.
+- Records a history entry.
+- Emits `request_cancelled` event.
+
+---
+
+### update_request_status
+
+```rust
+pub fn update_request_status(
+    env: Env,
+    caller: Address,
+    request_id: u64,
+    new_status: RequestStatus,
+    reason: String,
+) -> Result<(), ContractError>
+```
+
+Admin-only. Transitions a request to `Approved`, `Rejected`, or `Fulfilled`.
+
+- `Approved`: only from `Pending`.
+- `Rejected`: from `Pending` or `Approved`; requires non-empty reason; releases any reservation.
+- `Fulfilled`: from `Approved` or `InProgress`; sets `fulfilled_quantity_ml = quantity_ml`.
+- `InProgress`, `Pending`, `Cancelled` are not valid targets for this function.
+
+Records a history entry and emits `request_status_updated` event.
+
+---
+
+### partial_fulfill_request
+
+```rust
+pub fn partial_fulfill_request(
+    env: Env,
+    caller: Address,
+    request_id: u64,
+    fulfilled_delta_ml: u32,
+    reason: String,
+) -> Result<(), ContractError>
+```
+
+Admin-only. Records partial fulfillment. Request must be `Approved` or `InProgress`. `fulfilled_delta_ml` cannot exceed the remaining unfulfilled quantity.
+
+- Transitions to `InProgress` if still partially fulfilled, or `Fulfilled` if complete.
+- Records a history entry.
+
+---
+
+### get_request
+
+```rust
+pub fn get_request(env: Env, request_id: u64) -> Result<BloodRequest, ContractError>
+```
+
+Returns the full `BloodRequest` record including history.
+
+---
+
+### get_request_history
+
+```rust
+pub fn get_request_history(env: Env, request_id: u64) -> Result<Vec<RequestHistoryEntry>, ContractError>
+```
+
+Returns the history entries for a request.
+
+---
+
+### get_requests_by_hospital
+
+```rust
+pub fn get_requests_by_hospital(
+    env: Env,
+    hospital_id: Address,
+    page: u32,
+    page_size: u32,
+) -> Result<Vec<BloodRequest>, ContractError>
+```
+
+Returns a paginated slice of requests for a hospital. `page` is zero-indexed. `page_size` is capped at 50.
+
+---
+
+### get_admin / get_inventory_contract / get_request_counter
+
+```rust
+pub fn get_admin(env: Env) -> Result<Address, ContractError>
+pub fn get_inventory_contract(env: Env) -> Result<Address, ContractError>
+pub fn get_request_counter(env: Env) -> Result<u64, ContractError>
+```
+
+Read-only accessors.
+
+---
+
+### is_hospital_authorized / is_initialized
+
+```rust
+pub fn is_hospital_authorized(env: Env, hospital: Address) -> bool
+pub fn is_initialized(env: Env) -> bool
+```
+
+Read-only status checks.
+
+---
+
+### get_metadata
+
+```rust
+pub fn get_metadata(env: Env) -> Result<ContractMetadata, ContractError>
+```
+
+Returns the contract name and version.
+
+## Types
+
+### BloodRequest
+
+```rust
+pub struct BloodRequest {
+    pub id: u64,
+    pub hospital_id: Address,
+    pub blood_type: BloodType,
+    pub component: BloodComponent,
+    pub quantity_ml: u32,
+    pub urgency: Urgency,
+    pub created_timestamp: u64,
+    pub required_by_timestamp: u64,
+    pub status: RequestStatus,
+    pub assigned_units: Vec<u64>,
+    pub fulfilled_quantity_ml: u32,
+    pub reservation_id: Option<u64>,
+    pub history: Vec<RequestHistoryEntry>,
+}
+```
+
+### RequestStatus
+
+`Pending | Approved | InProgress | Fulfilled | Cancelled | Rejected`
+
+### BloodType
+
+`APositive | ANegative | BPositive | BNegative | ABPositive | ABNegative | OPositive | ONegative`
+
+### BloodComponent
+
+`WholeBlood | RedCells | Plasma | Platelets | Cryoprecipitate`
+
+### Urgency
+
+| Variant | Priority |
+|---|---|
+| `Critical` | 4 (highest) |
+| `Urgent` | 3 |
+| `Routine` | 2 |
+| `Scheduled` | 1 (lowest) |
+
+### RequestHistoryEntry
+
+```rust
+pub struct RequestHistoryEntry {
+    pub previous_status: RequestStatus,
+    pub is_initial_transition: bool,
+    pub new_status: RequestStatus,
+    pub actor: Address,
+    pub reason: String,
+    pub fulfilled_delta_ml: u32,
+    pub released_reservation: bool,
+    pub timestamp: u64,
+}
+```
+
+## Storage keys
+
+| Key | Storage tier | Type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Admin address |
+| `DataKey::InventoryContract` | Instance | `Address` | Inventory contract address |
+| `DataKey::RequestCounter` | Instance | `u64` | Auto-increment request ID |
+| `DataKey::Initialized` | Instance | `bool` | Initialization flag |
+| `DataKey::Metadata` | Instance | `ContractMetadata` | Contract name and version |
+| `DataKey::AuthorizedHospital(Address)` | Persistent | `bool` | Hospital authorization flag |
+| `DataKey::Request(id)` | Persistent | `BloodRequest` | Full request record including history |
+
+## Error codes
+
+| Code | Meaning |
+|---|---|
+| `AlreadyInitialized` | Contract already initialized |
+| `NotInitialized` | Contract not initialized |
+| `Unauthorized` | Caller is not admin |
+| `NotAuthorizedHospital` | Hospital not authorized |
+| `NotRequestOwner` | Caller is not the hospital or admin |
+| `RequestNotFound` | Request not found |
+| `InvalidRequestStatus` | Transition not allowed from current status |
+| `InvalidQuantity` | quantity_ml is zero or exceeds remaining |
+| `InvalidReason` | Reason string is empty |
+| `InvalidTimestamp` | required_by_timestamp is in the past |

--- a/lifebank-soroban/docs/contracts/temperature.md
+++ b/lifebank-soroban/docs/contracts/temperature.md
@@ -1,0 +1,244 @@
+# Temperature Contract
+
+Monitors cold-chain integrity for blood units in transit. Accepts IoT sensor readings, detects threshold violations, tracks consecutive violation streaks, and automatically escalates sustained excursions to the coordinator as payment disputes.
+
+## How it works
+
+1. Admin sets a per-unit temperature threshold (`set_threshold`).
+2. IoT oracles or the backend call `log_reading` for each sensor reading.
+3. The contract tracks a consecutive violation streak per unit. Three consecutive violations mark the unit as **compromised**.
+4. When a sustained excursion is confirmed, an authorized oracle calls `report_excursion_to_coordinator`, which calls `coordinator.flag_temperature_breach()` to transition the linked payment to `Disputed`.
+
+## Temperature encoding
+
+All temperatures are stored as integers scaled ×100 to avoid floating point. For example, 4.5°C is stored as `450`.
+
+## Public functions
+
+### initialize
+
+```rust
+pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError>
+```
+
+One-time setup. Returns `AlreadyInitialized` if called again.
+
+---
+
+### set_threshold
+
+```rust
+pub fn set_threshold(
+    env: Env,
+    admin: Address,
+    unit_id: u64,
+    min_celsius_x100: i32,
+    max_celsius_x100: i32,
+) -> Result<(), ContractError>
+```
+
+Admin-only. Sets the acceptable temperature range for a blood unit. `min` must be strictly less than `max`. A threshold must be set before `log_reading` can be called for a unit.
+
+---
+
+### log_reading
+
+```rust
+pub fn log_reading(
+    env: Env,
+    unit_id: u64,
+    temperature_celsius_x100: i32,
+    timestamp: u64,
+) -> Result<(), ContractError>
+```
+
+Records a temperature reading. Requires a threshold to be set for the unit (`ThresholdNotFound` otherwise).
+
+- Determines if the reading is a violation (outside min/max range).
+- Updates the consecutive violation streak: increments on violation, resets to 0 on a clean reading.
+- If the streak reaches 3, marks the unit as compromised (`IsCompromised = true`).
+- Stores readings in pages of 20 entries each.
+
+---
+
+### get_readings
+
+```rust
+pub fn get_readings(env: Env, unit_id: u64) -> Result<Vec<TemperatureReading>, ContractError>
+```
+
+Returns all temperature readings for a unit across all pages.
+
+---
+
+### get_violations
+
+```rust
+pub fn get_violations(env: Env, unit_id: u64) -> Result<Vec<TemperatureReading>, ContractError>
+```
+
+Returns only the readings where `is_violation == true`.
+
+---
+
+### get_temperature_summary
+
+```rust
+pub fn get_temperature_summary(env: Env, unit_id: u64) -> Result<TemperatureSummary, ContractError>
+```
+
+Returns aggregate statistics: count, average, min, max, and violation count. Uses an `i64` accumulator to prevent overflow with large datasets. Returns `UnitNotFound` if no readings exist.
+
+---
+
+### get_consecutive_violation_streak
+
+```rust
+pub fn get_consecutive_violation_streak(env: Env, unit_id: u64) -> u32
+```
+
+Returns the current consecutive violation streak. Resets to 0 after any clean reading.
+
+---
+
+### is_compromised
+
+```rust
+pub fn is_compromised(env: Env, unit_id: u64) -> bool
+```
+
+Returns `true` if the unit has accumulated 3 or more consecutive violations. Once set, this flag persists until explicitly reset by an admin.
+
+---
+
+### reset_compromised_status
+
+```rust
+pub fn reset_compromised_status(env: Env, admin: Address, unit_id: u64) -> Result<(), ContractError>
+```
+
+Admin-only. Clears the compromised flag and resets the violation streak to 0.
+
+---
+
+### set_coordinator
+
+```rust
+pub fn set_coordinator(env: Env, admin: Address, coordinator: Address) -> Result<(), ContractError>
+```
+
+Admin-only. Configures the coordinator contract address for cross-contract excursion reporting.
+
+---
+
+### add_oracle
+
+```rust
+pub fn add_oracle(env: Env, admin: Address, oracle: Address) -> Result<(), ContractError>
+```
+
+Admin-only. Whitelists an IoT oracle address that may call `report_excursion_to_coordinator`.
+
+---
+
+### report_excursion_to_coordinator
+
+```rust
+pub fn report_excursion_to_coordinator(
+    env: Env,
+    caller: Address,
+    unit_id: u64,
+    payment_id: u64,
+    excursion_summary: ExcursionSummary,
+) -> Result<(), ContractError>
+```
+
+Calls `coordinator.flag_temperature_breach()` to transition the linked payment to `Disputed`. Only the admin or a whitelisted oracle may call this. Emits `(tmp_excur,)` event with `(unit_id, payment_id, violation_count)`.
+
+---
+
+### pause / unpause / is_paused
+
+```rust
+pub fn pause(env: Env, admin: Address) -> Result<(), ContractError>
+pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError>
+pub fn is_paused(env: Env) -> bool
+```
+
+Admin-only circuit breaker.
+
+## Types
+
+### TemperatureReading
+
+```rust
+pub struct TemperatureReading {
+    pub temperature_celsius_x100: i32,
+    pub timestamp: u64,
+    pub is_violation: bool,
+}
+```
+
+### TemperatureThreshold
+
+```rust
+pub struct TemperatureThreshold {
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+}
+```
+
+### TemperatureSummary
+
+```rust
+pub struct TemperatureSummary {
+    pub count: u32,
+    pub avg_celsius_x100: i32,
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+    pub violation_count: u32,
+}
+```
+
+### ExcursionSummary
+
+```rust
+pub struct ExcursionSummary {
+    pub unit_id: u64,
+    pub violation_count: u32,
+    pub peak_celsius_x100: i32,
+    pub detected_at: u64,
+}
+```
+
+## Storage keys
+
+| Key | Storage tier | Type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Admin address |
+| `DataKey::Paused` | Instance | `bool` | Pause flag |
+| `DataKey::CoordinatorContract` | Instance | `Address` | Coordinator contract address |
+| `DataKey::Threshold(unit_id)` | Persistent | `TemperatureThreshold` | Per-unit temperature range |
+| `DataKey::TempPage(unit_id, page)` | Persistent | `Vec<TemperatureReading>` | Reading page (20 entries max) |
+| `DataKey::TempPageLen(unit_id, page)` | Persistent | `u32` | Number of valid entries in a page |
+| `DataKey::ConsecutiveViolationStreak(unit_id)` | Persistent | `u32` | Current consecutive violation count |
+| `DataKey::IsCompromised(unit_id)` | Persistent | `bool` | Compromised flag |
+| `DataKey::OracleWhitelist(Address)` | Persistent | `bool` | Whitelisted oracle flag |
+
+## Error codes
+
+| Code | Value | Meaning |
+|---|---|---|
+| `AlreadyInitialized` | 600 | Contract already initialized |
+| `Unauthorized` | 601 | Caller not authorized |
+| `ThresholdNotFound` | 602 | No threshold set for this unit |
+| `InvalidThreshold` | 603 | min ≥ max |
+| `UnitNotFound` | 604 | No readings found for this unit |
+| `ContractPaused` | 605 | Contract is paused |
+| `CoordinatorNotSet` | 606 | Coordinator address not configured |
+| `CoordinatorCallFailed` | 607 | Cross-contract call to coordinator failed |
+
+## Constants
+
+- Page size: **20 readings** per page
+- Compromise threshold: **3 consecutive violations**

--- a/lifebank-soroban/docs/deployment.md
+++ b/lifebank-soroban/docs/deployment.md
@@ -1,0 +1,244 @@
+# Deployment Guide
+
+This guide covers deploying the five core contracts (coordinator, inventory, payments, requests, temperature) to Stellar testnet and mainnet. The remaining contracts (analytics, delivery, identity, matching, reputation) follow the same pattern.
+
+## Prerequisites
+
+```bash
+# Install Rust and the WASM target
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+
+# Install Soroban CLI
+cargo install --locked soroban-cli
+
+# Verify
+soroban --version
+```
+
+## 1. Build
+
+```bash
+# From the lifebank-soroban directory
+cargo build --release --target wasm32-unknown-unknown
+
+# Optimize WASM files (reduces size, recommended for mainnet)
+for contract in coordinator inventory payments requests temperature; do
+    soroban contract optimize \
+        --wasm target/wasm32-unknown-unknown/release/${contract}_contract.wasm
+done
+```
+
+Artifacts land in `target/wasm32-unknown-unknown/release/`.
+
+## 2. Set up a Stellar identity
+
+```bash
+# Generate a new keypair (testnet only — never use this for mainnet)
+soroban keys generate deployer --network testnet
+
+# Fund the testnet account via Friendbot
+soroban keys fund deployer --network testnet
+
+# Verify the balance
+soroban keys show deployer
+```
+
+For mainnet, use a hardware wallet or a securely managed keypair. Never store mainnet private keys in plaintext.
+
+## 3. Deploy contracts
+
+Deploy each contract and capture its address. The order matters: inventory and requests must be deployed before coordinator.
+
+```bash
+NETWORK=testnet
+IDENTITY=deployer
+
+# Deploy inventory
+INVENTORY_ID=$(soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/inventory_contract.wasm \
+    --source $IDENTITY \
+    --network $NETWORK)
+echo "Inventory: $INVENTORY_ID"
+
+# Deploy requests
+REQUESTS_ID=$(soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/requests_contract.wasm \
+    --source $IDENTITY \
+    --network $NETWORK)
+echo "Requests: $REQUESTS_ID"
+
+# Deploy payments
+PAYMENTS_ID=$(soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/payments_contract.wasm \
+    --source $IDENTITY \
+    --network $NETWORK)
+echo "Payments: $PAYMENTS_ID"
+
+# Deploy temperature
+TEMPERATURE_ID=$(soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/temperature_contract.wasm \
+    --source $IDENTITY \
+    --network $NETWORK)
+echo "Temperature: $TEMPERATURE_ID"
+
+# Deploy coordinator
+COORDINATOR_ID=$(soroban contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/coordinator_contract.wasm \
+    --source $IDENTITY \
+    --network $NETWORK)
+echo "Coordinator: $COORDINATOR_ID"
+```
+
+Or use the helper script which does all of the above:
+
+```bash
+./scripts/deploy-testnet.sh
+```
+
+## 4. Initialize contracts
+
+Each contract must be initialized before use. The admin address is the deployer's public key.
+
+```bash
+ADMIN=$(soroban keys address $IDENTITY)
+
+# Initialize inventory
+soroban contract invoke \
+    --id $INVENTORY_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- initialize \
+    --admin $ADMIN
+
+# Initialize requests (links to inventory)
+soroban contract invoke \
+    --id $REQUESTS_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- initialize \
+    --admin $ADMIN \
+    --inventory_contract $INVENTORY_ID
+
+# Initialize payments (optionally links to requests for validation)
+soroban contract invoke \
+    --id $PAYMENTS_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- initialize \
+    --admin $ADMIN \
+    --requests_contract $REQUESTS_ID
+
+# Initialize temperature
+soroban contract invoke \
+    --id $TEMPERATURE_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- initialize \
+    --admin $ADMIN
+
+# Initialize coordinator (links all three domain contracts)
+soroban contract invoke \
+    --id $COORDINATOR_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- initialize \
+    --admin $ADMIN \
+    --request_contract $REQUESTS_ID \
+    --inventory_contract $INVENTORY_ID \
+    --payment_contract $PAYMENTS_ID
+```
+
+## 5. Post-initialization wiring
+
+```bash
+# Wire temperature → coordinator for excursion escalation
+soroban contract invoke \
+    --id $TEMPERATURE_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- set_coordinator \
+    --admin $ADMIN \
+    --coordinator $COORDINATOR_ID
+
+# Authorize a blood bank on the inventory contract
+soroban contract invoke \
+    --id $INVENTORY_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- authorize_bank \
+    --admin $ADMIN \
+    --bank <BLOOD_BANK_ADDRESS> \
+    --authorized true
+
+# Authorize a hospital on the requests contract
+soroban contract invoke \
+    --id $REQUESTS_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- authorize_hospital \
+    --hospital <HOSPITAL_ADDRESS>
+```
+
+## 6. Update contracts.json
+
+After deployment, update `contracts.json` with the deployed addresses so the backend can discover them:
+
+```json
+{
+  "testnet": {
+    "coordinator": "<COORDINATOR_ID>",
+    "inventory":   "<INVENTORY_ID>",
+    "payments":    "<PAYMENTS_ID>",
+    "temperature": "<TEMPERATURE_ID>",
+    "requests":    "<REQUESTS_ID>"
+  }
+}
+```
+
+The backend reads this file via `STELLAR_NETWORK` env var. Individual addresses can be overridden with env vars (`COORDINATOR_CONTRACT_ID`, etc.).
+
+## 7. Verify deployment
+
+```bash
+# Check coordinator is initialized
+soroban contract invoke \
+    --id $COORDINATOR_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- is_initialized
+
+# Check inventory admin
+soroban contract invoke \
+    --id $INVENTORY_ID \
+    --source $IDENTITY \
+    --network $NETWORK \
+    -- get_admin
+```
+
+## Mainnet checklist
+
+Before deploying to mainnet:
+
+- [ ] Audit all contract code (especially coordinator, payments)
+- [ ] Use a hardware wallet or multi-sig for the admin keypair
+- [ ] Test the full workflow end-to-end on testnet first
+- [ ] Set `NETWORK=mainnet` in all commands
+- [ ] Fund the deployer account with real XLM
+- [ ] Verify WASM hashes match the audited build
+- [ ] Store contract addresses in a secure secrets manager
+- [ ] Set up monitoring for the events listed in [indexing.md](indexing.md)
+
+## Upgrading contracts
+
+Soroban contracts can be upgraded by deploying a new WASM and calling `soroban contract install` + `soroban contract invoke ... upgrade`. The admin address controls upgrades. Coordinate upgrades with the backend team to avoid ABI mismatches.
+
+## Troubleshooting
+
+**`Error: account not found`** — The deployer account is not funded. Run `soroban keys fund deployer --network testnet`.
+
+**`Error: AlreadyInitialized`** — The contract was already initialized. This is expected if re-running the init step. Skip it.
+
+**`Error: contract not found`** — The contract ID is wrong or the contract was deployed to a different network. Double-check `$NETWORK` and the contract ID.
+
+**`Error: Unauthorized`** — The `--source` identity does not match the admin address stored in the contract. Use the same identity that initialized the contract.

--- a/lifebank-soroban/docs/indexing.md
+++ b/lifebank-soroban/docs/indexing.md
@@ -1,0 +1,348 @@
+# Event Schema for Off-Chain Indexers
+
+Soroban events are emitted as `(topics, data)` pairs. Topics are used for filtering; data carries the payload. All events below use `symbol_short!` for topic components, which are 1–8 character ASCII strings encoded as `Symbol`.
+
+To subscribe to events, use the Stellar Horizon API or a Soroban RPC node:
+
+```
+GET /v1/events?contract_id=<CONTRACT_ID>&topic[0]=<TOPIC>
+```
+
+---
+
+## Coordinator events
+
+Contract: `coordinator_contract`
+
+### coord:init:v1
+
+Emitted when the coordinator is initialized.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("init"), Symbol("v1"))` | |
+| data | `Address` | Admin address |
+
+### coord:alloc:v1
+
+Emitted when `allocate_units` succeeds.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("alloc"), Symbol("v1"))` | |
+| data | `(u64, u32)` | `(request_id, unit_count)` |
+
+### coord:dlvrd:v1
+
+Emitted when `confirm_delivery` succeeds.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("dlvrd"), Symbol("v1"))` | |
+| data | `(u64, String)` | `(request_id, delivery_location)` |
+
+### coord:settld:v1
+
+Emitted when `settle_payment` succeeds.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("settld"), Symbol("v1"))` | |
+| data | `(u64, u64)` | `(request_id, payment_id)` |
+
+### coord:rollbk:v1
+
+Emitted when `rollback` succeeds.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("rollbk"), Symbol("v1"))` | |
+| data | `u64` | `request_id` |
+
+### coord:emrghlt:v1
+
+Emitted when `emergency_halt` is activated.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("emrghlt"), Symbol("v1"))` | |
+| data | `Address` | Admin address |
+
+### coord:tmp_brch
+
+Emitted when a temperature breach is flagged.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("coord"), Symbol("tmp_brch"))` | |
+| data | `(u64, u64, u64)` | `(payment_id, unit_id, ledger_timestamp)` |
+
+---
+
+## Inventory events
+
+Contract: `inventory_contract`
+
+### blood_registered:v1
+
+Emitted when a blood unit is registered.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("blood_registered"), Symbol("v1"))` | |
+| data | `BloodRegisteredEvent` | See struct below |
+
+```
+BloodRegisteredEvent {
+    blood_unit_id: u64,
+    bank_id: Address,
+    blood_type: BloodType,
+    quantity_ml: u32,
+    expiration_timestamp: u64,
+    registered_at: u64,
+}
+```
+
+### status_changed:v1
+
+Legacy status change event (kept for backwards compatibility).
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("status_changed"), Symbol("v1"))` | |
+| data | `StatusChangeEvent` | See struct below |
+
+```
+StatusChangeEvent {
+    blood_unit_id: u64,
+    from_status: BloodStatus,
+    to_status: BloodStatus,
+    authorized_by: Address,
+    changed_at: u64,
+    reason: Option<String>,
+}
+```
+
+### bld_unit_chg:v1
+
+Canonical audit event for every status transition. Prefer this over `status_changed` for new indexers.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("bld_unit_chg"), Symbol("v1"))` | |
+| data | `AuditEvent` | See struct below |
+
+```
+AuditEvent {
+    unit_id: u64,
+    previous_status: BloodStatus,
+    new_status: BloodStatus,
+    actor: Address,
+    timestamp: u64,
+}
+```
+
+### blood_reserved:v1
+
+Emitted when a reservation is created.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("blood_reserved"), Symbol("v1"))` | |
+| data | `(u64, Address, u32)` | `(reservation_id, requester, unit_count)` |
+
+### reservation_released:v1
+
+Emitted when a reservation is released.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("reservation_released"), Symbol("v1"))` | |
+| data | `u64` | `reservation_id` |
+
+### invalid_transition:v1
+
+Emitted when an invalid status transition is attempted (for debugging).
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("invalid_transition"), Symbol("v1"))` | |
+| data | `(u64, u32, u32)` | `(blood_unit_id, from_status as u32, to_status as u32)` |
+
+---
+
+## Payments events
+
+Contract: `payments_contract`
+
+### payment:created:v1
+
+Emitted when a non-escrow payment is created.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("created"), Symbol("v1"))` | |
+| data | `u64` | `payment_id` |
+
+### payment:escrowed:v1
+
+Emitted when an escrow payment is created and funds are locked.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("escrowed"), Symbol("v1"))` | |
+| data | `u64` | `payment_id` |
+
+### payment:status
+
+Emitted on every status transition via `update_status`.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("status"))` | |
+| data | `(u64, PaymentStatus, PaymentStatus)` | `(payment_id, old_status, new_status)` |
+
+### payment:released
+
+Emitted when escrow funds are released to the payee.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("released"))` | |
+| data | `(u64, Address, i128)` | `(payment_id, payee, amount)` |
+
+### payment:refunded
+
+Emitted when escrow funds are refunded to the payer.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("refunded"))` | |
+| data | `(u64, Address, i128)` | `(payment_id, payer, amount)` |
+
+### payment:disputed:v1
+
+Emitted when a dispute is recorded.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("disputed"), Symbol("v1"))` | |
+| data | `(u64, u32, String)` | `(payment_id, reason_code, case_id)` |
+
+Reason codes: 1=FailedDelivery, 2=TemperatureExcursion, 3=PaymentContested, 4=WrongItem, 5=DamagedGoods, 6=LateDelivery, 7=Other
+
+### payment:resolved:v1
+
+Emitted when a dispute is resolved.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("payment"), Symbol("resolved"), Symbol("v1"))` | |
+| data | `u64` | `payment_id` |
+
+---
+
+## Requests events
+
+Contract: `requests_contract`
+
+### request_created
+
+Emitted when a blood request is created.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("req_created"), Symbol("v1"))` | |
+| data | `RequestCreatedEvent` | See struct below |
+
+```
+RequestCreatedEvent {
+    request_id: u64,
+    hospital: Address,
+    blood_type: BloodType,
+    quantity_ml: u32,
+    urgency: u32,   // 1=Scheduled, 2=Routine, 3=Urgent, 4=Critical
+    timestamp: u64,
+}
+```
+
+### request_status_updated
+
+Emitted on every status transition.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("req_updated"), Symbol("v1"))` | |
+| data | `(u64, Address, RequestStatus, RequestStatus, u64)` | `(request_id, actor, old_status, new_status, timestamp)` |
+
+### request_cancelled
+
+Emitted when a request is cancelled.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("req_cancel"), Symbol("v1"))` | |
+| data | `(u64, Address, u64)` | `(request_id, actor, timestamp)` |
+
+---
+
+## Temperature events
+
+Contract: `temperature_contract`
+
+### tmp_excur
+
+Emitted when an excursion is reported to the coordinator.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("tmp_excur"),)` | |
+| data | `(u64, u64, u32)` | `(unit_id, payment_id, violation_count)` |
+
+---
+
+## Reputation events
+
+Contract: `reputation_contract`
+
+### rep:updated:v1
+
+Emitted when a reputation score is recalculated.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("rep"), Symbol("updated"), Symbol("v1"))` | |
+| data | `(u64, i64)` | `(entity_id, final_score_x100)` |
+
+Score is ×100 (e.g. `7823` = 78.23 / 100).
+
+---
+
+## Analytics events
+
+Contract: `analytics_contract`
+
+### anlytcs:init:v1
+
+Emitted when the analytics contract is initialized.
+
+| Field | Type | Description |
+|---|---|---|
+| topics | `(Symbol("anlytcs"), Symbol("init"), Symbol("v1"))` | |
+| data | `Address` | Admin address |
+
+---
+
+## Indexer recommendations
+
+- Subscribe to `bld_unit_chg:v1` (not `status_changed:v1`) for blood unit state — it is the canonical audit event.
+- Subscribe to `payment:status` for all payment transitions; it fires on every `update_status` call including coordinator-driven ones.
+- Subscribe to `coord:settld:v1` to trigger downstream settlement logic (e.g. updating the backend database).
+- Subscribe to `coord:tmp_brch` to alert operations teams of cold-chain incidents.
+- The `BloodStatus` and `PaymentStatus` enums are encoded as their XDR discriminant integers in events. Map them as follows:
+
+**BloodStatus integers** (from `BloodStatus as u32` in `invalid_transition` events):
+`0=Available, 1=Reserved, 2=InTransit, 3=Delivered, 4=Expired, 5=Compromised, 6=Disposed`
+
+**PaymentStatus integers** (from `status_index_key` in payments):
+`0=Pending, 1=Locked, 2=Released, 3=Refunded, 4=Disputed, 5=Cancelled`


### PR DESCRIPTION
Summary
Adds comprehensive documentation for the lifebank-soroban smart contract layer. Previously there were no reference docs beyond inline code comments.

What's included
File	Description
README.md	Rewritten with contract table, build/test/deploy quickstart, doc links
ARCHITECTURE.md	Contract dependency graph, workflow state machine, storage tier table, circuit breaker explanation
coordinator.md
Function reference, state machine diagram, types, storage keys, error codes
inventory.md
Lifecycle diagram, all public functions, storage key schema, error codes
payments.md
Payment lifecycle, escrow functions, dispute handling, storage keys, error codes
temperature.md
IoT monitoring flow, all functions, storage keys, error codes
requests.md
Request lifecycle, all functions, storage keys, error codes
deployment.md
Step-by-step testnet and mainnet deploy, post-init wiring, mainnet checklist, troubleshooting
indexing.md
Full event schema for all contracts with topic arrays, data types, indexer recommendations
Acceptance criteria
 README explains what each contract does, how to build, how to test
 Architecture diagram shows cross-contract call graph
 Each contract doc lists all public functions with params and return types
 Deployment guide covers testnet end-to-end
 Storage key schemas documented for all five core contracts
 Event schema documented for off-chain indexers
Everything is committed and pushed on branch docs/soroban-contract-documentation. The gh CLI just needs gh auth login to create PRs from the terminal — if you want that wired up for next time, run that command and follow the prompts.
closes #860 