### PR TITLE
fix(auth): add stricter per-endpoint rate limit to POST /auth/login

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -118,6 +118,7 @@ export class AuthController {
   }
 
   @Public()
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @UseInterceptors(IdempotencyInterceptor)
   @Post('login')
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
## Summary

- Applies `@Throttle({ default: { limit: 5, ttl: 60_000 } })` directly to the `POST /auth/login` handler in `AuthController`, overriding the class-level `auth` throttler (10 req/min) with a tighter 5 req/60 s cap
- Uses the same `ttl` unit (milliseconds) as the rest of the codebase (`THROTTLE_TTL_MS = 60_000`) and matches the pattern already used on `POST /auth/forgot-password`
- No other endpoints are affected

## Test plan

- [ ] `POST /auth/login` now returns HTTP 429 after 5 requests within 60 s from the same IP/account
- [ ] All other auth endpoints still use the class-level `auth` throttler (10 req/min)
- [ ] Existing auth unit tests still pass

Closes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)