### PR TITLE
fix(backend): register JWT key service in auth module

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,14 +7,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IdempotencyModule } from '../common/idempotency/idempotency.module';
 import { RedisModule } from '../redis/redis.module';
 import { UserActivityModule } from '../user-activity/user-activity.module';
-import { UserEntity } from '../users/entities/user.entity';
 import { TwoFactorAuthEntity } from '../users/entities/two-factor-auth.entity';
+import { UserEntity } from '../users/entities/user.entity';
 
 import { AuthController } from './auth.controller';
-import { PermissionsController } from './permissions.controller';
 import { AuthService } from './auth.service';
-import { EmailVerificationEntity } from './entities/email-verification.entity';
 import { AuthSessionEntity } from './entities/auth-session.entity';
+import { EmailVerificationEntity } from './entities/email-verification.entity';
 import { PasswordResetTokenEntity } from './entities/password-reset-token.entity';
 import { RolePermissionEntity } from './entities/role-permission.entity';
 import { RoleEntity } from './entities/role.entity';
@@ -22,13 +21,15 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { PermissionsGuard } from './guards/permissions.guard';
 import { JwtKeyService } from './jwt-key.service';
 import { JwtStrategy } from './jwt.strategy';
-import { MfaController } from './mfa/mfa.controller';
 import { MfaService } from './mfa/mfa.service';
 import { PasswordResetService } from './password-reset.service';
+import { PermissionsController } from './permissions.controller';
 import { PermissionsService } from './permissions.service';
 import { AuthSessionRepository } from './repositories/auth-session.repository';
 import { ScopeResolutionService } from './scope-resolution.service';
 import { SessionRiskService } from './session-risk.service';
+
+import type { JwtModuleOptions } from '@nestjs/jwt';
 
 @Module({
   imports: [
@@ -36,12 +37,13 @@ import { SessionRiskService } from './session-risk.service';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const expiresIn = configService.get<string>('JWT_EXPIRES_IN') ?? '1h';
+      useFactory: (configService: ConfigService): JwtModuleOptions => {
+        const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') ??
+          '1h') as NonNullable<JwtModuleOptions['signOptions']>['expiresIn'];
         return {
           secret: configService.get<string>('JWT_SECRET') ?? 'default-secret',
           signOptions: {
-            expiresIn: expiresIn as any,
+            expiresIn,
           },
         };
       },
@@ -64,6 +66,7 @@ import { SessionRiskService } from './session-risk.service';
     AuthService,
     MfaService,
     PasswordResetService,
+    JwtKeyService,
     JwtStrategy,
     JwtAuthGuard,
     PermissionsGuard,
@@ -76,6 +79,7 @@ import { SessionRiskService } from './session-risk.service';
     AuthService,
     MfaService,
     PasswordResetService,
+    JwtKeyService,
     JwtStrategy,
     JwtAuthGuard,
     PermissionsGuard,


### PR DESCRIPTION
closes #980 
##Summary
Adds JwtKeyService to AuthModule.providers.
Adds JwtKeyService to AuthModule.exports.
Keeps authentication, JWT key resolution, guards, strategies, services, and route behavior unchanged.

##Reason
AuthService injects JwtKeyService, but JwtKeyService was missing from AuthModule.providers. This prevented NestJS from resolving the dependency when instantiating AuthService. The service is also exported as required so modules importing AuthModule can resolve the shared JWT key provider.