### PR TITLE
fix(backend): register missing module imports and providers

### DIFF
--- a/backend/src/blood-units/blood-units.module.ts
+++ b/backend/src/blood-units/blood-units.module.ts
@@ -12,6 +12,8 @@ import { DonorEligibilityModule } from '../donor-eligibility/donor-eligibility.m
 import { PolicyCenterModule } from '../policy-center/policy-center.module';
 import { ApprovalModule } from '../approvals/approval.module';
 import { FileMetadataModule } from '../file-metadata/file-metadata.module';
+import { AuthModule } from '../auth/auth.module';
+
 
 import { BloodInventoryQueryService } from './blood-inventory-query.service';
 import { BloodStatusService } from './blood-status.service';
@@ -54,6 +56,7 @@ import { BloodUnitBatchService } from './batch/blood-unit-batch.service';
     NotificationsModule,
     DonorEligibilityModule,
     PolicyCenterModule,
+    AuthModule,
     RegistryModule,
   ],
   controllers: [BloodUnitsController, DispositionController, QuarantineController],

--- a/backend/src/inventory/inventory.module.ts
+++ b/backend/src/inventory/inventory.module.ts
@@ -11,6 +11,8 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { OrderEntity } from '../orders/entities/order.entity';
 import { UsersModule } from '../users/users.module';
 import { InventoryStockRepository } from './repositories/inventory-stock.repository';
+import { OrganizationEntity } from '../organizations/entities/organization.entity';
+
 
 import { InventoryAlertController } from './controllers/inventory-alert.controller';
 import { ExpirationForecastingController } from './controllers/expiration-forecasting.controller';
@@ -22,6 +24,7 @@ import { InventoryEntity } from './entities/inventory.entity';
 import { InventoryStockEntity } from './entities/inventory-stock.entity';
 import { ReservationAuditEntity } from './entities/reservation-audit.entity';
 import { RestockingCampaignEntity } from './entities/restocking-campaign.entity';
+import { ExpirationForecastingService } from './expiration-forecasting.service';
 import { InventoryAnalyticsService } from './inventory-analytics.service';
 import { InventoryEventListener } from './inventory-event.listener';
 import { InventoryForecastingService } from './inventory-forecasting.service';
@@ -45,6 +48,7 @@ import { RestockingCampaignService } from './services/restocking-campaign.servic
       AlertPreferenceEntity,
       RestockingCampaignEntity,
       ReservationAuditEntity,
+      OrganizationEntity,
       BloodUnit,
     ]),
     BullModule.registerQueue({ name: 'donor-outreach' }),
@@ -66,6 +70,7 @@ import { RestockingCampaignService } from './services/restocking-campaign.servic
     InventoryForecastingService,
     InventoryAnalyticsService,
     InventoryEventListener,
+    ExpirationForecastingService,
     DonorOutreachProcessor,
     InventoryAlertService,
     RestockingCampaignService,

--- a/backend/src/maps/maps.module.ts
+++ b/backend/src/maps/maps.module.ts
@@ -6,11 +6,13 @@ import { RedisModule } from '../redis/redis.module';
 import { LiveOpsGateway } from './gateways/live-ops.gateway';
 import { MapsController } from './maps.controller';
 import { MapsService } from './maps.service';
+import { RoutePlanningController } from './controllers/route-planning.controller';
+import { RoutePlanningService } from './services/route-planning.service';
 
 @Module({
   imports: [ConfigModule, RedisModule],
-  controllers: [MapsController],
-  providers: [MapsService, LiveOpsGateway],
-  exports: [MapsService, LiveOpsGateway],
+  controllers: [MapsController, RoutePlanningController],
+  providers: [MapsService, LiveOpsGateway, RoutePlanningService],
+  exports: [MapsService, LiveOpsGateway, RoutePlanningService],
 })
 export class MapsModule {}


### PR DESCRIPTION
- Issue #991: Add AuthModule import to BloodUnitsModule (PermissionsService dependency)
- Issue #990: Add OrganizationEntity to TypeOrmModule.forFeature in InventoryModule
- Issue #989: Add ExpirationForecastingService to providers array in InventoryModule
- Issue #988: Register RoutePlanningController and RoutePlanningService in MapsModule

Closes #991, closes #990, closes #989, closes #988