### PR TITLE
feat: wallet integration, incident runbook, Leaflet SSR guards, and error boundaries

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,143 @@
+# Health-Chain Incident Response Runbook
+
+This runbook covers production failure modes for the Health-Chain Stellar platform. Given the system handles live blood delivery, follow these procedures promptly.
+
+---
+
+## 1. Backend Down
+
+### Detection signals
+- `/health` endpoint returns non-2xx or times out.
+- Frontend shows "Failed to fetch" errors across all pages.
+- Uptime monitor / Grafana dashboard shows HTTP 5xx spike.
+
+### Impact
+All API-dependent features unavailable: orders, dispatch, donor flows, admin console.
+
+### Recovery steps
+1. SSH into the server and check the process: `pm2 status` or `systemctl status health-chain-api`.
+2. Read recent logs: `pm2 logs health-chain-api --lines 200` or `journalctl -u health-chain-api -n 200`.
+3. If OOM or crash loop: `pm2 restart health-chain-api`.
+4. If the latest deploy is suspect: roll back with `git checkout <previous-tag> && npm run build && pm2 restart`.
+5. Confirm recovery by hitting `GET /health` — expect `{ "status": "ok" }`.
+
+---
+
+## 2. Redis Outage
+
+### Detection signals
+- BullMQ job queues stall; no workers picking up jobs.
+- Backend logs show `ECONNREFUSED` to Redis host.
+- Metrics show queue depth growing with zero throughput.
+
+### Impact
+Background jobs pause: SMS notifications, saga step processing, WebSocket broadcast relay.  
+Real-time features degrade; synchronous API calls still work if Redis is only used for queues.
+
+### Recovery steps
+1. Check Redis: `redis-cli -h <host> ping` — expect `PONG`.
+2. Restart Redis if self-hosted: `systemctl restart redis`.
+3. After Redis is healthy, BullMQ workers reconnect automatically.
+4. To drain and replay failed jobs, open the Bull Board dashboard (or run):
+   ```bash
+   # List failed jobs
+   redis-cli -h <host> LRANGE bull:<queue-name>:failed 0 -1
+   # Retry all failed jobs via BullMQ API or Bull Board UI
+   ```
+5. Monitor queue depth in Grafana until it returns to baseline.
+
+---
+
+## 3. PostgreSQL Outage
+
+### Detection signals
+- API returns 500 with `connection refused` or `too many connections` in logs.
+- Grafana shows DB connection pool exhaustion or zero active connections.
+
+### Impact
+All read/write operations fail. The system has no automatic read-only fallback; all order and custody endpoints return errors.
+
+### Recovery steps
+1. Check Postgres: `pg_isready -h <host> -p 5432`.
+2. If connection pool exhausted: identify long-running queries and terminate them:
+   ```sql
+   SELECT pid, now() - query_start AS duration, query
+   FROM pg_stat_activity
+   WHERE state = 'active'
+   ORDER BY duration DESC;
+
+   SELECT pg_terminate_backend(<pid>);
+   ```
+3. Restart Postgres if needed: `systemctl restart postgresql`.
+4. Verify connection pool recovers in backend logs (TypeORM/Prisma reconnect automatically).
+5. If a migration caused the outage, roll it back:
+   ```bash
+   npm run migration:revert
+   ```
+
+---
+
+## 4. Soroban RPC Unavailable
+
+### Detection signals
+- Contract-activity feed shows no new events.
+- Backend logs show `RPC request failed` or timeout against the configured `SOROBAN_RPC_URL`.
+- On-chain features (custody proof, payment settlement) return errors.
+
+### Impact
+Blockchain-dependent features degrade: custody trail anchoring, on-chain payment settlement, contract event indexing. Off-chain CRUD still works.
+
+### Recovery steps
+1. Confirm the outage is external: check the Stellar status page.
+2. Switch to a backup RPC endpoint by updating the environment variable:
+   ```bash
+   # In .env or platform secrets
+   SOROBAN_RPC_URL=https://soroban-testnet.stellar.org   # testnet fallback
+   # or a private Horizon/Soroban node
+   ```
+3. Restart the backend to pick up the new URL.
+4. Once the primary RPC recovers, revert `SOROBAN_RPC_URL` and restart again.
+5. Re-index any missed ledgers by triggering the indexer catch-up job.
+
+---
+
+## 5. Blood Request Stuck in Processing
+
+### Detection signals
+- Order status remains `processing` for more than 10 minutes.
+- Saga orchestrator logs show a step that never emitted its completion event.
+- BullMQ job for the saga is in `active` or `stalled` state.
+
+### Impact
+A hospital's blood request is not fulfilled; a rider is not dispatched. This is a critical patient-safety issue.
+
+### Recovery steps
+1. Identify the stuck order ID from the admin console or database:
+   ```sql
+   SELECT id, status, created_at, saga_state
+   FROM orders
+   WHERE status = 'processing'
+     AND created_at < NOW() - INTERVAL '10 minutes';
+   ```
+2. Inspect the saga state to determine which step is stuck.
+3. To manually advance the saga, emit the missing event via the admin API:
+   ```bash
+   POST /api/v1/admin/orders/:orderId/saga/advance
+   { "step": "<stuck-step-name>" }
+   ```
+4. To cancel the saga and notify the hospital:
+   ```bash
+   POST /api/v1/admin/orders/:orderId/cancel
+   { "reason": "saga timeout — manual cancellation by operator" }
+   ```
+5. Check BullMQ for a stalled job and retry or remove it via Bull Board.
+6. Escalate to engineering if the saga cannot be advanced without a code fix.
+
+---
+
+## Reference Links
+
+- Health endpoint: `GET <API_BASE_URL>/health`
+- Grafana dashboards: _add URL once provisioned_
+- Bull Board (queue UI): `<API_BASE_URL>/admin/queues`
+- Stellar network status: https://status.stellar.org

--- a/frontend/health-chain/app/admin/dashboard/page.tsx
+++ b/frontend/health-chain/app/admin/dashboard/page.tsx
@@ -1,10 +1,18 @@
 "use client";
 import React from "react";
+import dynamic from "next/dynamic";
 import { KPICards } from "@/components/dashboard/KPICards";
-import { LiveOpsMap } from "@/components/dashboard/LiveOpsMap";
 import { InventoryHeatmap } from "@/components/dashboard/InventoryHeatmap";
 import { ActivityFeed } from "@/components/dashboard/ActivityFeed";
 import { useDashboardData } from "@/lib/hooks/useDashboardData";
+
+const LiveOpsMap = dynamic(
+  () => import("@/components/dashboard/LiveOpsMap").then((m) => ({ default: m.LiveOpsMap })),
+  {
+    ssr: false,
+    loading: () => <div className="w-full h-full bg-gray-100 animate-pulse" />,
+  },
+);
 
 export default function AdminDashboardPage() {
   const { data, isConnected } = useDashboardData();

--- a/frontend/health-chain/app/dashboard/error.tsx
+++ b/frontend/health-chain/app/dashboard/error.tsx
@@ -1,0 +1,25 @@
+"use client";
+import React from "react";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <h2 className="text-xl font-bold text-gray-900 mb-2">Dashboard error</h2>
+      <p className="text-sm text-gray-500 mb-6 max-w-sm">
+        {error.message || "An error occurred while loading this page."}
+      </p>
+      <button
+        onClick={reset}
+        className="px-5 py-2 bg-black text-white text-sm font-semibold rounded-xl hover:bg-gray-800 transition"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/health-chain/app/dashboard/live-ops/page.tsx
+++ b/frontend/health-chain/app/dashboard/live-ops/page.tsx
@@ -1,4 +1,9 @@
-import LiveOpsCenter from "@/components/dashboard/LiveOpsCenter";
+import dynamic from "next/dynamic";
+
+const LiveOpsCenter = dynamic(() => import("@/components/dashboard/LiveOpsCenter"), {
+  ssr: false,
+  loading: () => <div className="flex-1 h-96 bg-gray-100 rounded-2xl animate-pulse" />,
+});
 
 export default function LiveOpsPage() {
   return (

--- a/frontend/health-chain/app/dashboard/orders/error.tsx
+++ b/frontend/health-chain/app/dashboard/orders/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+import React from "react";
+
+export default function OrdersError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <h2 className="text-xl font-bold text-gray-900 mb-2">Blood request error</h2>
+      <p className="text-sm text-gray-500 mb-2 max-w-sm">
+        {error.message || "An error occurred in the blood request flow."}
+      </p>
+      <p className="text-xs text-gray-400 mb-6 max-w-sm">
+        If a blood request was in progress, please refresh and check the orders list to confirm its
+        status before retrying.
+      </p>
+      <button
+        onClick={reset}
+        className="px-5 py-2 bg-black text-white text-sm font-semibold rounded-xl hover:bg-gray-800 transition"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/health-chain/app/dashboard/route-deviations/error.tsx
+++ b/frontend/health-chain/app/dashboard/route-deviations/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+import React from "react";
+
+export default function RouteDeviationsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <h2 className="text-xl font-bold text-gray-900 mb-2">Dispatch monitor error</h2>
+      <p className="text-sm text-gray-500 mb-2 max-w-sm">
+        {error.message || "An error occurred in the dispatch monitoring panel."}
+      </p>
+      <p className="text-xs text-gray-400 mb-6 max-w-sm">
+        Route deviation alerts may not be displayed. Check the backend connection and refresh to
+        resume monitoring.
+      </p>
+      <button
+        onClick={reset}
+        className="px-5 py-2 bg-black text-white text-sm font-semibold rounded-xl hover:bg-gray-800 transition"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/health-chain/app/error.tsx
+++ b/frontend/health-chain/app/error.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
+      <div className="max-w-md w-full text-center">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Something went wrong</h2>
+        <p className="text-sm text-gray-500 mb-6">
+          {error.message || "An unexpected error occurred. Please try again."}
+        </p>
+        <button
+          onClick={reset}
+          className="px-6 py-2.5 bg-black text-white text-sm font-semibold rounded-xl hover:bg-gray-800 transition"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/health-chain/app/layout.tsx
+++ b/frontend/health-chain/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { ToastProvider } from "../components/providers/ToastProvider";
 import { ReactQueryProvider } from "../components/providers/ReactQueryProvider";
 import { I18nProvider } from "../components/providers/I18nProvider";
+import { WalletProvider } from "../components/providers/WalletProvider";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -48,7 +49,9 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <I18nProvider>
             <ReactQueryProvider>
-              <ToastProvider>{children}</ToastProvider>
+              <WalletProvider>
+                <ToastProvider>{children}</ToastProvider>
+              </WalletProvider>
             </ReactQueryProvider>
           </I18nProvider>
         </Suspense>

--- a/frontend/health-chain/components/dispatch/RouteDeviationPanel.tsx
+++ b/frontend/health-chain/components/dispatch/RouteDeviationPanel.tsx
@@ -6,7 +6,12 @@ import { useRouteDeviations } from "@/lib/hooks/useRouteDeviations";
 import { useAuthStore } from "@/lib/stores/auth.store";
 import type { RouteDeviationIncident } from "@/lib/types/route-deviation";
 
-import DeviationIncidentCard from "./DeviationIncidentCard";
+import dynamic from "next/dynamic";
+
+const DeviationIncidentCard = dynamic(() => import("./DeviationIncidentCard"), {
+  ssr: false,
+  loading: () => <div className="h-48 bg-gray-100 rounded-2xl animate-pulse" />,
+});
 
 const SEVERITY_ORDER: Record<string, number> = { severe: 0, moderate: 1, minor: 2 };
 

--- a/frontend/health-chain/components/orders/new/BloodBankMap.tsx
+++ b/frontend/health-chain/components/orders/new/BloodBankMap.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef } from "react";
 import { BloodBankAvailability, BloodType, StockLevel } from "@/lib/types/orders";
 
-interface BloodBankMapProps {
+export interface BloodBankMapProps {
   bloodBanks: BloodBankAvailability[];
   hospitalLat: number;
   hospitalLng: number;

--- a/frontend/health-chain/components/orders/new/Step2BloodBankSelection.tsx
+++ b/frontend/health-chain/components/orders/new/Step2BloodBankSelection.tsx
@@ -1,7 +1,16 @@
 import React from "react";
+import dynamic from "next/dynamic";
 import { BloodBankAvailability, BloodType, StockLevel } from "@/lib/types/orders";
-import { BloodBankMap } from "./BloodBankMap";
 import { AlertCircle, Clock, MapPin, RefreshCw } from "lucide-react";
+import type { BloodBankMapProps } from "./BloodBankMap";
+
+const BloodBankMap = dynamic<BloodBankMapProps>(
+  () => import("./BloodBankMap").then((m) => ({ default: m.BloodBankMap })),
+  {
+    ssr: false,
+    loading: () => <div className="w-full h-[300px] rounded-xl bg-gray-100 animate-pulse" />,
+  },
+);
 
 interface Step2Props {
   bloodType: BloodType;

--- a/frontend/health-chain/components/providers/WalletProvider.tsx
+++ b/frontend/health-chain/components/providers/WalletProvider.tsx
@@ -1,0 +1,112 @@
+"use client";
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+interface WalletContextValue {
+  publicKey: string | null;
+  isInstalled: boolean;
+  isConnecting: boolean;
+  connect: () => Promise<void>;
+  sign: (xdr: string) => Promise<string>;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextValue | null>(null);
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
+
+  useEffect(() => {
+    const detect = async () => {
+      try {
+        const freighter = await import("@stellar/freighter-api");
+        const result = await freighter.isConnected();
+        const installed = typeof result === "boolean" ? result : (result as { isConnected: boolean }).isConnected;
+        setIsInstalled(installed);
+        if (installed) {
+          try {
+            const pk = await freighter.getPublicKey();
+            const key = typeof pk === "string" ? pk : (pk as { publicKey?: string }).publicKey;
+            if (key) setPublicKey(key);
+          } catch {
+            // not yet authorised — user hasn't connected yet
+          }
+        }
+      } catch {
+        setIsInstalled(false);
+      }
+    };
+    detect();
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!isInstalled) {
+      setShowInstallPrompt(true);
+      return;
+    }
+    setIsConnecting(true);
+    try {
+      const freighter = await import("@stellar/freighter-api");
+      const access = await freighter.requestAccess();
+      const pk = typeof access === "string" ? access : (access as { publicKey?: string }).publicKey;
+      if (pk) setPublicKey(pk);
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [isInstalled]);
+
+  const sign = useCallback(async (xdr: string): Promise<string> => {
+    const freighter = await import("@stellar/freighter-api");
+    const result = await freighter.signTransaction(xdr);
+    if (typeof result === "string") return result;
+    const r = result as { signedTxXdr?: string; error?: string };
+    if (r.error) throw new Error(r.error);
+    return r.signedTxXdr!;
+  }, []);
+
+  const disconnect = useCallback(() => setPublicKey(null), []);
+
+  return (
+    <WalletContext.Provider value={{ publicKey, isInstalled, isConnecting, connect, sign, disconnect }}>
+      {children}
+      {showInstallPrompt && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Freighter wallet not installed"
+          className="fixed bottom-4 right-4 z-50 bg-white border border-gray-200 rounded-2xl shadow-lg p-4 max-w-xs"
+        >
+          <p className="text-sm font-semibold text-gray-900 mb-1">Freighter not detected</p>
+          <p className="text-xs text-gray-500 mb-3">
+            Install the Freighter browser extension to connect your Stellar wallet and sign
+            Soroban transactions.
+          </p>
+          <div className="flex gap-2">
+            <a
+              href="https://www.freighter.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 text-center px-3 py-2 bg-black text-white text-xs font-semibold rounded-xl hover:bg-gray-800 transition"
+            >
+              Install Freighter
+            </a>
+            <button
+              onClick={() => setShowInstallPrompt(false)}
+              className="px-3 py-2 border border-gray-200 text-gray-600 text-xs rounded-xl hover:bg-gray-50 transition"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet(): WalletContextValue {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used inside <WalletProvider>");
+  return ctx;
+}

--- a/frontend/health-chain/package.json
+++ b/frontend/health-chain/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@stellar/freighter-api": "^3.0.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
     "@types/leaflet": "^1.9.21",


### PR DESCRIPTION
## Summary

- **#1043** — Add `WalletProvider` context (`components/providers/WalletProvider.tsx`) with Freighter detection, `connect()`, `sign(xdr)`, and `publicKey`. Shows an **Install Freighter** prompt when the extension is not detected. Wired into root layout. Adds `@stellar/freighter-api` dependency.
- **#1042** — Add `docs/runbook.md` with operator response procedures for: backend down, Redis outage, PostgreSQL outage, Soroban RPC unavailable, and blood request stuck in saga processing.
- **#1045** — Wrap every Leaflet-using component (`LiveOpsCenter`, `LiveOpsMap`, `BloodBankMap`, `DeviationIncidentCard`/`MiniMap`) in `next/dynamic` with `ssr: false` to eliminate `window is not defined` hydration errors in production.
- **#1044** — Add `app/error.tsx` (root), `app/dashboard/error.tsx`, `app/dashboard/orders/error.tsx`, and `app/dashboard/route-deviations/error.tsx` as Next.js App Router error boundaries so unhandled React errors show a **Try again** recovery UI instead of a blank screen.

## Test plan

- [ ] Install Freighter extension → connect button should call `requestAccess()` and store public key
- [ ] Without Freighter installed → calling `connect()` shows the Install Freighter prompt
- [ ] Navigate to `/dashboard/live-ops`, `/admin/dashboard`, `/dashboard/orders/new`, `/dashboard/route-deviations` — no `window is not defined` errors in server logs or hydration warnings in the browser
- [ ] Trigger an error in a dashboard child component (e.g. throw in dev) → error boundary renders with "Try again" button, clicking it calls `reset()`
- [ ] Verify `docs/runbook.md` renders correctly on GitHub

closes #1043
closes #1042
closes #1045
closes #1044