### PR TITLE
fix(backend): register upload validation provider

### DIFF
--- a/backend/src/delivery-proof/delivery-proof.module.ts
+++ b/backend/src/delivery-proof/delivery-proof.module.ts
@@ -1,14 +1,15 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { DeliveryProofEntity } from './entities/delivery-proof.entity';
-import { DeliveryProofService } from './delivery-proof.service';
-import { DeliveryProofController } from './delivery-proof.controller';
-
-import { ConfigModule } from '@nestjs/config';
-import { SorobanModule } from '../soroban/soroban.module';
 import { CustodyModule } from '../custody/custody.module';
 import { FileMetadataModule } from '../file-metadata/file-metadata.module';
+import { SorobanModule } from '../soroban/soroban.module';
+
+import { DeliveryProofController } from './delivery-proof.controller';
+import { DeliveryProofService } from './delivery-proof.service';
+import { DeliveryProofEntity } from './entities/delivery-proof.entity';
+import { UploadValidationService } from './upload-validation.service';
 
 @Module({
   imports: [
@@ -19,8 +20,7 @@ import { FileMetadataModule } from '../file-metadata/file-metadata.module';
     FileMetadataModule,
   ],
   controllers: [DeliveryProofController],
-  providers: [DeliveryProofService],
+  providers: [DeliveryProofService, UploadValidationService],
   exports: [DeliveryProofService],
 })
 export class DeliveryProofModule {}
-


### PR DESCRIPTION
closes #983 

##Summary
Adds UploadValidationService to DeliveryProofModule.providers.
Keeps DeliveryProofService as the only exported provider.
Leaves delivery proof controller, service logic, upload validation logic, DTOs, and entities unchanged.

##Reason
DeliveryProofService injects UploadValidationService, but UploadValidationService was not registered in DeliveryProofModule.providers. This could cause NestJS to fail at startup with UnknownDependenciesException.