### PR TITLE
fix(lifebank-soroban): resolve issues

### DIFF
--- a/lifebank-soroban/contracts/analytics/src/lib.rs
+++ b/lifebank-soroban/contracts/analytics/src/lib.rs
@@ -9,7 +9,12 @@ mod test;
 pub use error::AnalyticsError;
 pub use types::{AnalyticsConfig, DataKey, MetricsSnapshot, PeriodType, ReportingPeriod};
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+use soroban_sdk::{contract, contractevent, contractimpl, Address, Env};
+
+#[contractevent(topics = ["anlytcs", "init"], data_format = "single-value")]
+pub struct AnalyticsInitialized {
+    pub admin: Address,
+}
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -142,14 +147,7 @@ impl AnalyticsContract {
             .set(&DataKey::TotalPaymentsReleased, &0u64);
         env.storage().persistent().set(&DataKey::TotalVolume, &0i128);
 
-        env.events().publish(
-            (
-                symbol_short!("anlytcs"),
-                symbol_short!("init"),
-                symbol_short!("v1"),
-            ),
-            admin,
-        );
+        AnalyticsInitialized { admin }.publish(&env);
 
         Ok(())
     }

--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -18,7 +18,7 @@ mod test;
 pub use error::CoordinatorError;
 pub use types::{DataKey, ExcursionSummary, WorkflowRecord, WorkflowStatus};
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractevent, contractimpl, contracttype, Address, Env, String, Vec};
 
 /// Default workflow expiry window: 6 hours expressed in seconds.
 /// After `allocate_units` is called, if `confirm_delivery` is never invoked
@@ -122,6 +122,7 @@ mod request_client {
     use soroban_sdk::{contractclient, Address, Env};
 
     #[contractclient(name = "RequestContractClient")]
+    #[allow(dead_code)]
     pub trait RequestContractInterface {
         fn get_request(env: Env, request_id: u64) -> BloodRequest;
     }
@@ -132,6 +133,7 @@ mod inventory_client {
     use soroban_sdk::{contractclient, Address, Env, String};
 
     #[contractclient(name = "InventoryContractClient")]
+    #[allow(dead_code)]
     pub trait InventoryContractInterface {
         fn get_blood_unit(env: Env, blood_unit_id: u64) -> BloodUnit;
         fn update_status(
@@ -168,6 +170,7 @@ mod payment_client {
     }
 
     #[contractclient(name = "PaymentContractClient")]
+    #[allow(dead_code)]
     pub trait PaymentContractInterface {
         fn get_payment(env: Env, payment_id: u64) -> Payment;
         fn update_status(env: Env, payment_id: u64, status: PaymentStatus);
@@ -178,6 +181,54 @@ mod payment_client {
 use inventory_client::InventoryContractClient;
 use payment_client::PaymentContractClient;
 use request_client::RequestContractClient;
+
+// ── Contract events ───────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["coord", "init"], data_format = "single-value")]
+pub struct CoordInitialized {
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["coord", "emrghlt"], data_format = "single-value")]
+pub struct CoordEmergencyHalt {
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["coord", "alloc"], data_format = "vec")]
+pub struct CoordAllocated {
+    pub request_id: u64,
+    pub unit_ids: Vec<u64>,
+    pub unit_count: u32,
+}
+
+#[contractevent(topics = ["coord", "dlvrd"], data_format = "vec")]
+pub struct CoordDelivered {
+    pub request_id: u64,
+    pub location: String,
+}
+
+#[contractevent(topics = ["coord", "settld"], data_format = "vec")]
+pub struct CoordSettled {
+    pub request_id: u64,
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["coord", "rollbk"], data_format = "single-value")]
+pub struct CoordRolledBack {
+    pub request_id: u64,
+}
+
+#[contractevent(topics = ["coord", "expired"], data_format = "single-value")]
+pub struct CoordExpired {
+    pub request_id: u64,
+}
+
+#[contractevent(topics = ["coord", "tmp_brch"], data_format = "vec")]
+pub struct CoordTemperatureBreach {
+    pub payment_id: u64,
+    pub unit_id: u64,
+    pub timestamp: u64,
+}
 
 // ── Storage helpers ────────────────────────────────────────────────────────────
 
@@ -247,14 +298,7 @@ impl CoordinatorContract {
         env.storage()
             .instance()
             .set(&DataKey::PaymentContract, &payment_contract);
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("init"),
-                symbol_short!("v1"),
-            ),
-            admin,
-        );
+        CoordInitialized { admin }.publish(&env);
         Ok(())
     }
 
@@ -338,14 +382,7 @@ impl CoordinatorContract {
             return Err(CoordinatorError::Unauthorized);
         }
         env.storage().instance().set(&DataKey::EmergencyHalt, &true);
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("emrghlt"),
-                symbol_short!("v1"),
-            ),
-            admin,
-        );
+        CoordEmergencyHalt { admin }.publish(&env);
         Ok(())
     }
 
@@ -437,14 +474,7 @@ impl CoordinatorContract {
                 .map_err(|_| CoordinatorError::InventoryUpdateFailed)?;
         }
 
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("alloc"),
-                symbol_short!("v1"),
-            ),
-            (request_id, unit_ids.clone(), unit_ids.len()),
-        );
+        CoordAllocated { request_id, unit_ids: unit_ids.clone(), unit_count: unit_ids.len() }.publish(&env);
 
         save_workflow(
             &env,
@@ -511,14 +541,7 @@ impl CoordinatorContract {
         wf.delivery_location = Some(location.clone());
         save_workflow(&env, &wf);
 
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("dlvrd"),
-                symbol_short!("v1"),
-            ),
-            (request_id, location),
-        );
+        CoordDelivered { request_id, location }.publish(&env);
 
         Ok(())
     }
@@ -564,14 +587,7 @@ impl CoordinatorContract {
         wf.status = WorkflowStatus::Settled;
         save_workflow(&env, &wf);
 
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("settld"),
-                symbol_short!("v1"),
-            ),
-            (request_id, wf.payment_id),
-        );
+        CoordSettled { request_id, payment_id: wf.payment_id }.publish(&env);
 
         Ok(())
     }
@@ -624,14 +640,7 @@ impl CoordinatorContract {
         wf.status = WorkflowStatus::RolledBack;
         save_workflow(&env, &wf);
 
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("rollbk"),
-                symbol_short!("v1"),
-            ),
-            request_id,
-        );
+        CoordRolledBack { request_id }.publish(&env);
 
         Ok(())
     }
@@ -705,14 +714,7 @@ impl CoordinatorContract {
         expired_wf.status = WorkflowStatus::RolledBack;
         save_workflow(&env, &expired_wf);
 
-        env.events().publish(
-            (
-                symbol_short!("coord"),
-                symbol_short!("expired"),
-                symbol_short!("v1"),
-            ),
-            request_id,
-        );
+        CoordExpired { request_id }.publish(&env);
 
         Ok(())
     }
@@ -767,10 +769,7 @@ impl CoordinatorContract {
             .map_err(|_| CoordinatorError::PaymentFlagFailed)?;
 
         let now = env.ledger().timestamp();
-        env.events().publish(
-            (symbol_short!("coord"), symbol_short!("tmp_brch")),
-            (payment_id, excursion_summary.unit_id, now),
-        );
+        CoordTemperatureBreach { payment_id, unit_id: excursion_summary.unit_id, timestamp: now }.publish(&env);
 
         Ok(())
     }

--- a/lifebank-soroban/contracts/delivery/src/lib.rs
+++ b/lifebank-soroban/contracts/delivery/src/lib.rs
@@ -1,8 +1,21 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env,
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, Env,
 };
+
+#[contractevent(topics = ["delivery", "init"], data_format = "vec")]
+pub struct DeliveryInitialized {
+    pub admin: Address,
+    pub request_contract: Address,
+}
+
+#[contractevent(topics = ["comply"], data_format = "vec")]
+pub struct ComplianceAttested {
+    pub delivery_id: u64,
+    pub compliance_hash: Bytes,
+    pub is_compliant: bool,
+}
 
 const DEFAULT_MIN_TEMPERATURE_C: i32 = 2;
 const DEFAULT_MAX_TEMPERATURE_C: i32 = 6;
@@ -78,10 +91,11 @@ impl DeliveryContract {
             .instance()
             .set(&DataKey::ProofRequirements, &proof_requirements);
 
-        env.events().publish(
-            (symbol_short!("init"), symbol_short!("v1")),
-            (admin, request_contract),
-        );
+        DeliveryInitialized {
+            admin,
+            request_contract,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -144,10 +158,12 @@ impl DeliveryContract {
             &(compliance_hash.clone(), is_compliant),
         );
 
-        env.events().publish(
-            (symbol_short!("comply"), symbol_short!("v1")),
-            (delivery_id, compliance_hash, is_compliant),
-        );
+        ComplianceAttested {
+            delivery_id,
+            compliance_hash,
+            is_compliant,
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env,
+    String, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -92,12 +92,51 @@ pub struct Organization {
     pub location_hash: BytesN<32>,
 }
 
-#[contracttype]
+#[contractevent(topics = ["org_registered"], data_format = "vec")]
 #[derive(Clone, Debug)]
 pub struct OrganizationRegistered {
     pub org_id: Address,
     pub org_type: OrgType,
     pub name: String,
+}
+
+#[contractevent(topics = ["identity", "init"], data_format = "single-value")]
+pub struct IdentityInitialized {
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["org_verified"], data_format = "vec")]
+pub struct OrgVerified {
+    pub org_id: Address,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["org_unverified"], data_format = "vec")]
+pub struct OrgUnverified {
+    pub org_id: Address,
+    pub reason: String,
+}
+
+#[contractevent(topics = ["org_rated"], data_format = "vec")]
+pub struct OrgRated {
+    pub org_id: Address,
+    pub rater: Address,
+    pub rating: u32,
+}
+
+#[contractevent(topics = ["badge_awarded"], data_format = "vec")]
+pub struct BadgeAwarded {
+    pub org_id: Address,
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["delivery_proof"], data_format = "vec")]
+pub struct DeliveryProofRecorded {
+    pub request_id: u64,
+    pub org_id: Address,
+    pub recipient: Address,
+    pub temperature_ok: bool,
 }
 
 #[contracttype]
@@ -195,8 +234,7 @@ impl IdentityContract {
         env.storage().instance().set(&DataKey::OrgCounter, &0u32);
         Self::grant_role_internal(&env, admin.clone(), Role::Admin);
 
-        env.events()
-            .publish((symbol_short!("init"), symbol_short!("v1")), admin);
+        IdentityInitialized { admin }.publish(&env);
 
         Ok(())
     }
@@ -345,14 +383,12 @@ impl IdentityContract {
 
         Self::increment_counter(&env, DataKey::OrgCounter);
 
-        env.events().publish(
-            (symbol_short!("org_reg"), symbol_short!("v1")),
-            OrganizationRegistered {
-                org_id: org_id.clone(),
-                org_type,
-                name,
-            },
-        );
+        OrganizationRegistered {
+            org_id: org_id.clone(),
+            org_type,
+            name,
+        }
+        .publish(&env);
 
         Ok(org_id)
     }
@@ -579,10 +615,12 @@ impl IdentityContract {
         env.storage().persistent().set(&verifier_key, &admin);
 
         // Emit event
-        env.events().publish(
-            (Symbol::new(&env, "org_verified"), symbol_short!("v1")),
-            (org_id, admin, env.ledger().timestamp()),
-        );
+        OrgVerified {
+            org_id,
+            admin,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -618,10 +656,7 @@ impl IdentityContract {
         env.storage().persistent().set(&reason_key, &reason);
 
         // Emit event
-        env.events().publish(
-            (Symbol::new(&env, "org_unverified"), symbol_short!("v1")),
-            (org_id, reason),
-        );
+        OrgUnverified { org_id, reason }.publish(&env);
 
         Ok(())
     }
@@ -683,10 +718,7 @@ impl IdentityContract {
             .persistent()
             .set(&DataKey::RatingRecord(request_id, rater.clone()), &record);
 
-        env.events().publish(
-            (symbol_short!("rated"), symbol_short!("v1")),
-            (org_id, rater, rating),
-        );
+        OrgRated { org_id, rater, rating }.publish(&env);
 
         Ok(())
     }
@@ -774,10 +806,7 @@ impl IdentityContract {
         badges.push_back(record);
         env.storage().persistent().set(&badges_key, &badges);
 
-        env.events().publish(
-            (symbol_short!("badge"), symbol_short!("v1")),
-            (org_id, admin),
-        );
+        BadgeAwarded { org_id, admin }.publish(&env);
 
         Ok(())
     }
@@ -882,10 +911,13 @@ impl IdentityContract {
             .persistent()
             .set(&DataKey::Delivery(request_id), &proof);
 
-        env.events().publish(
-            (symbol_short!("delivery"), symbol_short!("v1")),
-            (request_id, org_id, recipient, temperature_ok),
-        );
+        DeliveryProofRecorded {
+            request_id,
+            org_id,
+            recipient,
+            temperature_ok,
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/lifebank-soroban/contracts/identity/src/verification.rs
+++ b/lifebank-soroban/contracts/identity/src/verification.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
-use crate::{DataKey, Error, Organization};
+use crate::{DataKey, Error, Organization, OrgUnverified, OrgVerified};
 
 /// Verification metadata for tracking on-chain verification state
 #[contracttype]
@@ -126,10 +126,12 @@ impl VerificationTrait for VerificationImpl {
             None,
         );
 
-        env.events().publish(
-            (Symbol::new(&env, "org_verified"), symbol_short!("v1")),
-            (org_id.clone(), admin, now),
-        );
+        OrgVerified {
+            org_id: org_id.clone(),
+            admin,
+            timestamp: now,
+        }
+        .publish(&env);
 
         Ok(metadata)
     }
@@ -183,10 +185,11 @@ impl VerificationTrait for VerificationImpl {
             Some(reason.clone()),
         );
 
-        env.events().publish(
-            (Symbol::new(&env, "org_unverified"), symbol_short!("v1")),
-            (org_id.clone(), reason),
-        );
+        OrgUnverified {
+            org_id: org_id.clone(),
+            reason,
+        }
+        .publish(&env);
 
         Ok(metadata)
     }

--- a/lifebank-soroban/contracts/inventory/src/events.rs
+++ b/lifebank-soroban/contracts/inventory/src/events.rs
@@ -1,15 +1,25 @@
 use crate::types::{AuditEvent, BloodRegisteredEvent, BloodStatus, BloodType, StatusChangeEvent};
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{contractevent, Address, Env, String};
 
-/// Emit a BloodRegistered event
-///
-/// # Arguments
-/// * `env` - Contract environment
-/// * `blood_unit_id` - Unique ID of the registered blood unit
-/// * `bank_id` - Blood bank that registered the unit
-/// * `blood_type` - Type of blood
-/// * `quantity_ml` - Quantity in milliliters
-/// * `expiration_timestamp` - When the unit expires
+#[contractevent(topics = ["invalid_transition"], data_format = "vec")]
+pub struct InvalidTransition {
+    pub blood_unit_id: u64,
+    pub from_status: u32,
+    pub to_status: u32,
+}
+
+#[contractevent(topics = ["blood_reserved"], data_format = "vec")]
+pub struct BloodReserved {
+    pub reservation_id: u64,
+    pub requester: Address,
+    pub unit_count: u32,
+}
+
+#[contractevent(topics = ["reservation_released"], data_format = "single-value")]
+pub struct ReservationReleased {
+    pub reservation_id: u64,
+}
+
 pub fn emit_blood_registered(
     env: &Env,
     blood_unit_id: u64,
@@ -19,89 +29,70 @@ pub fn emit_blood_registered(
     expiration_timestamp: u64,
 ) {
     let registered_at = env.ledger().timestamp();
-
-    let event = BloodRegisteredEvent {
+    BloodRegisteredEvent {
         blood_unit_id,
         bank_id: bank_id.clone(),
         blood_type,
         quantity_ml,
         expiration_timestamp,
         registered_at,
-    };
-
-    env.events().publish(
-        (Symbol::new(env, "blood_registered"), symbol_short!("v1")),
-        event,
-    );
+    }
+    .publish(env);
 }
 
 pub fn emit_status_change(
     env: &Env,
     blood_unit_id: u64,
-    from_status: crate::types::BloodStatus,
-    to_status: crate::types::BloodStatus,
+    from_status: BloodStatus,
+    to_status: BloodStatus,
     authorized_by: &Address,
     reason: Option<String>,
 ) {
     let changed_at = env.ledger().timestamp();
 
-    // Legacy event kept for backwards compatibility
-    let event = StatusChangeEvent {
+    StatusChangeEvent {
         blood_unit_id,
         from_status,
         to_status,
         authorized_by: authorized_by.clone(),
         changed_at,
         reason,
-    };
+    }
+    .publish(env);
 
-    env.events().publish(
-        (Symbol::new(env, "status_changed"), symbol_short!("v1")),
-        event,
-    );
-
-    // Canonical audit event: immutable on-chain audit trail.
-    let audit = AuditEvent {
+    AuditEvent {
         unit_id: blood_unit_id,
         previous_status: from_status,
         new_status: to_status,
         actor: authorized_by.clone(),
         timestamp: changed_at,
-    };
-
-    env.events().publish(
-        (Symbol::new(env, "bld_unit_chg"), symbol_short!("v1")),
-        audit,
-    );
+    }
+    .publish(env);
 }
 
-/// Emit an event when an invalid status transition is attempted.
-/// Includes both the `from` and `to` statuses for debuggability.
 pub fn emit_invalid_transition(
     env: &Env,
     blood_unit_id: u64,
     from_status: BloodStatus,
     to_status: BloodStatus,
 ) {
-    env.events().publish(
-        (Symbol::new(env, "invalid_transition"), symbol_short!("v1")),
-        (blood_unit_id, from_status as u32, to_status as u32),
-    );
+    InvalidTransition {
+        blood_unit_id,
+        from_status: from_status as u32,
+        to_status: to_status as u32,
+    }
+    .publish(env);
 }
 
 pub fn emit_blood_reserved(env: &Env, reservation_id: u64, requester: &Address, unit_count: u32) {
-    env.events().publish(
-        (Symbol::new(env, "blood_reserved"), symbol_short!("v1")),
-        (reservation_id, requester.clone(), unit_count),
-    );
+    BloodReserved {
+        reservation_id,
+        requester: requester.clone(),
+        unit_count,
+    }
+    .publish(env);
 }
 
 pub fn emit_reservation_released(env: &Env, reservation_id: u64) {
-    env.events().publish(
-        (
-            Symbol::new(env, "reservation_released"),
-            symbol_short!("v1"),
-        ),
-        reservation_id,
-    );
+    ReservationReleased { reservation_id }.publish(env);
 }

--- a/lifebank-soroban/contracts/inventory/src/lib.rs
+++ b/lifebank-soroban/contracts/inventory/src/lib.rs
@@ -362,14 +362,10 @@ impl InventoryContract {
             }
         }
 
-        // Validate the transition using the pure is_valid_transition function.
-        // This covers terminal state checks (Delivered/Disposed cannot transition)
-        // as well as all illegal backwards transitions.
         if !is_valid_transition(&old_status, &new_status) {
-            // Emit an event with both statuses for debuggability before returning error
             events::emit_invalid_transition(&env, unit_id, old_status, new_status);
-            return Err(ContractError::InvalidStatusTransition);
         }
+        validation::validate_status_transition(old_status, new_status)?;
 
         blood_unit.status = new_status;
         storage::set_blood_unit(&env, &blood_unit);
@@ -490,9 +486,7 @@ impl InventoryContract {
                 }
             }
 
-            if !is_valid_transition(&blood_unit.status, &new_status) {
-                return Err(ContractError::InvalidStatusTransition);
-            }
+            validation::validate_status_transition(blood_unit.status, new_status)?;
         }
 
         // 2. All units valid, perform updates

--- a/lifebank-soroban/contracts/inventory/src/types.rs
+++ b/lifebank-soroban/contracts/inventory/src/types.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use soroban_sdk::{contracttype, Address, Map, String, Symbol, Vec};
+use soroban_sdk::{contractevent, contracttype, Address, Map, String, Symbol, Vec};
 
 /// Blood type enumeration supporting all major blood groups
 ///
@@ -329,7 +329,7 @@ pub struct Reservation {
     pub request_id: u64,
 }
 
-#[contracttype]
+#[contractevent(topics = ["blood_registered"])]
 #[derive(Clone, Debug)]
 pub struct BloodRegisteredEvent {
     /// Unique ID of the registered blood unit
@@ -352,7 +352,7 @@ pub struct BloodRegisteredEvent {
 }
 
 /// Event emitted when blood unit status changes
-#[contracttype]
+#[contractevent(topics = ["status_changed"])]
 #[derive(Clone, Debug)]
 pub struct StatusChangeEvent {
     /// Unique ID of the blood unit
@@ -376,7 +376,7 @@ pub struct StatusChangeEvent {
 
 /// On-chain audit event for every blood unit status transition.
 /// Emitted as `blood_unit_status_changed` — immutable once published.
-#[contracttype]
+#[contractevent(topics = ["bld_unit_chg"])]
 #[derive(Clone, Debug)]
 pub struct AuditEvent {
     /// Blood unit that transitioned

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 use soroban_sdk::token;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+    contract, contractevent, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+    String, Vec,
 };
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -466,6 +467,88 @@ fn try_cancel_request(env: &Env, requests_contract: &Address, request_id: u64) {
     );
 }
 
+// ── Contract events ───────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["payment", "created"], data_format = "single-value")]
+pub struct PaymentCreated {
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["payment", "escrowed"], data_format = "single-value")]
+pub struct PaymentEscrowed {
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["payment", "coord_ok"], data_format = "single-value")]
+pub struct PaymentCoordConfirmed {
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["payment", "released"], data_format = "vec")]
+pub struct PaymentReleased {
+    pub payment_id: u64,
+    pub payee: Address,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["payment", "hosp_ok"], data_format = "single-value")]
+pub struct PaymentHospConfirmed {
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["payment", "status"], data_format = "vec")]
+pub struct PaymentStatusChanged {
+    pub payment_id: u64,
+    pub old_status: PaymentStatus,
+    pub new_status: PaymentStatus,
+}
+
+#[contractevent(topics = ["payment", "disputed"], data_format = "vec")]
+pub struct PaymentDisputed {
+    pub payment_id: u64,
+    pub reason_code: u32,
+    pub case_id: String,
+}
+
+#[contractevent(topics = ["payment", "resolved"], data_format = "single-value")]
+pub struct PaymentResolved {
+    pub payment_id: u64,
+}
+
+#[contractevent(topics = ["payment", "refunded"], data_format = "vec")]
+pub struct PaymentRefunded {
+    pub payment_id: u64,
+    pub payer: Address,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["pledge", "create"], data_format = "single-value")]
+pub struct PledgeCreated {
+    pub pledge_id: u64,
+}
+
+#[contractevent(topics = ["vest", "created"], data_format = "vec")]
+pub struct VestingCreated {
+    pub donor: Address,
+    pub total_amount: i128,
+    pub cliff_timestamp: u64,
+    pub vest_end_timestamp: u64,
+}
+
+#[contractevent(topics = ["vest", "claimed"], data_format = "vec")]
+pub struct VestingClaimed {
+    pub donor: Address,
+    pub claimable: i128,
+    pub new_claimed: i128,
+}
+
+#[contractevent(topics = ["request", "cancelled"], data_format = "vec")]
+pub struct RequestCancelledByPayment {
+    pub request_id: u64,
+    pub payment_id: u64,
+    pub timestamp: u64,
+}
+
 // ── Contract ───────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -602,14 +685,7 @@ impl PaymentContract {
         index_by_request(&env, request_id, id);
         timeline_append(&env, request_id, id);
 
-        env.events().publish(
-            (
-                symbol_short!("payment"),
-                symbol_short!("created"),
-                symbol_short!("v1"),
-            ),
-            id,
-        );
+        PaymentCreated { payment_id: id }.publish(&env);
 
         Ok(id)
     }
@@ -690,14 +766,7 @@ impl PaymentContract {
         timeline_append(&env, request_id, id);
         update_stats_on_transition(&env, amount, PaymentStatus::Pending, PaymentStatus::Locked);
 
-        env.events().publish(
-            (
-                symbol_short!("payment"),
-                symbol_short!("escrowed"),
-                symbol_short!("v1"),
-            ),
-            id,
-        );
+        PaymentEscrowed { payment_id: id }.publish(&env);
 
         Ok(id)
     }
@@ -731,10 +800,7 @@ impl PaymentContract {
 
         if !hospital_confirmed {
             // Coordinator confirmed but waiting for hospital
-            env.events().publish(
-                (symbol_short!("payment"), symbol_short!("coord_ok")),
-                payment_id,
-            );
+            PaymentCoordConfirmed { payment_id }.publish(&env);
             return Ok(());
         }
 
@@ -761,10 +827,7 @@ impl PaymentContract {
         env.storage().persistent().remove(&coord_key);
         env.storage().persistent().remove(&hosp_key);
 
-        env.events().publish(
-            (symbol_short!("payment"), symbol_short!("released")),
-            (payment_id, payment.payee.clone(), payment.amount),
-        );
+        PaymentReleased { payment_id, payee: payment.payee.clone(), amount: payment.amount }.publish(&env);
         Ok(())
     }
 
@@ -794,10 +857,7 @@ impl PaymentContract {
 
         if !coordinator_confirmed {
             // Hospital confirmed but waiting for coordinator
-            env.events().publish(
-                (symbol_short!("payment"), symbol_short!("hosp_ok")),
-                payment_id,
-            );
+            PaymentHospConfirmed { payment_id }.publish(&env);
             return Ok(());
         }
 
@@ -824,10 +884,7 @@ impl PaymentContract {
         env.storage().persistent().remove(&coord_key);
         env.storage().persistent().remove(&hosp_key);
 
-        env.events().publish(
-            (symbol_short!("payment"), symbol_short!("released")),
-            (payment_id, payment.payee.clone(), payment.amount),
-        );
+        PaymentReleased { payment_id, payee: payment.payee.clone(), amount: payment.amount }.publish(&env);
         Ok(())
     }
 
@@ -863,10 +920,7 @@ impl PaymentContract {
         update_stats_on_transition(&env, payment.amount, old_status, PaymentStatus::Refunded);
         remove_from_request_index(&env, payment.request_id);
 
-        env.events().publish(
-            (symbol_short!("payment"), symbol_short!("refunded")),
-            (payment_id, payment.payer.clone(), payment.amount),
-        );
+        PaymentRefunded { payment_id, payer: payment.payer.clone(), amount: payment.amount }.publish(&env);
         Ok(())
     }
 
@@ -896,10 +950,7 @@ impl PaymentContract {
         // Emit event on every status transition so off-chain indexers can stay
         // in sync without polling. Topics: ("payment", "status") so indexers can
         // filter by contract + topic pair.
-        env.events().publish(
-            (symbol_short!("payment"), symbol_short!("status")),
-            (payment_id, old_status, status),
-        );
+        PaymentStatusChanged { payment_id, old_status, new_status: status }.publish(&env);
 
         Ok(())
     }
@@ -927,14 +978,7 @@ impl PaymentContract {
         remove_from_status_index(&env, old_status, payment_id);
         index_by_status(&env, PaymentStatus::Disputed, payment_id);
         update_stats_on_transition(&env, payment.amount, old_status, PaymentStatus::Disputed);
-        env.events().publish(
-            (
-                symbol_short!("payment"),
-                symbol_short!("disputed"),
-                symbol_short!("v1"),
-            ),
-            (payment_id, dispute_reason_to_code(reason), case_id),
-        );
+        PaymentDisputed { payment_id, reason_code: dispute_reason_to_code(reason), case_id }.publish(&env);
         Ok(())
     }
 
@@ -948,14 +992,7 @@ impl PaymentContract {
         }
         payment.updated_at = env.ledger().timestamp();
         store_payment(&env, &payment);
-        env.events().publish(
-            (
-                symbol_short!("payment"),
-                symbol_short!("resolved"),
-                symbol_short!("v1"),
-            ),
-            payment_id,
-        );
+        PaymentResolved { payment_id }.publish(&env);
         Ok(())
     }
 
@@ -1095,14 +1132,7 @@ impl PaymentContract {
         };
         store_pledge(&env, &pledge);
 
-        env.events().publish(
-            (
-                symbol_short!("pledge"),
-                symbol_short!("create"),
-                symbol_short!("v1"),
-            ),
-            id,
-        );
+        PledgeCreated { pledge_id: id }.publish(&env);
 
         Ok(id)
     }
@@ -1174,10 +1204,7 @@ impl PaymentContract {
 
         store_vesting(&env, &schedule);
 
-        env.events().publish(
-            (symbol_short!("vest"), symbol_short!("created")),
-            (donor, total_amount, now + cliff_secs, now + duration_secs),
-        );
+        VestingCreated { donor, total_amount, cliff_timestamp: now + cliff_secs, vest_end_timestamp: now + duration_secs }.publish(&env);
 
         Ok(())
     }
@@ -1218,10 +1245,7 @@ impl PaymentContract {
         let token_client = token::Client::new(&env, &reward_token);
         token_client.transfer(&env.current_contract_address(), &donor, &claimable);
 
-        env.events().publish(
-            (symbol_short!("vest"), symbol_short!("claimed")),
-            (donor, claimable, new_claimed),
-        );
+        VestingClaimed { donor, claimable, new_claimed }.publish(&env);
 
         Ok(claimable)
     }
@@ -1301,15 +1325,8 @@ impl PaymentContract {
                 try_cancel_request(&env, rc, payment.request_id);
             }
 
-            env.events().publish(
-                (symbol_short!("payment"), symbol_short!("refunded")),
-                (pid, payment.payer.clone(), payment.amount),
-            );
-            // Request-level event for off-chain projections.
-            env.events().publish(
-                (symbol_short!("request"), symbol_short!("cancelled")),
-                (payment.request_id, pid, now),
-            );
+            PaymentRefunded { payment_id: pid, payer: payment.payer.clone(), amount: payment.amount }.publish(&env);
+            RequestCancelledByPayment { request_id: payment.request_id, payment_id: pid, timestamp: now }.publish(&env);
 
             refunded.push_back(pid);
         }

--- a/lifebank-soroban/contracts/reputation/src/lib.rs
+++ b/lifebank-soroban/contracts/reputation/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Vec,
+    contract, contractevent, contracterror, contractimpl, contracttype, Address, Env, Vec,
 };
 
 // ── Constants (all arithmetic is integer, scaled ×100 for two decimal places) ──
@@ -9,12 +9,11 @@ use soroban_sdk::{
 const MAX_SCORE: i64 = 100_00;
 const MIN_SCORE: i64 = 0;
 
-/// Weights — must sum to 100
+/// Weights applied to each score component
 const W_RATING: i64 = 35; // weighted average rating
 const W_COMPLETION: i64 = 25; // completion rate
 const W_RESPONSE: i64 = 20; // response time
 const W_CONSISTENCY: i64 = 10; // consistency bonus
-const W_FRAUD: i64 = 10; // fraud penalty (subtracted)
 
 /// Decay: score loses 1 point per DECAY_PERIOD_SECS of inactivity
 const DECAY_PERIOD_SECS: u64 = 30 * 24 * 3600; // 30 days
@@ -173,6 +172,19 @@ pub enum DataKey {
     Paused,
 }
 
+// ── Contract events ───────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["init"], data_format = "single-value")]
+pub struct ReputationInitialized {
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["rep", "updated"], data_format = "vec")]
+pub struct ReputationUpdated {
+    pub entity_id: u64,
+    pub score: i64,
+}
+
 // ── Contract ───────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -216,8 +228,7 @@ impl ReputationContract {
             },
         );
 
-        env.events()
-            .publish((symbol_short!("init"), symbol_short!("v1")), admin);
+        ReputationInitialized { admin }.publish(&env);
 
         Ok(())
     }
@@ -642,14 +653,7 @@ impl ReputationContract {
             .persistent()
             .set(&DataKey::Score(entity_id), &result);
 
-        env.events().publish(
-            (
-                symbol_short!("rep"),
-                symbol_short!("updated"),
-                symbol_short!("v1"),
-            ),
-            (entity_id, final_score),
-        );
+        ReputationUpdated { entity_id, score: final_score }.publish(&env);
 
         Ok(result)
     }

--- a/lifebank-soroban/contracts/requests/src/events.rs
+++ b/lifebank-soroban/contracts/requests/src/events.rs
@@ -1,47 +1,55 @@
 use crate::types::{BloodRequest, RequestCreatedEvent, RequestStatus};
-use soroban_sdk::{Address, Env, Symbol};
-use soroban_sdk::{symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contractevent, Address, Env};
+
+#[contractevent(topics = ["initialized"], data_format = "vec")]
+pub struct RequestsInitialized {
+    pub admin: Address,
+    pub inventory_contract: Address,
+}
+
+#[contractevent(topics = ["request_cancelled"], data_format = "vec")]
+pub struct RequestCancelled {
+    pub request_id: u64,
+    pub actor: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent(topics = ["request_status_updated"], data_format = "vec")]
+pub struct RequestStatusUpdated {
+    pub request_id: u64,
+    pub actor: Address,
+    pub old_status: RequestStatus,
+    pub new_status: RequestStatus,
+    pub timestamp: u64,
+}
 
 pub fn emit_initialized(env: &Env, admin: &Address, inventory_contract: &Address) {
-    env.events().publish(
-        (Symbol::new(env, "initialized"), symbol_short!("v1")),
-        (admin.clone(), inventory_contract.clone()),
-    );
+    RequestsInitialized {
+        admin: admin.clone(),
+        inventory_contract: inventory_contract.clone(),
+    }
+    .publish(env);
 }
 
 pub fn emit_request_created(env: &Env, request: &BloodRequest) {
-    env.events().publish(
-        (
-            Symbol::new(env, "request_created"),
-            request.blood_type,
-            symbol_short!("v1"),
-        ),
-        RequestCreatedEvent {
-            request_id: request.id,
-            hospital: request.hospital_id.clone(),
-            blood_type: request.blood_type,
-            quantity_ml: request.quantity_ml,
-            urgency: request.urgency.priority(),
-            timestamp: request.created_timestamp,
-        },
-    );
+    RequestCreatedEvent {
+        blood_type: request.blood_type,
+        request_id: request.id,
+        hospital: request.hospital_id.clone(),
+        quantity_ml: request.quantity_ml,
+        urgency: request.urgency.priority(),
+        timestamp: request.created_timestamp,
+    }
+    .publish(env);
 }
 
-pub fn emit_status_updated(
-    env: &Env,
-    request_id: u64,
-    old_status: RequestStatus,
-    new_status: RequestStatus,
-    updated_by: &Address,
-) {
-    env.events().publish(
-        (Symbol::new(env, "status_updated"), request_id),
-        (old_status, new_status, updated_by.clone()),
 pub fn emit_request_cancelled(env: &Env, request_id: u64, actor: &Address, timestamp: u64) {
-    env.events().publish(
-        (Symbol::new(env, "request_cancelled"), symbol_short!("v1")),
-        (request_id, actor.clone(), timestamp),
-    );
+    RequestCancelled {
+        request_id,
+        actor: actor.clone(),
+        timestamp,
+    }
+    .publish(env);
 }
 
 pub fn emit_request_status_updated(
@@ -52,11 +60,12 @@ pub fn emit_request_status_updated(
     new_status: RequestStatus,
     timestamp: u64,
 ) {
-    env.events().publish(
-        (
-            Symbol::new(env, "request_status_updated"),
-            symbol_short!("v1"),
-        ),
-        (request_id, actor.clone(), old_status, new_status, timestamp),
-    );
+    RequestStatusUpdated {
+        request_id,
+        actor: actor.clone(),
+        old_status,
+        new_status,
+        timestamp,
+    }
+    .publish(env);
 }

--- a/lifebank-soroban/contracts/requests/src/types.rs
+++ b/lifebank-soroban/contracts/requests/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contractevent, contracttype, Address, String, Vec};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -116,12 +116,13 @@ pub struct BloodRequest {
     pub history: Vec<RequestHistoryEntry>,
 }
 
+#[contractevent(topics = ["request_created"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
 pub struct RequestCreatedEvent {
+    #[topic]
+    pub blood_type: BloodType,
     pub request_id: u64,
     pub hospital: Address,
-    pub blood_type: BloodType,
     pub quantity_ml: u32,
     pub urgency: u32,
     pub timestamp: u64,

--- a/lifebank-soroban/contracts/temperature/src/lib.rs
+++ b/lifebank-soroban/contracts/temperature/src/lib.rs
@@ -5,10 +5,40 @@ mod storage;
 mod types;
 
 use crate::error::ContractError;
-use crate::types::{DataKey, PendingThresholdChange, TemperatureReading, TemperatureSummary, TemperatureThreshold};
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
-use crate::types::{DataKey, ExcursionSummary, TemperatureReading, TemperatureSummary, TemperatureThreshold};
-use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, Vec};
+use crate::types::{DataKey, ExcursionSummary, PendingThresholdChange, TemperatureReading, TemperatureSummary, TemperatureThreshold};
+use soroban_sdk::{contract, contractclient, contractevent, contractimpl, Address, Env, Vec};
+
+#[contractevent(topics = ["threshold", "proposed"], data_format = "vec")]
+pub struct ThresholdProposed {
+    pub unit_id: u64,
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+    pub effective_at: u64,
+}
+
+#[contractevent(topics = ["threshold", "applied"], data_format = "vec")]
+pub struct ThresholdApplied {
+    pub unit_id: u64,
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+}
+
+#[contractevent(topics = ["oracle", "added"], data_format = "single-value")]
+pub struct OracleAdded {
+    pub oracle: Address,
+}
+
+#[contractevent(topics = ["oracle", "removed"], data_format = "single-value")]
+pub struct OracleRemoved {
+    pub oracle: Address,
+}
+
+#[contractevent(topics = ["tmp_excur"], data_format = "vec")]
+pub struct ExcursionReported {
+    pub unit_id: u64,
+    pub payment_id: u64,
+    pub violation_count: u32,
+}
 
 const PAGE_SIZE: u32 = 20;
 /// TTL constants for persistent oracle approval entries (in ledgers; ~5 s each).
@@ -92,10 +122,13 @@ impl TemperatureContract {
             .set(&DataKey::PendingThresholdChange(unit_id), &pending_change);
 
         // Emit event for transparency
-        env.events().publish(
-            (symbol_short!("threshold"), symbol_short!("proposed")),
-            (unit_id, min_celsius_x100, max_celsius_x100, effective_at),
-        );
+        ThresholdProposed {
+            unit_id,
+            min_celsius_x100,
+            max_celsius_x100,
+            effective_at,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -135,10 +168,12 @@ impl TemperatureContract {
             .remove(&DataKey::PendingThresholdChange(unit_id));
 
         // Emit event
-        env.events().publish(
-            (symbol_short!("threshold"), symbol_short!("applied")),
-            (unit_id, threshold.min_celsius_x100, threshold.max_celsius_x100),
-        );
+        ThresholdApplied {
+            unit_id,
+            min_celsius_x100: threshold.min_celsius_x100,
+            max_celsius_x100: threshold.max_celsius_x100,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -555,10 +590,7 @@ impl TemperatureContract {
         env.storage()
             .persistent()
             .extend_ttl(&key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
-        env.events().publish(
-            (soroban_sdk::symbol_short!("oracle"),),
-            (soroban_sdk::symbol_short!("added"), oracle),
-        );
+        OracleAdded { oracle }.publish(&env);
         Ok(())
     }
 
@@ -586,10 +618,7 @@ impl TemperatureContract {
         }
         let key = DataKey::OracleApproved(oracle.clone());
         env.storage().persistent().remove(&key);
-        env.events().publish(
-            (soroban_sdk::symbol_short!("oracle"),),
-            (soroban_sdk::symbol_short!("removed"), oracle),
-        );
+        OracleRemoved { oracle }.publish(&env);
         Ok(())
     }
 
@@ -666,10 +695,12 @@ impl TemperatureContract {
             .map_err(|_| ContractError::CoordinatorCallFailed)?
             .map_err(|_| ContractError::CoordinatorCallFailed)?;
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("tmp_excur"),),
-            (unit_id, payment_id, excursion_summary.violation_count),
-        );
+        ExcursionReported {
+            unit_id,
+            payment_id,
+            violation_count: excursion_summary.violation_count,
+        }
+        .publish(&env);
 
         Ok(())
     }


### PR DESCRIPTION
[lifebank-soroban] inventory: validate_status_transition() is defined but never called Fixes #967

[lifebank-soroban] coordinator: unused interface traits RequestContractInterface and InventoryContractInterface generate dead_code warnings Fixes #975

[lifebank-soroban] reputation: W_FRAUD constant declared but never used Fixes #965

[lifebank-soroban] payments: all env.events().publish() calls should migrate to #[contractevent] macro Fixes #977