### PR TITLE
fix(backend): wire order splitting into blood requests modul

### DIFF
--- a/backend/src/blood-requests/blood-requests.module.ts
+++ b/backend/src/blood-requests/blood-requests.module.ts
@@ -1,36 +1,37 @@
 import { BullModule } from '@nestjs/bullmq';
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockchainModule } from '../blockchain/blockchain.module';
 import { CompensationModule } from '../common/compensation/compensation.module';
-import { InventoryModule } from '../inventory/inventory.module';
-import { NotificationsModule } from '../notifications/notifications.module';
-import { MapsModule } from '../maps/maps.module';
 import { EscalationModule } from '../escalation/escalation.module';
+import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
+import { InventoryModule } from '../inventory/inventory.module';
+import { MapsModule } from '../maps/maps.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { OrganizationEntity } from '../organizations/entities/organization.entity';
-import { ReportingModule } from '../reporting/reporting.module';
 
 import { BloodRequestsController } from './blood-requests.controller';
 import { BloodRequestsService } from './blood-requests.service';
+import { OrderSplittingController } from './controllers/order-splitting.controller';
 import { RequestQueryController } from './controllers/request-query.controller';
 import { BloodRequestItemEntity } from './entities/blood-request-item.entity';
-import { BloodRequestEntity } from './entities/blood-request.entity';
 import { BloodRequestReservationEntity } from './entities/blood-request-reservation.entity';
+import { BloodRequestSagaEntity } from './entities/blood-request-saga.entity';
+import { BloodRequestEntity } from './entities/blood-request.entity';
+import { FulfillmentLegEntity } from './entities/fulfillment-leg.entity';
 import { BLOOD_REQUEST_QUEUE } from './enums/request-urgency.enum';
 import { SlaBreachListener } from './listeners/sla-breach.listener';
 import { BloodRequestProcessor } from './processors/blood-request.processor';
-import { RequestQueryService } from './services/request-query.service';
 import { BloodBankAvailabilityService } from './services/blood-bank-availability.service';
-import { BloodRequestReservationService } from './services/blood-request-reservation.service';
-import { TriageScoringService } from './services/triage-scoring.service';
-import { InventoryStockEntity } from '../inventory/entities/inventory-stock.entity';
-
 import { BloodRequestChainService } from './services/blood-request-chain.service';
 import { BloodRequestEmailService } from './services/blood-request-email.service';
+import { BloodRequestReservationService } from './services/blood-request-reservation.service';
+import { OrderSplittingService } from './services/order-splitting.service';
+import { RequestQueryService } from './services/request-query.service';
 import { SagaCoordinatorService } from './services/saga-coordinator.service';
-import { BloodRequestSagaEntity } from './entities/blood-request-saga.entity';
+import { TriageScoringService } from './services/triage-scoring.service';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { BloodRequestSagaEntity } from './entities/blood-request-saga.entity';
       BloodRequestItemEntity,
       BloodRequestReservationEntity,
       BloodRequestSagaEntity,
+      FulfillmentLegEntity,
       InventoryStockEntity,
       OrganizationEntity,
     ]),
@@ -66,7 +68,11 @@ import { BloodRequestSagaEntity } from './entities/blood-request-saga.entity';
     MapsModule,
     EscalationModule,
   ],
-  controllers: [BloodRequestsController, RequestQueryController],
+  controllers: [
+    BloodRequestsController,
+    RequestQueryController,
+    OrderSplittingController,
+  ],
   providers: [
     BloodRequestsService,
     BloodRequestChainService,
@@ -76,6 +82,7 @@ import { BloodRequestSagaEntity } from './entities/blood-request-saga.entity';
     RequestQueryService,
     BloodBankAvailabilityService,
     BloodRequestReservationService,
+    OrderSplittingService,
     TriageScoringService,
     SagaCoordinatorService,
   ],


### PR DESCRIPTION
closes #984 

##Summary
Registers OrderSplittingController in BloodRequestsModule.
Registers OrderSplittingService in BloodRequestsModule.
Registers FulfillmentLegEntity with TypeOrmModule.forFeature(...) so the service’s repository dependency can resolve.

##Reason
OrderSplittingController and OrderSplittingService already existed, but they were not wired into BloodRequestsModule. As a result, order-splitting routes were not reachable and the service could not be resolved by NestJS dependency injection.