### PR TITLE
docs: add contract reference docs, setup guide, Swagger, and architecture diagram

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,39 @@ Thank you for your interest in contributing to HealthDonor Protocol! This guide 
 
 ## Getting Started
 
-### Prerequisites
+### System Dependencies
 
-- **Node.js** >= 18.x
-- **npm** >= 9.x
-- **Rust** and **Cargo** (for Soroban smart contracts)
-- **Docker** and **Docker Compose** (for Postgres and Redis)
+Install these tools before running the project locally:
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **Node.js** | >= 18.x | Backend and frontend runtime |
+| **npm** | >= 9.x | Package manager |
+| **Docker** + **Docker Compose** | latest | PostgreSQL and Redis |
+| **Rust** + **Cargo** | stable (via [rustup](https://rustup.rs)) | Soroban smart contracts |
+| **Stellar CLI** (`stellar`) | >= 21.x | Deploy and invoke Soroban contracts |
+| **wasm32-unknown-unknown** target | — | Cross-compile Rust contracts to WASM |
+
+Install the Rust WASM target after installing Rust:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+Install the Stellar CLI:
+
+```bash
+cargo install --locked stellar-cli
+```
+
+### Expected Service Ports
+
+| Service | Port |
+|---|---|
+| Next.js frontend | `:3000` |
+| NestJS backend | `:3001` |
+| PostgreSQL | `:5432` |
+| Redis | `:6379` |
 
 ### Local Development Setup
 
@@ -20,39 +47,72 @@ Thank you for your interest in contributing to HealthDonor Protocol! This guide 
    cd Health-chain-stellar
    ```
 
-2. **Start infrastructure services:**
+2. **Start infrastructure services (PostgreSQL + Redis):**
 
    ```bash
    docker-compose up -d
    ```
 
-   This starts Postgres and Redis.
+   Verify the containers are running:
+
+   ```bash
+   docker-compose ps
+   ```
 
 3. **Set up the backend:**
 
    ```bash
    cd backend
    cp .env.example .env
-   # Edit .env with your configuration
+   ```
+
+   Open `backend/.env` and configure at minimum:
+
+   ```env
+   DATABASE_NAME=health_chain
+   DATABASE_USERNAME=postgres
+   DATABASE_PASSWORD=         # match your docker-compose config
+   JWT_SECRET=change-me-in-dev
+   JWT_REFRESH_SECRET=change-me-in-dev
+   ```
+
+   Then install dependencies and run database migrations:
+
+   ```bash
    npm install
    npm run migration:run
-   npm run start:dev
+   npm run start:dev          # starts on http://localhost:3001
    ```
+
+   The Swagger UI is available at `http://localhost:3001/docs` once the server is running.
 
 4. **Set up the frontend:**
 
    ```bash
-   cd frontend
+   cd frontend/health-chain
    npm install
-   npm run dev
+   npm run dev                # starts on http://localhost:3000
    ```
 
-5. **Build smart contracts (optional):**
+5. **Build and deploy smart contracts to testnet (optional):**
 
    ```bash
+   # Build the main registry contract
    cd contracts
-   cargo build
+   cargo build --target wasm32-unknown-unknown --release
+
+   # Build the lifebank-soroban suite
+   cd ../lifebank-soroban
+   bash scripts/build-all.sh
+
+   # Set up a Stellar identity for deployment
+   bash scripts/setup-identity.sh
+
+   # Deploy all contracts to testnet
+   bash scripts/deploy-testnet.sh
    ```
+
+   After deployment, copy the printed contract IDs into `backend/.env` under the `*_CONTRACT_ID` variables.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -50,21 +50,47 @@ All critical actions are enforced by smart contracts, reducing fraud and manual 
 
 ## Getting Started
 
-### Local Development Setup
+### Prerequisites
 
-For contributors, we provide a Docker Compose stack for easy local development:
+| Dependency | Version | Purpose |
+|---|---|---|
+| Node.js | >= 18.x | Backend and frontend runtime |
+| Docker + Docker Compose | latest | PostgreSQL (:5432) and Redis (:6379) |
+| Rust + Cargo | stable | Soroban smart contracts |
+| Stellar CLI (`stellar`) | >= 21.x | Deploy and invoke contracts |
+
+### Quick Start
 
 ```bash
-# Start Postgres + Redis
+# 1. Start PostgreSQL and Redis
 docker-compose up -d
 
-# Setup backend
+# 2. Set up the backend
 cd backend
+cp .env.example .env   # edit DATABASE_PASSWORD, JWT_SECRET at minimum
 npm install
-npm run start:dev
+npm run migration:run
+npm run start:dev      # http://localhost:3001 — Swagger UI at /docs
 ```
 
-See [DOCKER_SETUP.md](./DOCKER_SETUP.md) for detailed instructions and optional development tools.
+```bash
+# 3. Set up the frontend (separate terminal)
+cd frontend/health-chain
+npm install
+npm run dev            # http://localhost:3000
+```
+
+For contract deployment, full environment variable reference, and contributor guidelines see **[CONTRIBUTING.md](./CONTRIBUTING.md)**.
+
+### Service Ports
+
+| Service | Port |
+|---|---|
+| Next.js frontend | `:3000` |
+| NestJS backend | `:3001` |
+| Swagger UI | `:3001/docs` |
+| PostgreSQL | `:5432` |
+| Redis | `:6379` |
 
 ## Project Structure
 
@@ -73,3 +99,5 @@ See [DOCKER_SETUP.md](./DOCKER_SETUP.md) for detailed instructions and optional 
 | `backend/` | [Backend README](./backend/README.md) |
 | `contracts/` | [Contracts README](./contracts/README.md) |
 | `lifebank-soroban/` | [Lifebank Soroban README](./lifebank-soroban/README.md) |
+| `docs/contracts/` | [Contract Reference Docs](./docs/contracts/) |
+| `docs/architecture.md` | [Architecture Diagram](./docs/architecture.md) |

--- a/backend/src/anomaly/anomaly.controller.ts
+++ b/backend/src/anomaly/anomaly.controller.ts
@@ -20,6 +20,8 @@ import { AnomalyDriftService, FeatureBaseline } from './anomaly-drift.service';
 import { QueryAnomaliesDto } from './dto/query-anomalies.dto';
 import { ReviewAnomalyDto } from './dto/review-anomaly.dto';
 
+@ApiTags('Anomalies')
+@ApiBearerAuth()
 @Controller('anomalies')
 export class AnomalyController {
   constructor(
@@ -28,18 +30,24 @@ export class AnomalyController {
     private readonly driftService: AnomalyDriftService,
   ) {}
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   @RequirePermissions(Permission.ADMIN_ACCESS)
   findAll(@Query(new ValidationPipe({ transform: true })) query: QueryAnomaliesDto) {
     return this.anomalyService.findAll(query);
   }
 
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.anomalyService.findOne(id);
   }
 
+  @ApiOperation({ summary: 'Patch :id review' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/review')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   review(
@@ -51,6 +59,8 @@ export class AnomalyController {
   }
 
   /** Manually trigger the scoring pipeline (admin use) */
+  @ApiOperation({ summary: 'Post run pipeline' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('run-pipeline')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   async runPipeline() {
@@ -61,6 +71,8 @@ export class AnomalyController {
   // ── Drift detection endpoints ────────────────────────────────────────────
 
   /** Manually trigger drift evaluation for a model version */
+  @ApiOperation({ summary: 'Post drift evaluate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('drift/evaluate')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   async evaluateDrift(@Body() body: { modelVersion?: string }) {
@@ -68,6 +80,8 @@ export class AnomalyController {
   }
 
   /** Register a baseline distribution snapshot */
+  @ApiOperation({ summary: 'Post drift baseline' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('drift/baseline')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   registerBaseline(@Body() baseline: FeatureBaseline) {
@@ -76,6 +90,8 @@ export class AnomalyController {
   }
 
   /** Get drift report for governance/clinical review */
+  @ApiOperation({ summary: 'Get drift report' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('drift/report')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   getDriftReport(@Query('modelVersion') modelVersion?: string) {
@@ -83,6 +99,8 @@ export class AnomalyController {
   }
 
   /** Shadow/canary scoring comparison */
+  @ApiOperation({ summary: 'Post drift shadow compare' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('drift/shadow-compare')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   shadowCompare(

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,19 +1,24 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
 
 import { AppService } from './app.service';
 
+@ApiTags('App')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  /** Custom limit example: tighter than the global 100/min default. */
+  @ApiOperation({ summary: 'Root endpoint' })
+  @ApiResponse({ status: 200, description: 'Returns greeting message' })
   @Throttle({ default: { limit: 50, ttl: 60_000 } })
   @Get()
   getHello(): string {
     return this.appService.getHello();
   }
 
+  @ApiOperation({ summary: 'Health check' })
+  @ApiResponse({ status: 200, description: 'Service health status' })
   @SkipThrottle()
   @Get('health')
   getHealth() {

--- a/backend/src/blockchain/controllers/blockchain.controller.ts
+++ b/backend/src/blockchain/controllers/blockchain.controller.ts
@@ -34,6 +34,8 @@ import type {
   SorobanTxResult,
 } from '../types/soroban-tx.types';
 
+@ApiTags('Blockchain')
+@ApiBearerAuth()
 @Controller('blockchain')
 export class BlockchainController {
   private readonly logger = new Logger(BlockchainController.name);
@@ -57,6 +59,8 @@ export class BlockchainController {
    * @returns Job ID for status tracking
    * @throws 400 if idempotency key already exists (duplicate submission)
    */
+  @ApiOperation({ summary: 'Post submit transaction' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('submit-transaction')
   @HttpCode(HttpStatus.ACCEPTED)
   async submitTransaction(
@@ -118,6 +122,8 @@ export class BlockchainController {
     }
   }
 
+  @ApiOperation({ summary: 'Post webhook callback' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('webhook/callback')
   @HttpCode(HttpStatus.OK)
   async processCallback(
@@ -178,6 +184,8 @@ export class BlockchainController {
    * @returns Queue metrics
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Get queue status' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('queue/status')
   @UseGuards(AdminGuard)
   @RequireAdminScope(AdminScope.READ_METRICS)
@@ -194,6 +202,8 @@ export class BlockchainController {
    * @param jobId - Job ID to check
    * @returns Job status or null if not found
    */
+  @ApiOperation({ summary: 'Get job :jobId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('job/:jobId')
   @HttpCode(HttpStatus.OK)
   async getJobStatus(
@@ -211,6 +221,8 @@ export class BlockchainController {
    * @returns Detailed metrics object
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Get metrics' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('metrics')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
@@ -228,6 +240,8 @@ export class BlockchainController {
    * @returns Plain-text Prometheus metrics
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Get metrics prometheus' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('metrics/prometheus')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
@@ -306,6 +320,8 @@ export class BlockchainController {
    * @returns Replay summary with counts and per-job errors
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Post admin retry failed' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('admin/retry-failed')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
@@ -370,6 +386,8 @@ export class BlockchainController {
    *
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Get admin replay audits' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('admin/replay-audits')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
@@ -388,6 +406,8 @@ export class BlockchainController {
    *
    * @throws 403 if not authenticated as admin
    */
+  @ApiOperation({ summary: 'Get admin health' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('admin/health')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)

--- a/backend/src/blood-matching/controllers/blood-matching.controller.ts
+++ b/backend/src/blood-matching/controllers/blood-matching.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
@@ -24,6 +25,8 @@ import {
   ApiLegacyAdapter,
 } from '../../common/versioning/api-compatibility.decorator';
 
+@ApiTags('Blood Matching')
+@ApiBearerAuth()
 @Controller('blood-matching')
 export class BloodMatchingController {
   constructor(
@@ -32,6 +35,8 @@ export class BloodMatchingController {
   ) {}
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Post match' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('match')
   @HttpCode(HttpStatus.OK)
   findMatches(@Body() request: MatchingRequest): Promise<MatchingResponse> {
@@ -39,6 +44,8 @@ export class BloodMatchingController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Post match multiple' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('match-multiple')
   @HttpCode(HttpStatus.OK)
   findMatchesForMultipleRequests(
@@ -48,12 +55,16 @@ export class BloodMatchingController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get compatibility' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('compatibility')
   getCompatibilityMatrix() {
     return this.matchingService.getCompatibilityMatrix();
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get compatible types' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('compatible-types')
   @ApiCompatibility(ApiCompatibilityClass.DEPRECATED)
   @ApiDeprecation({
@@ -68,6 +79,8 @@ export class BloodMatchingController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get donatable types' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('donatable-types')
   @ApiCompatibility(ApiCompatibilityClass.DEPRECATED)
   @ApiDeprecation({
@@ -82,6 +95,8 @@ export class BloodMatchingController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get calculate score' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('calculate-score')
   calculateMatchingScore(
     @Query('bloodType') bloodType: string,
@@ -99,6 +114,8 @@ export class BloodMatchingController {
 
   /** Admin preview: check compatibility with explanation for a given donor/recipient/component */
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Post preview' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('preview')
   @HttpCode(HttpStatus.OK)
   @ApiCompatibility(ApiCompatibilityClass.STRICT)
@@ -108,6 +125,8 @@ export class BloodMatchingController {
 
   /** Return all compatible donors for a recipient + component */
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get compatible donors' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('compatible-donors')
   @ApiCompatibility(ApiCompatibilityClass.ADDITIVE)
   @ApiDeprecation({

--- a/backend/src/blood-requests/blood-requests.controller.ts
+++ b/backend/src/blood-requests/blood-requests.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -11,6 +12,8 @@ import { GetAvailabilityRequestDto, GetAvailabilityResponseDto } from './dto/get
 import { BloodBankAvailabilityService } from './services/blood-bank-availability.service';
 
 @UseGuards(RoleAwareThrottlerGuard)
+@ApiTags('Blood Requests')
+@ApiBearerAuth()
 @Controller('blood-requests')
 export class BloodRequestsController {
   constructor(
@@ -19,6 +22,8 @@ export class BloodRequestsController {
   ) {}
 
   @RequirePermissions(Permission.CREATE_ORDER)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(
     @Body() dto: CreateBloodRequestDto,
@@ -32,6 +37,8 @@ export class BloodRequestsController {
    * Find nearby blood banks with requested blood type/component
    * Returns ranked list by confidence score (stock, ETA, reliability)
    */
+  @ApiOperation({ summary: 'Get availability' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('availability')
   async getAvailability(
     @Query() query: GetAvailabilityRequestDto,

--- a/backend/src/blood-requests/controllers/order-splitting.controller.ts
+++ b/backend/src/blood-requests/controllers/order-splitting.controller.ts
@@ -15,6 +15,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FulfillmentLegStatus } from '../entities/fulfillment-leg.entity';
 
+@ApiTags('Blood Requests')
+@ApiBearerAuth()
 @Controller('api/v1/orders/split')
 @UseGuards(JwtAuthGuard)
 export class OrderSplittingController {
@@ -24,6 +26,8 @@ export class OrderSplittingController {
     private readonly bloodRequestRepository: Repository<BloodRequestEntity>,
   ) {}
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   async createSplitOrder(@Body() dto: CreateSplitOrderDto) {
     const parentRequest = await this.bloodRequestRepository.findOne({
@@ -40,16 +44,22 @@ export class OrderSplittingController {
     );
   }
 
+  @ApiOperation({ summary: 'Get :parentRequestId progress' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':parentRequestId/progress')
   async getOrderProgress(@Param('parentRequestId') parentRequestId: string) {
     return this.orderSplittingService.getParentOrderProgress(parentRequestId);
   }
 
+  @ApiOperation({ summary: 'Get :parentRequestId legs' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':parentRequestId/legs')
   async getFulfillmentLegs(@Param('parentRequestId') parentRequestId: string) {
     return this.orderSplittingService.getFulfillmentLegs(parentRequestId);
   }
 
+  @ApiOperation({ summary: 'Patch legs :legId status' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('legs/:legId/status')
   async updateLegStatus(
     @Param('legId') legId: string,
@@ -66,6 +76,8 @@ export class OrderSplittingController {
     });
   }
 
+  @ApiOperation({ summary: 'Post legs :legId fail' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('legs/:legId/fail')
   async markLegAsFailed(
     @Param('legId') legId: string,

--- a/backend/src/blood-requests/controllers/request-query.controller.ts
+++ b/backend/src/blood-requests/controllers/request-query.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, Res, Header, UseGuards, HttpStatus, Param } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Response } from 'express';
 
@@ -10,18 +11,24 @@ import { PermissionsGuard } from '../../auth/guards/permissions.guard';
 import { QueryRequestsDto } from '../dto/query-requests.dto';
 import { RequestQueryService } from '../services/request-query.service';
 
+@ApiTags('Blood Requests')
+@ApiBearerAuth()
 @Controller('blood-requests/query')
 @UseGuards(JwtAuthGuard, PermissionsGuard)
 export class RequestQueryController {
   constructor(private readonly queryService: RequestQueryService) {}
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   queryRequests(@Query() queryDto: QueryRequestsDto) {
     return this.queryService.queryRequests(queryDto);
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get statistics' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('statistics')
   getRequestStatistics(
     @Query('hospitalId') hospitalId?: string,
@@ -36,6 +43,8 @@ export class RequestQueryController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get sla compliance' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('sla-compliance')
   getSLAComplianceReport(
     @Query('hospitalId') hospitalId?: string,
@@ -50,6 +59,8 @@ export class RequestQueryController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get export csv' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export/csv')
   async exportToCSV(
     @Query() queryDto: QueryRequestsDto,
@@ -74,6 +85,8 @@ export class RequestQueryController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get export pdf' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export/pdf')
   async exportToPDF(
     @Query() queryDto: QueryRequestsDto,
@@ -98,6 +111,8 @@ export class RequestQueryController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_REQUESTS)
+  @ApiOperation({ summary: 'Get export status :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export/status/:id')
   async getExportStatus(@Param('id') id: string, @User() user: any) {
     // This would typically call a report service directly

--- a/backend/src/blood-units/blood-units.controller.ts
+++ b/backend/src/blood-units/blood-units.controller.ts
@@ -17,7 +17,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiBody, ApiConsumes, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Request } from 'express';
 
@@ -46,6 +46,7 @@ import {
 import { BloodType } from './enums/blood-type.enum';
 import { BloodUnitBatchService } from './batch/blood-unit-batch.service';
 
+@ApiTags('Blood Units')
 @Controller('blood-units')
 export class BloodUnitsController {
   constructor(

--- a/backend/src/blood-units/controllers/disposition.controller.ts
+++ b/backend/src/blood-units/controllers/disposition.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -34,11 +35,15 @@ class RecordDispositionDto {
   coldChainVerified?: boolean;
 }
 
+@ApiTags('Blood Units')
+@ApiBearerAuth()
 @Controller('api/v1/dispositions')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class DispositionController {
   constructor(private readonly dispositionService: DispositionService) {}
 
+  @ApiOperation({ summary: 'Post evaluate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('evaluate')
   @Roles(UserRole.OPERATIONS_STAFF, UserRole.BLOOD_BANK_ADMIN)
   async evaluateFailedDelivery(@Body() dto: EvaluateDispositionDto) {
@@ -50,6 +55,8 @@ export class DispositionController {
     );
   }
 
+  @ApiOperation({ summary: 'Post record' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('record')
   @Roles(UserRole.OPERATIONS_STAFF, UserRole.BLOOD_BANK_ADMIN)
   async recordDisposition(
@@ -68,6 +75,8 @@ export class DispositionController {
     );
   }
 
+  @ApiOperation({ summary: 'Get history :bloodUnitId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('history/:bloodUnitId')
   @Roles(
     UserRole.OPERATIONS_STAFF,

--- a/backend/src/blood-units/controllers/quarantine.controller.ts
+++ b/backend/src/blood-units/controllers/quarantine.controller.ts
@@ -24,11 +24,15 @@ import {
 } from '../dto/quarantine.dto';
 import { QuarantineService } from '../services/quarantine.service';
 
+@ApiTags('Blood Units')
+@ApiBearerAuth()
 @Controller('blood-units/quarantine')
 export class QuarantineController {
   constructor(private readonly quarantineService: QuarantineService) {}
 
   @RequirePermissions(Permission.UPDATE_BLOOD_STATUS)
+  @ApiOperation({ summary: 'Post cases' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('cases')
   async createCase(
     @Body() dto: CreateQuarantineCaseDto,
@@ -38,18 +42,24 @@ export class QuarantineController {
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_STATUS_HISTORY)
+  @ApiOperation({ summary: 'Get cases' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('cases')
   async listCases(@Query() query: QueryQuarantineCasesDto) {
     return this.quarantineService.listCases(query);
   }
 
   @RequirePermissions(Permission.VIEW_BLOOD_STATUS_HISTORY)
+  @ApiOperation({ summary: 'Get cases :caseId recommendation' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('cases/:caseId/recommendation')
   async getRecommendation(@Param('caseId', ParseUUIDPipe) caseId: string) {
     return this.quarantineService.getRecommendedDisposition(caseId);
   }
 
   @RequirePermissions(Permission.UPDATE_BLOOD_STATUS)
+  @ApiOperation({ summary: 'Patch cases :caseId assign reviewer' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('cases/:caseId/assign-reviewer')
   async assignReviewer(
     @Param('caseId', ParseUUIDPipe) caseId: string,
@@ -59,6 +69,8 @@ export class QuarantineController {
   }
 
   @RequirePermissions(Permission.UPDATE_BLOOD_STATUS)
+  @ApiOperation({ summary: 'Patch cases :caseId review' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('cases/:caseId/review')
   async updateReview(
     @Param('caseId', ParseUUIDPipe) caseId: string,
@@ -69,6 +81,8 @@ export class QuarantineController {
   }
 
   @RequirePermissions(Permission.UPDATE_BLOOD_STATUS)
+  @ApiOperation({ summary: 'Patch cases :caseId finalize' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('cases/:caseId/finalize')
   async finalizeCase(
     @Param('caseId', ParseUUIDPipe) caseId: string,

--- a/backend/src/cold-chain/cold-chain.controller.ts
+++ b/backend/src/cold-chain/cold-chain.controller.ts
@@ -1,8 +1,11 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ColdChainService } from './cold-chain.service';
 import { DeliveryTimelineService } from './delivery-timeline.service';
 import { IngestTelemetryDto } from './dto/ingest-telemetry.dto';
 
+@ApiTags('Cold Chain')
+@ApiBearerAuth()
 @Controller('cold-chain')
 export class ColdChainController {
   constructor(
@@ -10,16 +13,22 @@ export class ColdChainController {
     private readonly timelineService: DeliveryTimelineService,
   ) {}
 
+  @ApiOperation({ summary: 'Post telemetry' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('telemetry')
   ingest(@Body() dto: IngestTelemetryDto) {
     return this.coldChainService.ingest(dto);
   }
 
+  @ApiOperation({ summary: 'Get deliveries :deliveryId timeline' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:deliveryId/timeline')
   getTimeline(@Param('deliveryId') deliveryId: string) {
     return this.coldChainService.getTimeline(deliveryId);
   }
 
+  @ApiOperation({ summary: 'Get deliveries :deliveryId compliance' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:deliveryId/compliance')
   getCompliance(@Param('deliveryId') deliveryId: string) {
     return this.coldChainService.getCompliance(deliveryId);
@@ -29,6 +38,8 @@ export class ColdChainController {
    * Unified delivery evidence bundle: correlates cold-chain telemetry
    * with route deviation incidents on a single timeline (Issue #616).
    */
+  @ApiOperation({ summary: 'Get deliveries :deliveryId evidence' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:deliveryId/evidence')
   getEvidenceBundle(
     @Param('deliveryId') deliveryId: string,
@@ -40,6 +51,8 @@ export class ColdChainController {
   /**
    * Re-evaluate the evidence bundle after late-arriving data (Issue #616).
    */
+  @ApiOperation({ summary: 'Post deliveries :deliveryId evidence reevaluate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('deliveries/:deliveryId/evidence/reevaluate')
   reevaluateEvidence(
     @Param('deliveryId') deliveryId: string,

--- a/backend/src/common/errors/error-documentation.controller.ts
+++ b/backend/src/common/errors/error-documentation.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '../../auth/decorators/public.decorator';
 import { ErrorDocumentationGenerator } from './error-documentation.generator';
 import { ErrorDomain, ERROR_CODE_REGISTRY } from './error-taxonomy';
@@ -8,11 +9,15 @@ import { ErrorDomain, ERROR_CODE_REGISTRY } from './error-taxonomy';
  * 
  * Provides API endpoints for error code documentation
  */
+@ApiTags('Errors')
+@ApiBearerAuth()
 @Controller('api/v1/errors')
 export class ErrorDocumentationController {
     /**
      * Get all error codes
      */
+    @ApiOperation({ summary: 'Get codes' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('codes')
     @Public()
     getAllErrorCodes(@Query('domain') domain?: ErrorDomain) {
@@ -31,6 +36,8 @@ export class ErrorDocumentationController {
     /**
      * Get error code details
      */
+    @ApiOperation({ summary: 'Get codes :code' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('codes/:code')
     @Public()
     getErrorCodeDetails(@Query('code') code: string) {
@@ -49,6 +56,8 @@ export class ErrorDocumentationController {
     /**
      * Get error documentation in JSON format
      */
+    @ApiOperation({ summary: 'Get documentation json' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('documentation/json')
     @Public()
     getJSONDocumentation() {
@@ -58,6 +67,8 @@ export class ErrorDocumentationController {
     /**
      * Get error documentation in Markdown format
      */
+    @ApiOperation({ summary: 'Get documentation markdown' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('documentation/markdown')
     @Public()
     getMarkdownDocumentation() {
@@ -70,6 +81,8 @@ export class ErrorDocumentationController {
     /**
      * Get all error domains
      */
+    @ApiOperation({ summary: 'Get domains' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('domains')
     @Public()
     getAllDomains() {

--- a/backend/src/contract-event-indexer/contract-event-indexer.controller.ts
+++ b/backend/src/contract-event-indexer/contract-event-indexer.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { ContractEventIndexerService } from './contract-event-indexer.service';
 import {
@@ -13,41 +14,55 @@ import {
 } from './dto/contract-event.dto';
 import { PoisonEventStatus } from './entities/poison-event.entity';
 
+@ApiTags('Contract Events')
+@ApiBearerAuth()
 @Controller('api/v1/contract-events')
 export class ContractEventIndexerController {
   constructor(private readonly service: ContractEventIndexerService) {}
 
   /** Ingest a single contract event (idempotent — duplicates are silently ignored) */
+  @ApiOperation({ summary: 'Post ingest' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('ingest')
   ingest(@Body() dto: IngestEventDto) {
     return this.service.ingest(dto);
   }
 
   /** Ingest a batch of contract events */
+  @ApiOperation({ summary: 'Post ingest batch' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('ingest/batch')
   ingestBatch(@Body() events: IngestEventDto[]) {
     return this.service.ingestBatch(events);
   }
 
   /** Query indexed contract events with optional filters */
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll(@Query() query: QueryContractEventsDto) {
     return this.service.findAll(query);
   }
 
   /** Get all events for a specific off-chain entity (order, donor, etc.) */
+  @ApiOperation({ summary: 'Get entity :ref' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('entity/:ref')
   findByEntityRef(@Param('ref') ref: string) {
     return this.service.findByEntityRef(ref);
   }
 
   /** Get current indexer cursor positions per domain+projection */
+  @ApiOperation({ summary: 'Get cursors' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('cursors')
   getCursors() {
     return this.service.getCursors();
   }
 
   /** Replay: delete events from a ledger height and reset cursors for re-ingestion */
+  @ApiOperation({ summary: 'Post replay' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('replay')
   replay(@Body() dto: ReplayFromLedgerDto) {
     return this.service.replayFromLedger(dto);
@@ -59,6 +74,8 @@ export class ContractEventIndexerController {
    * Reset cursor(s) to a specific ledger without deleting indexed events.
    * Use when a cursor is corrupted but events are still valid.
    */
+  @ApiOperation({ summary: 'Post cursors reset' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('cursors/reset')
   resetCursor(@Body() dto: CursorResetDto) {
     return this.service.resetCursor(dto);
@@ -68,6 +85,8 @@ export class ContractEventIndexerController {
    * Verify indexed data integrity for a ledger range.
    * Returns event count and any ledger gaps.
    */
+  @ApiOperation({ summary: 'Post verify' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('verify')
   verifyIndexed(@Body() dto: VerifyIndexedDto) {
     return this.service.verifyIndexed(dto);
@@ -76,24 +95,32 @@ export class ContractEventIndexerController {
   // ── Poison-event operator endpoints ──────────────────────────────────
 
   /** List quarantined poison events (optionally filtered by status) */
+  @ApiOperation({ summary: 'Get poison events' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('poison-events')
   getPoisonEvents(@Query('status') status?: PoisonEventStatus) {
     return this.service.getPoisonEvents(status);
   }
 
   /** Quarantine a poison event (called by projection workers on failure) */
+  @ApiOperation({ summary: 'Post poison events quarantine' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('poison-events/quarantine')
   quarantine(@Body() dto: QuarantinePoisonEventDto) {
     return this.service.quarantinePoisonEvent(dto);
   }
 
   /** Operator: mark a poison event as replayed and re-process it */
+  @ApiOperation({ summary: 'Post poison events replay' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('poison-events/replay')
   replayPoison(@Body() dto: ReplayPoisonEventDto) {
     return this.service.replayPoisonEvent(dto);
   }
 
   /** Operator: discard a poison event (no further processing) */
+  @ApiOperation({ summary: 'Post poison events discard' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('poison-events/discard')
   discardPoison(@Body() dto: DiscardPoisonEventDto) {
     return this.service.discardPoisonEvent(dto);

--- a/backend/src/delivery-proof/delivery-proof.controller.ts
+++ b/backend/src/delivery-proof/delivery-proof.controller.ts
@@ -1,14 +1,19 @@
 import { Body, Controller, Get, Param, Post, Query, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 
 import { CreateDeliveryProofDto } from './dto/create-delivery-proof.dto';
 import { DeliveryProofQueryDto } from './dto/delivery-proof-query.dto';
 import { DeliveryProofService } from './delivery-proof.service';
 
+@ApiTags('Delivery Proofs')
+@ApiBearerAuth()
 @Controller('delivery-proofs')
 export class DeliveryProofController {
   constructor(private readonly service: DeliveryProofService) {}
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() dto: CreateDeliveryProofDto) {
     return this.service.create(dto);
@@ -19,6 +24,8 @@ export class DeliveryProofController {
    * Multipart/form-data, max 5MB.
    * Closes #464
    */
+  @ApiOperation({ summary: 'Post :orderId upload' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':orderId/upload')
   @UseInterceptors(FileInterceptor('image'))
   async uploadPhoto(
@@ -29,16 +36,22 @@ export class DeliveryProofController {
   }
 
 
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   getOne(@Param('id') id: string) {
     return this.service.getDeliveryProof(id);
   }
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   query(@Query() query: DeliveryProofQueryDto) {
     return this.service.queryProofs(query);
   }
 
+  @ApiOperation({ summary: 'Get rider :riderId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('rider/:riderId')
   byRider(
     @Param('riderId') riderId: string,
@@ -47,6 +60,8 @@ export class DeliveryProofController {
     return this.service.getProofsByRider(riderId, query);
   }
 
+  @ApiOperation({ summary: 'Get request :requestId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('request/:requestId')
   byRequest(
     @Param('requestId') requestId: string,
@@ -55,6 +70,8 @@ export class DeliveryProofController {
     return this.service.getProofsByRequest(requestId, query);
   }
 
+  @ApiOperation({ summary: 'Get rider :riderId statistics' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('rider/:riderId/statistics')
   statistics(
     @Param('riderId') riderId: string,

--- a/backend/src/dispatch/dispatch.controller.ts
+++ b/backend/src/dispatch/dispatch.controller.ts
@@ -17,41 +17,55 @@ import { Permission } from '../auth/enums/permission.enum';
 import { DispatchService } from './dispatch.service';
 import { CreateDispatchDto, UpdateDispatchDto, CancelDispatchDto } from './dto/dispatch.dto';
 
+@ApiTags('Dispatch')
+@ApiBearerAuth()
 @Controller('dispatch')
 export class DispatchController {
   constructor(private readonly dispatchService: DispatchService) {}
 
   @RequirePermissions(Permission.VIEW_DISPATCH)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll() {
     return this.dispatchService.findAll();
   }
 
   @RequirePermissions(Permission.VIEW_DISPATCH)
+  @ApiOperation({ summary: 'Get stats' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('stats')
   getStats() {
     return this.dispatchService.getDispatchStats();
   }
 
   @RequirePermissions(Permission.VIEW_DISPATCH)
+  @ApiOperation({ summary: 'Get assignments' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('assignments')
   getAssignments(@Query('orderId') orderId?: string) {
     return this.dispatchService.getAssignmentLogs(orderId);
   }
 
   @RequirePermissions(Permission.VIEW_DISPATCH)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.dispatchService.findOne(id);
   }
 
   @RequirePermissions(Permission.CREATE_DISPATCH)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() dto: CreateDispatchDto) {
     return this.dispatchService.create(dto);
   }
 
   @RequirePermissions(Permission.DISPATCH_OVERRIDE)
+  @ApiOperation({ summary: 'Post assign' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('assign')
   assignOrder(
     @Body('orderId') orderId: string,
@@ -61,6 +75,8 @@ export class DispatchController {
   }
 
   @RequirePermissions(Permission.MANAGE_DISPATCH)
+  @ApiOperation({ summary: 'Post assignments respond' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('assignments/respond')
   respondToAssignment(
     @Body('orderId') orderId: string,
@@ -71,24 +87,32 @@ export class DispatchController {
   }
 
   @RequirePermissions(Permission.UPDATE_DISPATCH)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(@Param('id') id: string, @Body() dto: UpdateDispatchDto) {
     return this.dispatchService.update(id, dto);
   }
 
   @RequirePermissions(Permission.UPDATE_DISPATCH)
+  @ApiOperation({ summary: 'Patch :id complete' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/complete')
   completeDispatch(@Param('id') id: string) {
     return this.dispatchService.completeDispatch(id);
   }
 
   @RequirePermissions(Permission.UPDATE_DISPATCH)
+  @ApiOperation({ summary: 'Patch :id cancel' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/cancel')
   cancelDispatch(@Param('id') id: string, @Body() dto: CancelDispatchDto) {
     return this.dispatchService.cancelDispatch(id, dto.reason);
   }
 
   @RequirePermissions(Permission.DELETE_DISPATCH)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {

--- a/backend/src/disputes/disputes.controller.ts
+++ b/backend/src/disputes/disputes.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Patch, Post, Query, Res, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { User } from '../auth/decorators/user.decorator';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
@@ -9,16 +10,22 @@ import { DisputesService } from './disputes.service';
 import { AddNoteDto, AssignDisputeDto, OpenDisputeDto, ResolveDisputeDto } from './dto/dispute.dto';
 import { DisputeSeverity, DisputeStatus } from './enums/dispute.enum';
 
+@ApiTags('Disputes')
+@ApiBearerAuth()
 @Controller('disputes')
 @UseGuards(JwtAuthGuard, PermissionsGuard)
 export class DisputesController {
   constructor(private readonly service: DisputesService) {}
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   open(@Body() dto: OpenDisputeDto, @User('id') userId: string) {
     return this.service.open(dto, userId);
   }
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   list(
@@ -32,6 +39,8 @@ export class DisputesController {
   }
 
   @RequirePermissions(Permission.EXPORT_DISPUTES)
+  @ApiOperation({ summary: 'Get export' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export')
   async export(
     @Res() res: Response,
@@ -42,6 +51,8 @@ export class DisputesController {
     return this.service.streamCsvExport(res, { status, from, to });
   }
 
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   get(@Param('id') id: string) {
@@ -50,6 +61,8 @@ export class DisputesController {
 
   @Auditable({ action: 'dispute.assigned', resourceType: 'Dispute' })
   @UseInterceptors(AuditLogInterceptor)
+  @ApiOperation({ summary: 'Patch :id assign' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/assign')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   assign(@Param('id') id: string, @Body() dto: AssignDisputeDto) {
@@ -58,24 +71,32 @@ export class DisputesController {
 
   @Auditable({ action: 'dispute.resolved', resourceType: 'Dispute' })
   @UseInterceptors(AuditLogInterceptor)
+  @ApiOperation({ summary: 'Patch :id resolve' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/resolve')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   resolve(@Param('id') id: string, @Body() dto: ResolveDisputeDto) {
     return this.service.resolve(id, dto);
   }
 
+  @ApiOperation({ summary: 'Post :id notes' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/notes')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   addNote(@Param('id') id: string, @Body() dto: AddNoteDto, @User('id') userId: string) {
     return this.service.addNote(id, dto.content, userId);
   }
 
+  @ApiOperation({ summary: 'Get :id notes' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/notes')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   getNotes(@Param('id') id: string) {
     return this.service.getNotes(id);
   }
 
+  @ApiOperation({ summary: 'Post :id evidence' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/evidence')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
   addEvidence(@Param('id') id: string, @Body() body: { type: string; url: string }) {

--- a/backend/src/donor-eligibility/donor-eligibility.controller.ts
+++ b/backend/src/donor-eligibility/donor-eligibility.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { User } from '../auth/decorators/user.decorator';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -6,38 +7,52 @@ import { DonorEligibilityService } from './donor-eligibility.service';
 import { CreateDeferralDto, OverrideDeferralDto, SimulateEligibilityDto } from './dto/create-deferral.dto';
 import { EligibilityRuleVersionEntity } from './entities/eligibility-rule-version.entity';
 
+@ApiTags('Donor Eligibility')
+@ApiBearerAuth()
 @Controller('donor-eligibility')
 export class DonorEligibilityController {
   constructor(private readonly service: DonorEligibilityService) {}
 
+  @ApiOperation({ summary: 'Get :donorId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':donorId')
   checkEligibility(@Param('donorId') donorId: string) {
     return this.service.checkEligibility(donorId);
   }
 
+  @ApiOperation({ summary: 'Get :donorId deferrals' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':donorId/deferrals')
   getDeferrals(@Param('donorId') donorId: string) {
     return this.service.getDeferrals(donorId);
   }
 
+  @ApiOperation({ summary: 'Post deferrals' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('deferrals')
   createDeferral(@Body() dto: CreateDeferralDto, @User('id') userId: string) {
     return this.service.createDeferral(dto, userId);
   }
 
   /** Override deferral — requires approver identity and mandatory reason */
+  @ApiOperation({ summary: 'Post deferrals override' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('deferrals/override')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   overrideDeferral(@Body() dto: OverrideDeferralDto, @User('id') approverId: string) {
     return this.service.overrideDeferral(dto, approverId);
   }
 
+  @ApiOperation({ summary: 'Delete deferrals :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete('deferrals/:id')
   revokeDeferral(@Param('id') id: string) {
     return this.service.revokeDeferral(id);
   }
 
   /** Simulate eligibility decision for prospective policy changes */
+  @ApiOperation({ summary: 'Post simulate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('simulate')
   simulateEligibility(@Body() dto: SimulateEligibilityDto) {
     return this.service.simulateEligibility(dto);
@@ -45,12 +60,16 @@ export class DonorEligibilityController {
 
   // ── Rule version management ──────────────────────────────────────────────
 
+  @ApiOperation({ summary: 'Get rules versions' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('rules/versions')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   listRuleVersions(@Query('ruleKey') ruleKey?: string) {
     return this.service.listRuleVersions(ruleKey);
   }
 
+  @ApiOperation({ summary: 'Post rules versions' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('rules/versions')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   createRuleVersion(@Body() body: Partial<EligibilityRuleVersionEntity>, @User('id') userId: string) {

--- a/backend/src/escalation/escalation.controller.ts
+++ b/backend/src/escalation/escalation.controller.ts
@@ -12,10 +12,14 @@ import { EscalationService } from './escalation.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @UseGuards(JwtAuthGuard)
+@ApiTags('Escalations')
+@ApiBearerAuth()
 @Controller('api/v1/escalations')
 export class EscalationController {
   constructor(private readonly escalationService: EscalationService) {}
 
+  @ApiOperation({ summary: 'Get open' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('open')
   getOpen(@Request() req: any) {
     return this.escalationService.findOpen({
@@ -25,6 +29,8 @@ export class EscalationController {
     });
   }
 
+  @ApiOperation({ summary: 'Get request :requestId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('request/:requestId')
   getByRequest(@Param('requestId') requestId: string, @Request() req: any) {
     return this.escalationService.findByRequest(requestId, {
@@ -34,6 +40,8 @@ export class EscalationController {
     });
   }
 
+  @ApiOperation({ summary: 'Post :id acknowledge' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/acknowledge')
   acknowledge(@Param('id') id: string, @Request() req: any) {
     return this.escalationService.acknowledge(id, {
@@ -43,6 +51,8 @@ export class EscalationController {
     });
   }
 
+  @ApiOperation({ summary: 'Get timeline' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('timeline')
   getTimeline(
     @Query('requestId') requestId?: string,
@@ -60,6 +70,8 @@ export class EscalationController {
     });
   }
 
+  @ApiOperation({ summary: 'Post :id links' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/links')
   addLinks(
     @Param('id') id: string,

--- a/backend/src/events/dead-letter.controller.ts
+++ b/backend/src/events/dead-letter.controller.ts
@@ -15,6 +15,8 @@ import {
 } from './canonical-event.envelope';
 import { CanonicalEventEmitterService } from './canonical-event-emitter.service';
 
+@ApiTags('Events')
+@ApiBearerAuth()
 @Controller('api/v1/dead-letter')
 export class DeadLetterController {
     constructor(
@@ -25,6 +27,8 @@ export class DeadLetterController {
     /**
      * Query dead-letter events
      */
+    @ApiOperation({ summary: 'Get' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get()
     async queryDeadLetters(
         @Query('eventTypes') eventTypes?: string,
@@ -57,6 +61,8 @@ export class DeadLetterController {
     /**
      * Get dead-letter statistics
      */
+    @ApiOperation({ summary: 'Get statistics' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('statistics')
     async getStatistics(
         @Query('startTime') startTime?: string,
@@ -71,6 +77,8 @@ export class DeadLetterController {
     /**
      * Get a specific dead-letter event
      */
+    @ApiOperation({ summary: 'Get :id' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get(':id')
     async getDeadLetter(@Param('id') id: string) {
         const events = await this.deadLetterService.queryDeadLetters({
@@ -82,6 +90,8 @@ export class DeadLetterController {
     /**
      * Replay dead-letter events
      */
+    @ApiOperation({ summary: 'Post replay' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post('replay')
     async replayDeadLetters(@Body() request: ReplayRequest) {
         return this.deadLetterService.replayDeadLetters(
@@ -96,6 +106,8 @@ export class DeadLetterController {
     /**
      * Purge old dead-letter events
      */
+    @ApiOperation({ summary: 'Delete purge' })
+    @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
     @Delete('purge')
     async purgeOldEvents(@Query('olderThanDays') olderThanDays: string) {
         const days = parseInt(olderThanDays, 10) || 30;

--- a/backend/src/events/outbox.controller.ts
+++ b/backend/src/events/outbox.controller.ts
@@ -1,19 +1,26 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DeadLetterStatus } from './outbox-dead-letter.entity';
 import { OutboxService } from './outbox.service';
 
+@ApiTags('Events')
+@ApiBearerAuth()
 @Controller('api/v1/outbox')
 export class OutboxController {
   constructor(private readonly outboxService: OutboxService) {}
 
   /** List dead-lettered events (optionally filtered by status) */
+  @ApiOperation({ summary: 'Get dead letters' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('dead-letters')
   getDeadLetters(@Query('status') status?: DeadLetterStatus) {
     return this.outboxService.getDeadLetters(status);
   }
 
   /** Operator: replay a dead-lettered event */
+  @ApiOperation({ summary: 'Post dead letters :id replay' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('dead-letters/:id/replay')
   replayDeadLetter(
     @Param('id') id: string,
@@ -23,6 +30,8 @@ export class OutboxController {
   }
 
   /** Operator: discard a dead-lettered event */
+  @ApiOperation({ summary: 'Post dead letters :id discard' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('dead-letters/:id/discard')
   discardDeadLetter(
     @Param('id') id: string,

--- a/backend/src/fee-correction/fee-correction.controller.ts
+++ b/backend/src/fee-correction/fee-correction.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PermissionsGuard } from '../auth/guards/permissions.guard';
@@ -24,6 +25,8 @@ import {
   InitiateFeeCorrectionDto,
 } from './dto/fee-correction.dto';
 
+@ApiTags('Fee Corrections')
+@ApiBearerAuth()
 @Controller('fee-corrections')
 @UseGuards(JwtAuthGuard, PermissionsGuard)
 export class FeeCorrectionController {
@@ -38,6 +41,8 @@ export class FeeCorrectionController {
    * Idempotent: re-submitting with the same idempotencyKey returns the
    * existing run without creating a duplicate.
    */
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async initiate(
@@ -54,6 +59,8 @@ export class FeeCorrectionController {
    * Execution is asynchronous — the response returns immediately with
    * the run in RUNNING status.
    */
+  @ApiOperation({ summary: 'Post :id execute' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/execute')
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async execute(
@@ -67,6 +74,8 @@ export class FeeCorrectionController {
   /**
    * List all correction runs with optional status filter and pagination.
    */
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async listRuns(
@@ -80,6 +89,8 @@ export class FeeCorrectionController {
   /**
    * Get a single correction run by ID.
    */
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async getRun(@Param('id', ParseUUIDPipe) id: string) {
@@ -89,6 +100,8 @@ export class FeeCorrectionController {
   /**
    * List adjustment entries for a run, order, or status.
    */
+  @ApiOperation({ summary: 'Get entries' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('entries')
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async listEntries(
@@ -102,6 +115,8 @@ export class FeeCorrectionController {
    * Get the full fee adjustment history for a specific order.
    * Useful for auditing and reconciliation views.
    */
+  @ApiOperation({ summary: 'Get orders :orderId fee history' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('orders/:orderId/fee-history')
   @RequirePermissions(Permission.VIEW_FEE_POLICIES)
   async getOrderFeeHistory(@Param('orderId', ParseUUIDPipe) orderId: string) {
@@ -112,6 +127,8 @@ export class FeeCorrectionController {
    * Verify that re-running the correction with the same inputs produces
    * the same audit hashes (reproducibility check).
    */
+  @ApiOperation({ summary: 'Get :id verify reproducibility' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/verify-reproducibility')
   @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
   async verifyReproducibility(@Param('id', ParseUUIDPipe) id: string) {

--- a/backend/src/fee-policy/fee-policy.controller.ts
+++ b/backend/src/fee-policy/fee-policy.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, Get, Put, Delete, Param, HttpCode, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
 
@@ -7,6 +8,8 @@ import { FeePolicyAnalyzerService } from './fee-policy-analyzer.service';
 import { FeePolicyRolloutService } from './fee-policy-rollout.service';
 import { CreateFeePolicyDto, UpdateFeePolicyDto, FeePreviewDto, FeeBreakdownDto } from './dto/fee-policy.dto';
 
+@ApiTags('Fee Policy')
+@ApiBearerAuth()
 @Controller('fee-policy')
 export class FeePolicyController {
     constructor(
@@ -16,36 +19,48 @@ export class FeePolicyController {
     ) { }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post()
     create(@Body() createFeePolicyDto: CreateFeePolicyDto) {
         return this.feePolicyService.create(createFeePolicyDto);
     }
 
     @RequirePermissions(Permission.VIEW_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get()
     findAll() {
         return this.feePolicyService.findAll();
     }
 
     @RequirePermissions(Permission.VIEW_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get preview' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('preview')
     previewFees(@Body() previewDto: FeePreviewDto): Promise<FeeBreakdownDto> {
         return this.feePolicyService.previewFees(previewDto);
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get :id' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get(':id')
     findOne(@Param('id', ParseUUIDPipe) id: string) {
         return this.feePolicyService.findOne(id);
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Put :id' })
+    @ApiResponse({ status: 200, description: 'Resource updated successfully' })
     @Put(':id')
     update(@Param('id', ParseUUIDPipe) id: string, @Body() updateFeePolicyDto: UpdateFeePolicyDto) {
         return this.feePolicyService.update(id, updateFeePolicyDto);
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Delete :id' })
+    @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
     @Delete(':id')
     @HttpCode(HttpStatus.NO_CONTENT)
     remove(@Param('id', ParseUUIDPipe) id: string) {
@@ -53,18 +68,24 @@ export class FeePolicyController {
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get analysis conflicts' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('analysis/conflicts')
     analyzeConflicts() {
         return this.feePolicyAnalyzerService.analyzeConflicts();
     }
 
     @RequirePermissions(Permission.VIEW_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post dry run' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post('dry-run')
     dryRunCalculation(@Body() previewDto: FeePreviewDto) {
         return this.feePolicyAnalyzerService.dryRunCalculation(previewDto);
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post :id validate activation' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post(':id/validate-activation')
     validatePolicyForActivation(@Param('id', ParseUUIDPipe) id: string) {
         return this.feePolicyService.findOne(id).then(policy =>
@@ -73,6 +94,8 @@ export class FeePolicyController {
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post :id canary start' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post(':id/canary/start')
     startCanaryDeployment(
         @Param('id', ParseUUIDPipe) id: string,
@@ -86,24 +109,32 @@ export class FeePolicyController {
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post :id canary promote' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post(':id/canary/promote')
     promoteCanary(@Param('id', ParseUUIDPipe) id: string) {
         return this.feePolicyRolloutService.promoteCanary(id);
     }
 
     @RequirePermissions(Permission.MANAGE_FEE_POLICIES)
+    @ApiOperation({ summary: 'Post :id canary rollback' })
+    @ApiResponse({ status: 201, description: 'Resource created successfully' })
     @Post(':id/canary/rollback')
     rollbackCanary(@Param('id', ParseUUIDPipe) id: string) {
         return this.feePolicyRolloutService.rollbackCanary(id);
     }
 
     @RequirePermissions(Permission.VIEW_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get :id canary metrics' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get(':id/canary/metrics')
     getCanaryMetrics(@Param('id', ParseUUIDPipe) id: string) {
         return this.feePolicyRolloutService.getCanaryMetrics(id);
     }
 
     @RequirePermissions(Permission.VIEW_FEE_POLICIES)
+    @ApiOperation({ summary: 'Get canary active' })
+    @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
     @Get('canary/active')
     getActiveCanaries() {
         return this.feePolicyRolloutService.getActiveCanaries();

--- a/backend/src/hospitals/hospitals.controller.ts
+++ b/backend/src/hospitals/hospitals.controller.ts
@@ -26,6 +26,8 @@ import { OverrideReason } from './enums/override-reason.enum';
 import { HospitalIntakeWindowService } from './services/hospital-intake-window.service';
 import { HospitalsService } from './hospitals.service';
 
+@ApiTags('Hospitals')
+@ApiBearerAuth()
 @Controller('hospitals')
 export class HospitalsController {
   constructor(
@@ -36,12 +38,16 @@ export class HospitalsController {
   // ── Core CRUD ─────────────────────────────────────────────────────────────
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll() {
     return this.hospitalsService.findAll();
   }
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @ApiOperation({ summary: 'Get nearby' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('nearby')
   getNearby(
     @Query('latitude') latitude: string,
@@ -56,24 +62,32 @@ export class HospitalsController {
   }
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.hospitalsService.findOne(id);
   }
 
   @RequirePermissions(Permission.CREATE_HOSPITAL)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() dto: CreateHospitalDto) {
     return this.hospitalsService.create(dto);
   }
 
   @RequirePermissions(Permission.UPDATE_HOSPITAL)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(@Param('id') id: string, @Body() dto: UpdateHospitalDto) {
     return this.hospitalsService.update(id, dto);
   }
 
   @RequirePermissions(Permission.DELETE_HOSPITAL)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {
@@ -83,6 +97,8 @@ export class HospitalsController {
   // ── Capacity config ───────────────────────────────────────────────────────
 
   @RequirePermissions(Permission.UPDATE_HOSPITAL)
+  @ApiOperation({ summary: 'Post :id capacity config' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/capacity-config')
   upsertCapacityConfig(
     @Param('id') id: string,
@@ -92,6 +108,8 @@ export class HospitalsController {
   }
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @ApiOperation({ summary: 'Get :id capacity config' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/capacity-config')
   getCapacityConfig(@Param('id') id: string) {
     return this.hospitalsService.getCapacityConfig(id);
@@ -100,6 +118,8 @@ export class HospitalsController {
   // ── Intake window checks ──────────────────────────────────────────────────
 
   @RequirePermissions(Permission.VIEW_HOSPITALS)
+  @ApiOperation({ summary: 'Post intake check' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('intake-check')
   checkIntakeWindow(@Body() dto: IntakeWindowCheckDto) {
     return this.intakeWindowService.checkIntakeWindow(
@@ -112,6 +132,8 @@ export class HospitalsController {
   // ── Emergency overrides ───────────────────────────────────────────────────
 
   @RequirePermissions(Permission.MANAGE_HOSPITAL_OVERRIDES)
+  @ApiOperation({ summary: 'Post override' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('override')
   async requestOverride(
     @Body() dto: RequestEmergencyOverrideDto,
@@ -149,6 +171,8 @@ export class HospitalsController {
   }
 
   @RequirePermissions(Permission.VIEW_HOSPITAL_OVERRIDES)
+  @ApiOperation({ summary: 'Get :id overrides' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/overrides')
   getOverrideAuditLog(@Param('id') id: string, @Query('limit') limit?: string) {
     return this.intakeWindowService.getOverrideAuditLog(

--- a/backend/src/incident-reviews/incident-reviews.controller.ts
+++ b/backend/src/incident-reviews/incident-reviews.controller.ts
@@ -21,16 +21,22 @@ import { CompleteCorrectiveActionDto } from './dto/complete-corrective-action.dt
 import { VerifyCorrectiveActionDto } from './dto/verify-corrective-action.dto';
 import { IncidentReviewsService } from './incident-reviews.service';
 
+@ApiTags('Incident Reviews')
+@ApiBearerAuth()
 @Controller('incident-reviews')
 export class IncidentReviewsController {
   constructor(private readonly service: IncidentReviewsService) { }
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   @RequirePermissions(Permission.CREATE_INCIDENT_REVIEW)
   create(@Body() dto: CreateIncidentReviewDto, @Request() req: any) {
     return this.service.create(dto, req.user?.id ?? req.user?.sub ?? 'unknown');
   }
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   findAll(
@@ -45,6 +51,8 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Get stats' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('stats')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   getStats(
@@ -67,6 +75,8 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Get dashboard open risk' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('dashboard/open-risk')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   getOpenRiskDashboard(@Request() req: any) {
@@ -77,6 +87,8 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Get dashboard action completion rates' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('dashboard/action-completion-rates')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   getActionCompletionRates(
@@ -95,6 +107,8 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   findOne(@Param('id') id: string, @Request() req: any) {
@@ -105,18 +119,24 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Get :id corrective actions' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/corrective-actions')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   getCorrectiveActions(@Param('id') id: string) {
     return this.service.getCorrectiveActions(id);
   }
 
+  @ApiOperation({ summary: 'Get :id evidence links' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/evidence-links')
   @RequirePermissions(Permission.VIEW_INCIDENT_REVIEWS)
   getEvidenceLinks(@Param('id') id: string) {
     return this.service.getEvidenceLinks(id);
   }
 
+  @ApiOperation({ summary: 'Post :id corrective actions' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/corrective-actions')
   @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
   addCorrectiveAction(
@@ -131,6 +151,8 @@ export class IncidentReviewsController {
     });
   }
 
+  @ApiOperation({ summary: 'Patch corrective actions :actionId complete' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('corrective-actions/:actionId/complete')
   @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
   completeCorrectiveAction(
@@ -145,6 +167,8 @@ export class IncidentReviewsController {
     );
   }
 
+  @ApiOperation({ summary: 'Patch corrective actions :actionId verify' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('corrective-actions/:actionId/verify')
   @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
   verifyCorrectiveAction(
@@ -159,6 +183,8 @@ export class IncidentReviewsController {
     );
   }
 
+  @ApiOperation({ summary: 'Post :id validate closure' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/validate-closure')
   @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
   validateClosure(@Param('id') id: string, @Request() req: any) {
@@ -173,6 +199,8 @@ export class IncidentReviewsController {
     );
   }
 
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   @RequirePermissions(Permission.MANAGE_INCIDENT_REVIEWS)
   update(@Param('id') id: string, @Body() dto: UpdateIncidentReviewDto, @Request() req: any) {

--- a/backend/src/inventory/controllers/expiration-forecasting.controller.ts
+++ b/backend/src/inventory/controllers/expiration-forecasting.controller.ts
@@ -1,14 +1,19 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
 
 import { ExpirationForecastingService } from './expiration-forecasting.service';
 
+@ApiTags('Inventory')
+@ApiBearerAuth()
 @Controller('inventory/expiration')
 export class ExpirationForecastingController {
   constructor(private readonly service: ExpirationForecastingService) {}
 
+  @ApiOperation({ summary: 'Get forecast' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('forecast')
   @RequirePermissions(Permission.VIEW_INVENTORY)
   getForecast(@Query('horizonHours') horizonHours?: string) {
@@ -17,6 +22,8 @@ export class ExpirationForecastingController {
     );
   }
 
+  @ApiOperation({ summary: 'Get rebalancing' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('rebalancing')
   @RequirePermissions(Permission.VIEW_INVENTORY)
   getRebalancing() {

--- a/backend/src/inventory/controllers/inventory-alert.controller.ts
+++ b/backend/src/inventory/controllers/inventory-alert.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
@@ -23,11 +24,15 @@ import {
   ResolveAlertParams,
 } from '../services/inventory-alert.service';
 
+@ApiTags('Inventory')
+@ApiBearerAuth()
 @Controller('inventory/alerts')
 export class InventoryAlertController {
   constructor(private readonly alertService: InventoryAlertService) {}
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   getAlerts(
     @Query('bloodBankId') bloodBankId?: string,
@@ -50,18 +55,24 @@ export class InventoryAlertController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get stats' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('stats')
   getAlertStats(@Query('bloodBankId') bloodBankId?: string) {
     return this.alertService.getAlertStats(bloodBankId);
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   getAlertById(@Param('id') id: string) {
     return this.alertService.getAlertById(id);
   }
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Post :id dismiss' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/dismiss')
   @HttpCode(HttpStatus.OK)
   dismissAlert(@Param('id') id: string, @Request() req: any) {
@@ -73,6 +84,8 @@ export class InventoryAlertController {
   }
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Post :id resolve' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/resolve')
   @HttpCode(HttpStatus.OK)
   resolveAlert(@Param('id') id: string, @Request() req: any) {
@@ -84,12 +97,16 @@ export class InventoryAlertController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get preferences :organizationId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('preferences/:organizationId')
   getAlertPreferences(@Param('organizationId') organizationId: string) {
     return this.alertService.getAlertPreferences(organizationId);
   }
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Post preferences :organizationId' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('preferences/:organizationId')
   @HttpCode(HttpStatus.OK)
   updateAlertPreferences(

--- a/backend/src/inventory/controllers/inventory-analytics.controller.ts
+++ b/backend/src/inventory/controllers/inventory-analytics.controller.ts
@@ -1,44 +1,59 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { InventoryAnalyticsService } from '../inventory-analytics.service';
 
+@ApiTags('Inventory')
+@ApiBearerAuth()
 @Controller('inventory/analytics')
 export class InventoryAnalyticsController {
   constructor(private readonly analyticsService: InventoryAnalyticsService) {}
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get snapshot' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('snapshot')
   getSnapshot() {
     return this.analyticsService.getSnapshot();
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get turnover' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('turnover')
   getTurnoverRates(@Query('periodDays') periodDays = '30') {
     return this.analyticsService.getTurnoverRates(parseInt(periodDays, 10));
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get wastage' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('wastage')
   getWastage(@Query('periodDays') periodDays = '30') {
     return this.analyticsService.getWastageTracking(parseInt(periodDays, 10));
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get expiration' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('expiration')
   getExpirationAnalytics() {
     return this.analyticsService.getExpirationAnalytics();
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get type distribution' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('type-distribution')
   getTypeDistribution() {
     return this.analyticsService.getTypeDistribution();
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get shortage predictions' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('shortage-predictions')
   getShortagePredictions(@Query('periodDays') periodDays = '7') {
     return this.analyticsService.getShortagePredictions(
@@ -47,6 +62,8 @@ export class InventoryAnalyticsController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get trends' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('trends')
   getTrends(@Query('days') days = '14') {
     return this.analyticsService.getTrendAnalysis(parseInt(days, 10));

--- a/backend/src/inventory/controllers/restocking-campaign.controller.ts
+++ b/backend/src/inventory/controllers/restocking-campaign.controller.ts
@@ -1,27 +1,36 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { CreateCampaignDto } from '../dto/create-campaign.dto';
 import { RestockingCampaignService } from '../services/restocking-campaign.service';
 
+@ApiTags('Inventory')
+@ApiBearerAuth()
 @Controller('inventory/campaigns')
 export class RestockingCampaignController {
   constructor(private readonly campaignService: RestockingCampaignService) {}
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() dto: CreateCampaignDto) {
     return this.campaignService.createCampaign(dto);
   }
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   list(@Query('bloodBankId') bloodBankId?: string) {
     return this.campaignService.listCampaigns(bloodBankId);
   }
 
   @RequirePermissions(Permission.MANAGE_INVENTORY)
+  @ApiOperation({ summary: 'Post :id convert' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/convert')
   recordConversion(@Param('id') id: string) {
     return this.campaignService.recordConversion(id);

--- a/backend/src/inventory/inventory.controller.ts
+++ b/backend/src/inventory/inventory.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpStatus,
   ValidationPipe,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -22,6 +23,8 @@ import { InventoryStockEntity } from './entities/inventory-stock.entity';
 import { InventoryForecastingService } from './inventory-forecasting.service';
 import { InventoryService } from './inventory.service';
 
+@ApiTags('Inventory')
+@ApiBearerAuth()
 @Controller('inventory')
 export class InventoryController {
   constructor(
@@ -30,6 +33,8 @@ export class InventoryController {
   ) {}
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll(
     @Query(
@@ -46,12 +51,16 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get low stock' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('low-stock')
   getLowStock(@Query('threshold') threshold: string = '10') {
     return this.inventoryService.getLowStockItems(parseInt(threshold, 10));
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get critical stock' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('critical-stock')
   getCriticalStock() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -59,6 +68,8 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get aggregation' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('aggregation')
   getStockAggregation() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -66,6 +77,8 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get stats' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('stats')
   getInventoryStats(@Query('hospitalId') hospitalId?: string) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -73,6 +86,8 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get reorder summary' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('reorder-summary')
   getReorderSummary() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -80,30 +95,40 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get forecast' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('forecast')
   getForecast() {
     return this.inventoryForecastingService.calculateDemandForecasts();
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post forecast recalibrate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('forecast/recalibrate')
   recalibrateForecast() {
     return this.inventoryForecastingService.recalibrate();
   }
 
   @RequirePermissions(Permission.VIEW_INVENTORY)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.inventoryService.findOne(id);
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() createInventoryDto: CreateInventoryDto) {
     return this.inventoryService.create(createInventoryDto);
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -113,12 +138,16 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Patch :id stock' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/stock')
   updateStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     return this.inventoryService.updateStock(id, quantity);
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Patch :id reserve' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/reserve')
   reserveStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -126,6 +155,8 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Patch :id release' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/release')
   releaseStock(@Param('id') id: string, @Body('quantity') quantity: number) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -133,6 +164,8 @@ export class InventoryController {
   }
 
   @RequirePermissions(Permission.INVENTORY_WRITE)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {

--- a/backend/src/location-history/location-history.controller.ts
+++ b/backend/src/location-history/location-history.controller.ts
@@ -24,6 +24,8 @@ import {
 } from './dto/location-history.dto';
 import { LocationHistoryService } from './location-history.service';
 
+@ApiTags('Location History')
+@ApiBearerAuth()
 @Controller('location-history')
 export class LocationHistoryController {
   constructor(
@@ -35,6 +37,8 @@ export class LocationHistoryController {
    * Save a single location fix for a rider.
    */
   @RequirePermissions(Permission.RECORD_LOCATION)
+  @ApiOperation({ summary: 'Post riders :riderId' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('riders/:riderId')
   @HttpCode(HttpStatus.CREATED)
   saveLocation(
@@ -49,6 +53,8 @@ export class LocationHistoryController {
    * Save up to 500 location fixes in one request.
    */
   @RequirePermissions(Permission.RECORD_LOCATION)
+  @ApiOperation({ summary: 'Post riders :riderId batch' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('riders/:riderId/batch')
   @HttpCode(HttpStatus.CREATED)
   batchSaveLocations(
@@ -63,6 +69,8 @@ export class LocationHistoryController {
    * Query all location history for a rider (most recent first).
    */
   @RequirePermissions(Permission.VIEW_LOCATION_HISTORY)
+  @ApiOperation({ summary: 'Get riders :riderId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('riders/:riderId')
   getLocationsByRider(
     @Param('riderId', ParseUUIDPipe) riderId: string,
@@ -76,6 +84,8 @@ export class LocationHistoryController {
    * Get all raw location points for a delivery, chronological.
    */
   @RequirePermissions(Permission.VIEW_LOCATION_HISTORY)
+  @ApiOperation({ summary: 'Get deliveries :orderId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:orderId')
   getLocationsByDelivery(
     @Param('orderId', ParseUUIDPipe) orderId: string,
@@ -89,6 +99,8 @@ export class LocationHistoryController {
    * Reconstructed and Douglas-Peucker compressed route for a delivery.
    */
   @RequirePermissions(Permission.VIEW_LOCATION_HISTORY)
+  @ApiOperation({ summary: 'Get deliveries :orderId route' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:orderId/route')
   reconstructRoute(
     @Param('orderId', ParseUUIDPipe) orderId: string,
@@ -102,6 +114,8 @@ export class LocationHistoryController {
    * Ordered points with derived speed and bearing for route playback.
    */
   @RequirePermissions(Permission.VIEW_LOCATION_HISTORY)
+  @ApiOperation({ summary: 'Get deliveries :orderId playback' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:orderId/playback')
   getPlaybackData(
     @Param('orderId', ParseUUIDPipe) orderId: string,
@@ -115,6 +129,8 @@ export class LocationHistoryController {
    * GeoJSON LineString feature for map rendering.
    */
   @RequirePermissions(Permission.VIEW_LOCATION_HISTORY)
+  @ApiOperation({ summary: 'Get deliveries :orderId visualization' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('deliveries/:orderId/visualization')
   getVisualizationData(
     @Param('orderId', ParseUUIDPipe) orderId: string,

--- a/backend/src/maps/controllers/route-planning.controller.ts
+++ b/backend/src/maps/controllers/route-planning.controller.ts
@@ -1,27 +1,36 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { RouteRequestDto, MultiStopRouteDto } from '../dto/route-planning.dto';
 import { RoutePlanningService } from '../services/route-planning.service';
 
+@ApiTags('Maps')
+@ApiBearerAuth()
 @Controller('routes')
 export class RoutePlanningController {
   constructor(private readonly routePlanningService: RoutePlanningService) {}
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Post calculate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('calculate')
   async calculateRoute(@Body() routeDto: RouteRequestDto) {
     return this.routePlanningService.calculateRoute(routeDto);
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Post multi stop' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('multi-stop')
   async calculateMultiStopRoute(@Body() multiStopDto: MultiStopRouteDto) {
     return this.routePlanningService.calculateMultiStopRoute(multiStopDto);
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get eta' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('eta')
   async calculateETA(
     @Query('originLat') originLat: string,
@@ -41,12 +50,16 @@ export class RoutePlanningController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Post alternatives' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('alternatives')
   async getAlternativeRoutes(@Body() routeDto: RouteRequestDto) {
     return this.routePlanningService.getAlternativeRoutes(routeDto);
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get decode polyline' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('decode-polyline')
   async decodePolyline(@Query('polyline') polyline: string) {
     const points = this.routePlanningService.decodePolyline(polyline);
@@ -57,6 +70,8 @@ export class RoutePlanningController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get statistics' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('statistics')
   async getRouteStatistics(@Query() routeDto: RouteRequestDto) {
     const response = await this.routePlanningService.calculateRoute(routeDto);

--- a/backend/src/maps/maps.controller.ts
+++ b/backend/src/maps/maps.controller.ts
@@ -1,15 +1,20 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
 
 import { MapsService } from './maps.service';
 
+@ApiTags('Maps')
+@ApiBearerAuth()
 @Controller('maps')
 export class MapsController {
   constructor(private readonly mapsService: MapsService) {}
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get directions' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('directions')
   getDirections(
     @Query('originLat') originLat: string,
@@ -26,6 +31,8 @@ export class MapsController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get distance' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('distance')
   calculateDistance(
     @Query('originLat') originLat: string,
@@ -42,12 +49,16 @@ export class MapsController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Post geocode' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('geocode')
   geocodeAddress(@Body('address') address: string) {
     return this.mapsService.geocodeAddress(address);
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get reverse geocode' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('reverse-geocode')
   reverseGeocode(
     @Query('latitude') latitude: string,
@@ -60,6 +71,8 @@ export class MapsController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get search' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('search')
   searchPlaces(
     @Query('query') query: string,
@@ -72,6 +85,8 @@ export class MapsController {
   }
 
   @RequirePermissions(Permission.VIEW_MAPS)
+  @ApiOperation({ summary: 'Get place details' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('place-details')
   getPlaceDetails(@Query('placeId') placeId: string) {
     return this.mapsService.getPlaceDetails(placeId);

--- a/backend/src/migrations/migration-safety.controller.ts
+++ b/backend/src/migrations/migration-safety.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get, Post, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MigrationPreflightService } from './migration-preflight.service';
 import { MigrationIntegrityService } from './migration-integrity.service';
 import { MigrationRepairService } from './migration-repair.service';
 
+@ApiTags('Migration Safety')
+@ApiBearerAuth()
 @Controller('admin/migration-safety')
 export class MigrationSafetyController {
   constructor(
@@ -11,21 +14,29 @@ export class MigrationSafetyController {
     private readonly repair: MigrationRepairService,
   ) {}
 
+  @ApiOperation({ summary: 'Get preflight' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('preflight')
   runPreflight() {
     return this.preflight.runPreflight();
   }
 
+  @ApiOperation({ summary: 'Get integrity' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('integrity')
   getIntegrityReport() {
     return this.integrity.generateReport();
   }
 
+  @ApiOperation({ summary: 'Post repair standard' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('repair/standard')
   runStandardRepairs() {
     return this.repair.runStandardRepairs();
   }
 
+  @ApiOperation({ summary: 'Post repair column' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('repair/column')
   ensureColumn(@Body() body: { table: string; column: string; definition: string }) {
     return this.repair.ensureColumnExists(body.table, body.column, body.definition);

--- a/backend/src/notifications/controllers/notification-dlq.controller.ts
+++ b/backend/src/notifications/controllers/notification-dlq.controller.ts
@@ -1,14 +1,19 @@
 import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { DlqEntryStatus } from '../entities/notification-dlq.entity';
 import { NotificationDlqService } from '../services/notification-dlq.service';
 
+@ApiTags('Notifications')
+@ApiBearerAuth()
 @Controller('notifications/dlq')
 export class NotificationDlqController {
   constructor(private readonly dlqService: NotificationDlqService) {}
 
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   list(
     @Query('status') status?: DlqEntryStatus,
@@ -18,18 +23,24 @@ export class NotificationDlqController {
   }
 
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   get(@Param('id') id: string) {
     return this.dlqService.get(id);
   }
 
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Post :id replay' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/replay')
   replay(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
     return this.dlqService.replay(id, req.user?.id ?? 'system');
   }
 
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Post replay bulk' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('replay/bulk')
   replayBulk(
     @Body() body: { channel?: string },
@@ -39,6 +50,8 @@ export class NotificationDlqController {
   }
 
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Post :id abandon' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/abandon')
   abandon(
     @Param('id') id: string,

--- a/backend/src/notifications/controllers/notification-preference.controller.ts
+++ b/backend/src/notifications/controllers/notification-preference.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   ForbiddenException,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { NotificationPreferenceService } from '../services/notification-preference.service';
@@ -26,6 +27,8 @@ class SetPreferenceDto {
   emergencyBypassTier?: EmergencyTier;
 }
 
+@ApiTags('Notifications')
+@ApiBearerAuth()
 @Controller('api/v1/notification-preferences')
 @UseGuards(JwtAuthGuard)
 export class NotificationPreferenceController {
@@ -34,11 +37,15 @@ export class NotificationPreferenceController {
     private readonly securityEventLogger: SecurityEventLoggerService,
   ) {}
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   async getMyPreferences(@CurrentUser() user: any) {
     return this.preferenceService.getUserPreferences(user.id);
   }
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   async setPreference(
     @Body() dto: SetPreferenceDto,
@@ -55,11 +62,15 @@ export class NotificationPreferenceController {
     );
   }
 
+  @ApiOperation({ summary: 'Get delivery logs' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('delivery-logs')
   async getMyDeliveryLogs(@CurrentUser() user: any) {
     return this.preferenceService.getDeliveryLogs(user.id);
   }
 
+  @ApiOperation({ summary: 'Get delivery logs :userId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('delivery-logs/:userId')
   async getUserDeliveryLogs(@Param('userId') userId: string, @CurrentUser() user: any) {
     const role = String(user?.role ?? '').toLowerCase();

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -18,11 +18,15 @@ import { NotificationQueryDto } from './dto/notification-query.dto';
 import { SendNotificationDto } from './dto/send-notification.dto';
 import { NotificationsService } from './notifications.service';
 
+@ApiTags('Notifications')
+@ApiBearerAuth()
 @Controller('notifications')
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
   @RequirePermissions(Permission.VIEW_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   async findAll(@Query() query: NotificationQueryDto, @Request() req: any) {
     const result = await this.notificationsService.findForRecipient(query, {
@@ -37,6 +41,8 @@ export class NotificationsController {
   }
 
   @RequirePermissions(Permission.VIEW_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Patch :id read' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/read')
   async markRead(@Param('id') id: string, @Request() req: any) {
     return this.notificationsService.markRead(id, {
@@ -48,6 +54,8 @@ export class NotificationsController {
 
   // Exposed for testing/admin purposes to trigger notifications manually
   @RequirePermissions(Permission.MANAGE_NOTIFICATIONS)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   @HttpCode(HttpStatus.ACCEPTED)
   async send(@Body() dto: SendNotificationDto) {

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -38,6 +38,8 @@ interface AuthenticatedRequest {
   };
 }
 
+@ApiTags('Orders')
+@ApiBearerAuth()
 @Controller('orders')
 export class OrdersController {
   constructor(
@@ -51,12 +53,16 @@ export class OrdersController {
    * Returns all orders with inconsistent or invalid materialized state (Issue #617).
    */
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get state audit' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('state-audit')
   auditOrderStates() {
     return this.auditService.auditAll();
   }
 
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   async findAllWithFilters(
     @Query(
@@ -101,6 +107,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
     return this.ordersService.findOne(id, {
@@ -116,12 +124,16 @@ export class OrdersController {
    * Each row contains: order_id, event_type, payload, actor_id, timestamp.
    */
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Get :id sla' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/sla')
   getOrderSla(@Param('id') id: string) {
     return this.slaService.getOrderMetrics(id);
   }
 
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Get :id history' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/history')
   getOrderHistory(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
     return this.ordersService.getOrderHistory(id, {
@@ -132,6 +144,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Get :id track' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/track')
   trackOrder(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
     return this.ordersService.trackOrder(id, {
@@ -142,6 +156,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.VIEW_ORDER)
+  @ApiOperation({ summary: 'Post :id preview fees' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/preview-fees')
   previewOrderFees(
     @Param('id') id: string,
@@ -157,6 +173,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.CREATE_ORDER)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(
     @Body() createOrderDto: CreateOrderDto,
@@ -168,6 +186,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.UPDATE_ORDER)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -182,6 +202,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.UPDATE_ORDER)
+  @ApiOperation({ summary: 'Patch :id status' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/status')
   updateStatus(
     @Param('id') id: string,
@@ -204,6 +226,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Patch :id assign rider' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/assign-rider')
   assignRider(
     @Param('id') id: string,
@@ -219,6 +243,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.DELETE_ORDER)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
@@ -231,6 +257,8 @@ export class OrdersController {
   }
 
   @RequirePermissions(Permission.UPDATE_ORDER)
+  @ApiOperation({ summary: 'Patch :id raise dispute' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/raise-dispute')
   @HttpCode(HttpStatus.OK)
   raiseDispute(
@@ -250,6 +278,8 @@ export class OrdersController {
   @RequirePermissions(Permission.UPDATE_ORDER)
   @Auditable({ action: 'order.resolve-dispute', resourceType: 'Order' })
   @UseInterceptors(AuditLogInterceptor)
+  @ApiOperation({ summary: 'Patch :id resolve dispute' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/resolve-dispute')
   @HttpCode(HttpStatus.OK)
   resolveDispute(

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -39,6 +39,8 @@ import { OrganizationsService } from './organizations.service';
 import { OrganizationReviewsService } from './services/organization-reviews.service';
 import { VerificationSyncService } from './services/verification-sync.service';
 
+@ApiTags('Organizations')
+@ApiBearerAuth()
 @Controller('organizations')
 export class OrganizationsController {
   constructor(
@@ -49,6 +51,8 @@ export class OrganizationsController {
   ) {}
 
   @Public()
+  @ApiOperation({ summary: 'Post register' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('register')
   @UseInterceptors(
     FileFieldsInterceptor(
@@ -74,12 +78,16 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get pending' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('pending')
   listPending() {
     return this.organizationsService.listPending();
   }
 
   @Public()
+  @ApiOperation({ summary: 'Get search' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('search')
   search(
     @Query(
@@ -95,6 +103,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch :id approve' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/approve')
   approve(
     @Param('id', ParseUUIDPipe) id: string,
@@ -104,6 +114,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch :id reject' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/reject')
   reject(
     @Param('id', ParseUUIDPipe) id: string,
@@ -113,6 +125,8 @@ export class OrganizationsController {
     return this.organizationsService.reject(id, dto, req.user.id);
   }
 
+  @ApiOperation({ summary: 'Post :id reviews' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/reviews')
   submitReview(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -126,6 +140,8 @@ export class OrganizationsController {
     );
   }
 
+  @ApiOperation({ summary: 'Get :id reviews' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/reviews')
   listReviews(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -144,6 +160,8 @@ export class OrganizationsController {
     );
   }
 
+  @ApiOperation({ summary: 'Post reviews :reviewId report' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('reviews/:reviewId/report')
   reportReview(
     @Param('reviewId', ParseUUIDPipe) reviewId: string,
@@ -158,6 +176,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch reviews :reviewId moderate' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('reviews/:reviewId/moderate')
   moderateReview(
     @Param('reviewId', ParseUUIDPipe) reviewId: string,
@@ -171,6 +191,8 @@ export class OrganizationsController {
     );
   }
 
+  @ApiOperation({ summary: 'Delete reviews :reviewId' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete('reviews/:reviewId')
   deleteReview(
     @Param('reviewId', ParseUUIDPipe) reviewId: string,
@@ -188,6 +210,8 @@ export class OrganizationsController {
   // =========================================================================
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id verify on chain' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/verify-on-chain')
   verifyOnChain(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -197,6 +221,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id revoke verification' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/revoke-verification')
   revokeVerification(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -209,6 +235,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id retry sync' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/retry-sync')
   retrySyncVerification(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -217,6 +245,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get :id sync status' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/sync-status')
   getSyncStatus(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -225,12 +255,16 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get verification pending syncs' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('verification/pending-syncs')
   listPendingSyncs() {
     return this.verificationSyncService.listPendingSyncs();
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id check mismatch' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/check-mismatch')
   checkSyncMismatch(
     @Param('id', ParseUUIDPipe) organizationId: string,
@@ -243,6 +277,8 @@ export class OrganizationsController {
   // =========================================================================
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id suspend' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/suspend')
   suspend(
     @Param('id', ParseUUIDPipe) id: string,
@@ -253,6 +289,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id reinstate' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/reinstate')
   reinstate(
     @Param('id', ParseUUIDPipe) id: string,
@@ -263,6 +301,8 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Post :id unverify' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/unverify')
   unverify(
     @Param('id', ParseUUIDPipe) id: string,
@@ -272,6 +312,8 @@ export class OrganizationsController {
     return this.lifecycleService.unverify(id, req.user.id, dto);
   }
 
+  @ApiOperation({ summary: 'Post :id reapply' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post(':id/reapply')
   reapply(
     @Param('id', ParseUUIDPipe) id: string,
@@ -282,18 +324,24 @@ export class OrganizationsController {
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get :id lifecycle history' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/lifecycle-history')
   getLifecycleHistory(@Param('id', ParseUUIDPipe) id: string) {
     return this.lifecycleService.getHistory(id);
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get :id grace period' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/grace-period')
   getGracePeriod(@Param('id', ParseUUIDPipe) id: string) {
     return this.lifecycleService.getActiveGracePeriod(id);
   }
 
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get :id restriction level' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/restriction-level')
   getRestrictionLevel(@Param('id', ParseUUIDPipe) id: string) {
     return this.lifecycleService.getRestrictionLevel(id);

--- a/backend/src/organizations/stats/org-stats.controller.ts
+++ b/backend/src/organizations/stats/org-stats.controller.ts
@@ -11,10 +11,14 @@ import { Response } from 'express';
 import { OrgStatsService } from './org-stats.service';
 import { exportToExcel, exportToPdf } from './export.helper';
 
+@ApiTags('Organizations')
+@ApiBearerAuth()
 @Controller('api/v1/organization/stats')
 export class OrgStatsController {
   constructor(private readonly statsService: OrgStatsService) {}
 
+  @ApiOperation({ summary: 'Get :orgId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':orgId')
   async getStats(
     @Param('orgId', ParseUUIDPipe) orgId: string,
@@ -23,6 +27,8 @@ export class OrgStatsController {
     return this.statsService.getStats(orgId, req.user.organizationId);
   }
 
+  @ApiOperation({ summary: 'Get :orgId export' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':orgId/export')
   async exportStats(
     @Param('orgId', ParseUUIDPipe) orgId: string,

--- a/backend/src/policy-center/policy-center.controller.ts
+++ b/backend/src/policy-center/policy-center.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   Req,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -18,6 +19,8 @@ import { UpdatePolicyVersionDto } from './dto/update-policy-version.dto';
 import { PolicyCenterService } from './policy-center.service';
 import { PolicyReplayService } from './policy-replay.service';
 
+@ApiTags('Policy Center')
+@ApiBearerAuth()
 @Controller('policy-center')
 export class PolicyCenterController {
   constructor(
@@ -25,48 +28,64 @@ export class PolicyCenterController {
     private readonly replayService: PolicyReplayService,
   ) {}
 
+  @ApiOperation({ summary: 'List all policy versions' })
+  @ApiResponse({ status: 200, description: 'List of policy versions' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get('versions')
   listVersions(@Query() query: ListPolicyVersionsDto) {
     return this.policyCenterService.listVersions(query);
   }
 
+  @ApiOperation({ summary: 'Get a policy version by ID' })
+  @ApiResponse({ status: 200, description: 'Policy version record' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get('versions/:id')
   getVersion(@Param('id') id: string) {
     return this.policyCenterService.getVersion(id);
   }
 
+  @ApiOperation({ summary: 'Create a new policy version' })
+  @ApiResponse({ status: 201, description: 'Policy version created' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post('versions')
   createVersion(@Body() dto: CreatePolicyVersionDto, @Req() req: { user?: { id?: string } }) {
     return this.policyCenterService.createVersion(dto, req.user?.id ?? 'system');
   }
 
+  @ApiOperation({ summary: 'Update a policy version' })
+  @ApiResponse({ status: 200, description: 'Policy version updated' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Patch('versions/:id')
   updateVersion(@Param('id') id: string, @Body() dto: UpdatePolicyVersionDto) {
     return this.policyCenterService.updateVersion(id, dto);
   }
 
+  @ApiOperation({ summary: 'Activate a policy version' })
+  @ApiResponse({ status: 201, description: 'Policy version activated' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post('versions/:id/activate')
   activateVersion(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
     return this.policyCenterService.activateVersion(id, req.user?.id ?? 'system');
   }
 
+  @ApiOperation({ summary: 'Rollback to a policy version' })
+  @ApiResponse({ status: 201, description: 'Rolled back to policy version' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post('versions/:id/rollback')
   rollbackVersion(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
     return this.policyCenterService.rollbackToVersion(id, req.user?.id ?? 'system');
   }
 
+  @ApiOperation({ summary: 'Get active policy snapshot' })
+  @ApiResponse({ status: 200, description: 'Active policy snapshot' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get('active')
   getActiveVersion(@Query('policyName') policyName?: string) {
     return this.policyCenterService.getActivePolicySnapshot(policyName);
   }
 
+  @ApiOperation({ summary: 'Compare two policy versions' })
+  @ApiResponse({ status: 200, description: 'Diff between policy versions' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get('compare')
   compareVersions(
@@ -76,11 +95,8 @@ export class PolicyCenterController {
     return this.policyCenterService.compareVersions(fromVersionId, toVersionId);
   }
 
-  /**
-   * POST /policy-center/versions/:id/replay
-   * Re-evaluate a historical decision using the archived policy snapshot.
-   * Returns archived rules, current rules, and a structured drift report (Issue #618).
-   */
+  @ApiOperation({ summary: 'Replay a historical decision against an archived policy snapshot' })
+  @ApiResponse({ status: 201, description: 'Replay result with drift report' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post('versions/:id/replay')
   replayVersion(@Param('id') id: string) {

--- a/backend/src/policy-center/policy-rollout.controller.ts
+++ b/backend/src/policy-center/policy-rollout.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
 import {
@@ -6,40 +7,54 @@ import {
   StartRolloutDto,
 } from './policy-rollout.service';
 
+@ApiTags('Policy Center')
+@ApiBearerAuth()
 @Controller('policy-center/rollouts')
 export class PolicyRolloutController {
   constructor(private readonly rolloutService: PolicyRolloutService) {}
 
+  @ApiOperation({ summary: 'List policy rollouts' })
+  @ApiResponse({ status: 200, description: 'List of rollouts' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get()
   list(@Query('policyVersionId') policyVersionId?: string) {
     return this.rolloutService.listRollouts(policyVersionId);
   }
 
+  @ApiOperation({ summary: 'Get a rollout by ID' })
+  @ApiResponse({ status: 200, description: 'Rollout record' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get(':id')
   get(@Param('id') id: string) {
     return this.rolloutService.getRollout(id);
   }
 
+  @ApiOperation({ summary: 'Get rollout summary' })
+  @ApiResponse({ status: 200, description: 'Rollout summary' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Get(':id/summary')
   summary(@Param('id') id: string) {
     return this.rolloutService.getSummary(id);
   }
 
+  @ApiOperation({ summary: 'Start a new policy rollout' })
+  @ApiResponse({ status: 201, description: 'Rollout started' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post()
   start(@Body() dto: StartRolloutDto, @Req() req: { user?: { id?: string } }) {
     return this.rolloutService.startRollout(dto, req.user?.id ?? 'system');
   }
 
+  @ApiOperation({ summary: 'Advance rollout to next step' })
+  @ApiResponse({ status: 201, description: 'Rollout advanced' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post(':id/advance')
   advance(@Param('id') id: string, @Req() req: { user?: { id?: string } }) {
     return this.rolloutService.advanceStep(id, req.user?.id ?? 'system');
   }
 
+  @ApiOperation({ summary: 'Emergency rollback of a rollout' })
+  @ApiResponse({ status: 201, description: 'Rollout rolled back' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post(':id/rollback')
   rollback(
@@ -54,6 +69,8 @@ export class PolicyRolloutController {
     );
   }
 
+  @ApiOperation({ summary: 'Record a rollout metric snapshot' })
+  @ApiResponse({ status: 201, description: 'Metric recorded' })
   @RequirePermissions(Permission.ADMIN_ACCESS)
   @Post(':id/metrics')
   recordMetric(

--- a/backend/src/proof-bundle/proof-bundle.controller.ts
+++ b/backend/src/proof-bundle/proof-bundle.controller.ts
@@ -1,37 +1,45 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { ValidateProofBundleDto } from './dto/validate-proof-bundle.dto';
 import { ProofBundleService } from './proof-bundle.service';
 
+@ApiTags('Proof Bundles')
+@ApiBearerAuth()
 @Controller('proof-bundles')
 export class ProofBundleController {
   constructor(private readonly service: ProofBundleService) {}
 
-  /** Validate artifacts and attach a proof bundle to a payment */
+  @ApiOperation({ summary: 'Validate artifacts and attach a proof bundle to a payment' })
+  @ApiResponse({ status: 201, description: 'Proof bundle created and attached' })
   @Post('validate')
   validate(@Body() dto: ValidateProofBundleDto) {
     return this.service.validateAndAttach(dto);
   }
 
-  /** Release escrow once a validated bundle exists */
+  @ApiOperation({ summary: 'Release escrow once a validated bundle exists' })
+  @ApiResponse({ status: 201, description: 'Escrow released' })
   @Post(':id/release')
   release(@Param('id') id: string, @Body('releasedBy') releasedBy: string) {
     return this.service.releaseEscrow(id, releasedBy);
   }
 
-  /** Re-verify an existing bundle's manifest integrity (tamper detection) */
+  @ApiOperation({ summary: 'Re-verify an existing bundle\'s manifest integrity (tamper detection)' })
+  @ApiResponse({ status: 200, description: 'Bundle integrity result' })
   @Get(':id/verify')
   verify(@Param('id') id: string) {
     return this.service.verifyBundle(id);
   }
 
-  /** Get all proof bundles for a payment */
+  @ApiOperation({ summary: 'Get all proof bundles for a payment' })
+  @ApiResponse({ status: 200, description: 'List of proof bundles' })
   @Get('payment/:paymentId')
   byPayment(@Param('paymentId') paymentId: string) {
     return this.service.getByPayment(paymentId);
   }
 
-  /** Get a single proof bundle */
+  @ApiOperation({ summary: 'Get a single proof bundle' })
+  @ApiResponse({ status: 200, description: 'Proof bundle record' })
   @Get(':id')
   getOne(@Param('id') id: string) {
     return this.service.getOne(id);

--- a/backend/src/readiness/readiness.controller.ts
+++ b/backend/src/readiness/readiness.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import {
   CreateChecklistDto,
@@ -17,20 +18,28 @@ import {
 import { ReadinessEntityType, ReadinessItemKey } from './enums/readiness.enum';
 import { ReadinessService } from './readiness.service';
 
+@ApiTags('Readiness')
+@ApiBearerAuth()
 @Controller('api/v1/readiness')
 export class ReadinessController {
   constructor(private readonly service: ReadinessService) {}
 
+  @ApiOperation({ summary: 'Create a readiness checklist' })
+  @ApiResponse({ status: 201, description: 'Checklist created' })
   @Post()
   create(@Body() dto: CreateChecklistDto) {
     return this.service.createChecklist(dto);
   }
 
+  @ApiOperation({ summary: 'List readiness checklists' })
+  @ApiResponse({ status: 200, description: 'List of checklists' })
   @Get()
   list(@Query() query: QueryReadinessDto) {
     return this.service.listChecklists(query);
   }
 
+  @ApiOperation({ summary: 'Update checklist item dependencies' })
+  @ApiResponse({ status: 201, description: 'Dependencies updated' })
   @Post('dependencies')
   updateDependencies(
     @Body()
@@ -42,21 +51,29 @@ export class ReadinessController {
     return this.service.updateDependencies(dto);
   }
 
+  @ApiOperation({ summary: 'List all blocked readiness items' })
+  @ApiResponse({ status: 200, description: 'List of blocked items' })
   @Get('blocked')
   listBlocked() {
     return this.service.listBlocked();
   }
 
+  @ApiOperation({ summary: 'Get a readiness checklist by ID' })
+  @ApiResponse({ status: 200, description: 'Checklist record' })
   @Get(':id')
   getById(@Param('id') id: string) {
     return this.service.getChecklist(id);
   }
 
+  @ApiOperation({ summary: 'Get readiness report for a checklist' })
+  @ApiResponse({ status: 200, description: 'Readiness report' })
   @Get(':id/report')
   getReport(@Param('id') id: string) {
     return this.service.getReadinessReport(id);
   }
 
+  @ApiOperation({ summary: 'Get readiness checklist by entity type and ID' })
+  @ApiResponse({ status: 200, description: 'Checklist for entity' })
   @Get('entity/:type/:entityId')
   getByEntity(
     @Param('type') type: ReadinessEntityType,
@@ -65,17 +82,20 @@ export class ReadinessController {
     return this.service.getChecklistByEntity(type, entityId);
   }
 
+  @ApiOperation({ summary: 'Update a checklist item' })
+  @ApiResponse({ status: 200, description: 'Item updated' })
   @Patch(':id/items/:itemKey')
   updateItem(
     @Param('id') id: string,
     @Param('itemKey') itemKey: ReadinessItemKey,
     @Body() dto: UpdateReadinessItemDto,
-    // In production this comes from JWT; using header for simplicity
     @Query('userId') userId: string = 'system',
   ) {
     return this.service.updateItem(id, itemKey, userId, dto);
   }
 
+  @ApiOperation({ summary: 'Sign off on a readiness checklist' })
+  @ApiResponse({ status: 201, description: 'Sign-off recorded' })
   @Post(':id/sign-off')
   signOff(
     @Param('id') id: string,
@@ -85,6 +105,8 @@ export class ReadinessController {
     return this.service.signOff(id, userId, dto);
   }
 
+  @ApiOperation({ summary: 'Check if an entity is ready' })
+  @ApiResponse({ status: 200, description: 'Readiness gate result' })
   @Get('gate/:type/:entityId')
   isReady(
     @Param('type') type: ReadinessEntityType,

--- a/backend/src/regions/regions.controller.ts
+++ b/backend/src/regions/regions.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -19,17 +20,23 @@ import { QueryRegionDto } from './dto/query-region.dto';
 import { RegionScopeGuard } from './guards/region-scope.guard';
 import { RegionsService } from './regions.service';
 
+@ApiTags('Regions')
+@ApiBearerAuth()
 @Controller('regions')
 @UseGuards(PermissionsGuard, RegionScopeGuard)
 export class RegionsController {
   constructor(private readonly regionsService: RegionsService) {}
 
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   @RequirePermissions(Permission.MANAGE_REGIONS)
   create(@Body() dto: CreateRegionDto) {
     return this.regionsService.create(dto);
   }
 
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   @RegionScoped()
   @RequirePermissions(Permission.VIEW_REGIONS)
@@ -37,18 +44,24 @@ export class RegionsController {
     return this.regionsService.findAll(query);
   }
 
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   @RequirePermissions(Permission.VIEW_REGIONS)
   findOne(@Param('id') id: string) {
     return this.regionsService.findOne(id);
   }
 
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   @RequirePermissions(Permission.MANAGE_REGIONS)
   update(@Param('id') id: string, @Body() dto: Partial<CreateRegionDto>) {
     return this.regionsService.update(id, dto);
   }
 
+  @ApiOperation({ summary: 'Patch :id deactivate' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/deactivate')
   @RequirePermissions(Permission.MANAGE_REGIONS)
   deactivate(@Param('id') id: string) {

--- a/backend/src/reporting/reporting.controller.ts
+++ b/backend/src/reporting/reporting.controller.ts
@@ -22,6 +22,8 @@ import { ReportingService } from './reporting.service';
 import { ReportViewRefreshService, MaterializedViewName } from './report-view-refresh.service';
 import { ReportingQueryDto, ReportSummaryQueryDto } from './dto/reporting-query.dto';
 
+@ApiTags('Reporting')
+@ApiBearerAuth()
 @Controller('reporting')
 @UseGuards(JwtAuthGuard, PermissionsGuard)
 export class ReportingController {
@@ -34,6 +36,8 @@ export class ReportingController {
    * Multi-domain search with pagination.
    * Supports page/pageSize (preferred) or legacy limit/offset.
    */
+  @ApiOperation({ summary: 'Get search' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('search')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async search(
@@ -48,6 +52,8 @@ export class ReportingController {
    * Served from materialized views when fresh; falls back to live queries.
    * Staleness metadata is always included in the response.
    */
+  @ApiOperation({ summary: 'Get summary' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('summary')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async getSummary(
@@ -61,6 +67,8 @@ export class ReportingController {
    * Pre-aggregated daily order summary from materialized view.
    * Supports optional date range and pagination.
    */
+  @ApiOperation({ summary: 'Get orders daily summary' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('orders/daily-summary')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async getOrderDailySummary(
@@ -75,6 +83,8 @@ export class ReportingController {
   /**
    * Blood unit inventory snapshot from materialized view.
    */
+  @ApiOperation({ summary: 'Get units inventory' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('units/inventory')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async getBloodUnitInventory(
@@ -88,6 +98,8 @@ export class ReportingController {
    * Returns freshness metadata for all materialized views.
    * Consumers use this to decide whether to request a refresh.
    */
+  @ApiOperation({ summary: 'Get views freshness' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('views/freshness')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async getViewFreshness() {
@@ -98,6 +110,8 @@ export class ReportingController {
    * Trigger a manual refresh of a specific materialized view.
    * Requires ADMIN_ACCESS permission.
    */
+  @ApiOperation({ summary: 'Post views :viewName refresh' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('views/:viewName/refresh')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   async refreshView(@Param('viewName') viewName: string) {
@@ -108,6 +122,8 @@ export class ReportingController {
    * Trigger refresh of all materialized views.
    * Requires ADMIN_ACCESS permission.
    */
+  @ApiOperation({ summary: 'Post views refresh all' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('views/refresh-all')
   @RequirePermissions(Permission.ADMIN_ACCESS)
   async refreshAllViews() {
@@ -118,6 +134,8 @@ export class ReportingController {
    * Excel export endpoint.
    * Capped at 10 000 rows per domain.
    */
+  @ApiOperation({ summary: 'Get export' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export')
   @RequirePermissions(Permission.READ_ANALYTICS)
   async export(

--- a/backend/src/reputation/reputation-abuse.controller.ts
+++ b/backend/src/reputation/reputation-abuse.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { User } from '../auth/decorators/user.decorator';
@@ -6,12 +7,16 @@ import { Permission } from '../auth/enums/permission.enum';
 
 import { ReputationAbuseService } from './reputation-abuse.service';
 
+@ApiTags('Reputation')
+@ApiBearerAuth()
 @Controller('reputation/abuse')
 export class ReputationAbuseController {
   constructor(private readonly abuseService: ReputationAbuseService) {}
 
   /** GET /reputation/abuse/flags — list all PENDING flags (admin only) */
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Get flags' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('flags')
   listPending() {
     return this.abuseService.listPendingFlags();
@@ -19,6 +24,8 @@ export class ReputationAbuseController {
 
   /** PATCH /reputation/abuse/flags/:id/review — start review */
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch flags :id review' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('flags/:id/review')
   startReview(@Param('id') id: string, @User('id') reviewerId: string) {
     return this.abuseService.startReview(id, reviewerId);
@@ -26,6 +33,8 @@ export class ReputationAbuseController {
 
   /** PATCH /reputation/abuse/flags/:id/clear — clear flag (delta is safe to apply) */
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch flags :id clear' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('flags/:id/clear')
   clear(
     @Param('id') id: string,
@@ -37,6 +46,8 @@ export class ReputationAbuseController {
 
   /** PATCH /reputation/abuse/flags/:id/reverse — reverse flag (delta must NOT be applied) */
   @RequirePermissions(Permission.ADMIN_ACCESS)
+  @ApiOperation({ summary: 'Patch flags :id reverse' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('flags/:id/reverse')
   reverse(
     @Param('id') id: string,

--- a/backend/src/reputation/reputation.controller.ts
+++ b/backend/src/reputation/reputation.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { User } from '../auth/decorators/user.decorator';
@@ -10,12 +11,16 @@ import {
 } from './dto/reputation-query.dto';
 import { ReputationService } from './reputation.service';
 
+@ApiTags('Reputation')
+@ApiBearerAuth()
 @Controller('reputation')
 export class ReputationController {
   constructor(private readonly reputationService: ReputationService) {}
 
   /** GET /reputation/leaderboard */
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get leaderboard' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('leaderboard')
   getLeaderboard(@Query() query: LeaderboardQueryDto) {
     return this.reputationService.getLeaderboard(query);
@@ -23,6 +28,8 @@ export class ReputationController {
 
   /** GET /reputation/me — current rider's own reputation */
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get me' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('me')
   getMyReputation(@User('id') userId: string) {
     // userId maps to riderId via the rider profile; service handles lookup
@@ -31,6 +38,8 @@ export class ReputationController {
 
   /** GET /reputation/me/badges */
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get me badges' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('me/badges')
   getMyBadges(@User('id') userId: string) {
     return this.reputationService.getBadges(userId);
@@ -38,6 +47,8 @@ export class ReputationController {
 
   /** GET /reputation/me/history */
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get me history' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('me/history')
   getMyHistory(
     @User('id') userId: string,
@@ -48,6 +59,8 @@ export class ReputationController {
 
   /** GET /reputation/me/rank */
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get me rank' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('me/rank')
   getMyRank(@User('id') userId: string) {
     return this.reputationService.getRank(userId);
@@ -55,6 +68,8 @@ export class ReputationController {
 
   /** GET /reputation/:riderId — admin/hospital view */
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Get :riderId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':riderId')
   getReputation(@Param('riderId') riderId: string) {
     return this.reputationService.getReputation(riderId);
@@ -62,6 +77,8 @@ export class ReputationController {
 
   /** GET /reputation/:riderId/badges */
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Get :riderId badges' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':riderId/badges')
   getBadges(@Param('riderId') riderId: string) {
     return this.reputationService.getBadges(riderId);
@@ -69,6 +86,8 @@ export class ReputationController {
 
   /** GET /reputation/:riderId/history */
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Get :riderId history' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':riderId/history')
   getHistory(
     @Param('riderId') riderId: string,
@@ -79,6 +98,8 @@ export class ReputationController {
 
   /** GET /reputation/:riderId/rank */
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Get :riderId rank' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':riderId/rank')
   getRank(@Param('riderId') riderId: string) {
     return this.reputationService.getRank(riderId);

--- a/backend/src/riders/controllers/assignment.controller.ts
+++ b/backend/src/riders/controllers/assignment.controller.ts
@@ -1,31 +1,42 @@
 import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { ReputationAwareAssignmentService } from '../services/reputation-aware-assignment.service';
 
+@ApiTags('Riders')
+@ApiBearerAuth()
 @Controller('riders/assignment')
 export class AssignmentController {
   constructor(private readonly service: ReputationAwareAssignmentService) {}
 
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   assign(@Body() body: { orderId: string; pickupLat: number; pickupLon: number; maxCandidates?: number }) {
     return this.service.assignRider(body);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get decisions :orderId' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('decisions/:orderId')
   getDecision(@Param('orderId') orderId: string) {
     return this.service.getDecision(orderId);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get weights' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('weights')
   getWeights() {
     return this.service.getActiveWeights();
   }
 
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Patch weights' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('weights')
   updateWeights(@Body() body: Record<string, number>) {
     return this.service.updateWeights(body);

--- a/backend/src/riders/controllers/rider-search.controller.ts
+++ b/backend/src/riders/controllers/rider-search.controller.ts
@@ -1,27 +1,36 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
 import { Permission } from '../../auth/enums/permission.enum';
 import { RiderSearchDto, RiderAssignmentDto } from '../dto/rider-search.dto';
 import { RiderSearchService } from '../services/rider-search.service';
 
+@ApiTags('Riders')
+@ApiBearerAuth()
 @Controller('riders')
 export class RiderSearchController {
   constructor(private readonly riderSearchService: RiderSearchService) {}
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get search' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('search')
   async searchRiders(@Query() searchDto: RiderSearchDto) {
     return this.riderSearchService.searchRiders(searchDto);
   }
 
   @RequirePermissions(Permission.ASSIGN_RIDER)
+  @ApiOperation({ summary: 'Post assign' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('assign')
   async findRidersForAssignment(@Body() assignmentDto: RiderAssignmentDto) {
     return this.riderSearchService.findRidersForAssignment(assignmentDto);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get statistics' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('statistics')
   async getRiderStatistics(@Query('riderId') riderId: string) {
     return this.riderSearchService.getRiderStatistics(riderId);

--- a/backend/src/riders/riders.controller.ts
+++ b/backend/src/riders/riders.controller.ts
@@ -28,11 +28,15 @@ import { RiderEntity } from './entities/rider.entity';
 import { RiderStatus } from './enums/rider-status.enum';
 import { RidersService } from './riders.service';
 
+@ApiTags('Riders')
+@ApiBearerAuth()
 @Controller('riders')
 export class RidersController {
   constructor(private readonly ridersService: RidersService) {}
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll(
     @Query(
@@ -49,12 +53,16 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get available' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('available')
   getAvailable() {
     return this.ridersService.getAvailableRiders();
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get availability' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('availability')
   queryAvailability(
     @Query(
@@ -66,12 +74,16 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get leaderboard' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('leaderboard')
   getLeaderboard(@Query('limit') limit?: string) {
     return this.ridersService.getLeaderboard(limit ? parseInt(limit, 10) : 10);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get nearby' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('nearby')
   getNearby(
     @Query('latitude') latitude: string,
@@ -86,23 +98,31 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get me' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('me')
   getMe(@User('id') userId: string) {
     return this.ridersService.findByUserId(userId);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.ridersService.findOne(id);
   }
 
   @RequirePermissions(Permission.VIEW_RIDERS)
+  @ApiOperation({ summary: 'Get :id performance' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id/performance')
   getPerformance(@Param('id') id: string) {
     return this.ridersService.getPerformance(id);
   }
 
+  @ApiOperation({ summary: 'Post register' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('register')
   register(
     @User('id') userId: string,
@@ -112,24 +132,32 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.CREATE_RIDER)
+  @ApiOperation({ summary: 'Post' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post()
   create(@Body() createRiderDto: CreateRiderDto) {
     return this.ridersService.create(createRiderDto);
   }
 
   @RequirePermissions(Permission.UPDATE_RIDER)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateRiderDto: UpdateRiderDto) {
     return this.ridersService.update(id, updateRiderDto);
   }
 
   @RequirePermissions(Permission.MANAGE_RIDERS)
+  @ApiOperation({ summary: 'Patch :id verify' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/verify')
   verify(@Param('id') id: string) {
     return this.ridersService.verify(id);
   }
 
   @RequirePermissions(Permission.UPDATE_RIDER)
+  @ApiOperation({ summary: 'Patch :id status' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/status')
   updateStatus(
     @Param('id') id: string,
@@ -139,6 +167,8 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.UPDATE_RIDER)
+  @ApiOperation({ summary: 'Patch :id location' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/location')
   updateLocation(
     @Param('id') id: string,
@@ -148,6 +178,8 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.UPDATE_RIDER)
+  @ApiOperation({ summary: 'Patch :id working hours' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/working-hours')
   setWorkingHours(
     @Param('id') id: string,
@@ -157,6 +189,8 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.UPDATE_RIDER)
+  @ApiOperation({ summary: 'Patch :id preferred areas' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/preferred-areas')
   setPreferredAreas(
     @Param('id') id: string,
@@ -166,6 +200,8 @@ export class RidersController {
   }
 
   @RequirePermissions(Permission.DELETE_RIDER)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {

--- a/backend/src/route-deviation/route-deviation.controller.ts
+++ b/backend/src/route-deviation/route-deviation.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import {
   AcknowledgeDeviationDto,
@@ -8,10 +9,14 @@ import {
 import { RouteDeviationService } from './route-deviation.service';
 import { DeviationSeverity } from './entities/route-deviation-incident.entity';
 
+@ApiTags('Route Deviation')
+@ApiBearerAuth()
 @Controller('api/v1/route-deviation')
 export class RouteDeviationController {
   constructor(private readonly service: RouteDeviationService) { }
 
+  @ApiOperation({ summary: 'Create a planned route for an order' })
+  @ApiResponse({ status: 201, description: 'Planned route created' })
   @Post('planned-routes')
   createPlannedRoute(@Body() dto: CreatePlannedRouteDto) {
     return this.service.createPlannedRoute(dto);

--- a/backend/src/sla/sla.controller.ts
+++ b/backend/src/sla/sla.controller.ts
@@ -1,42 +1,51 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SlaService } from './sla.service';
 import { SlaBreachQueryDto } from './dto/sla-breach-query.dto';
 
+@ApiTags('SLA')
+@ApiBearerAuth()
 @Controller('sla')
 export class SlaController {
   constructor(private readonly slaService: SlaService) {}
 
-  /** SLA metrics for a single order */
+  @ApiOperation({ summary: 'Get SLA metrics for a single order' })
+  @ApiResponse({ status: 200, description: 'SLA metrics for the order' })
   @Get('orders/:orderId')
   getOrderMetrics(@Param('orderId') orderId: string) {
     return this.slaService.getOrderMetrics(orderId);
   }
 
-  /** All breached records, filterable */
+  @ApiOperation({ summary: 'Query all breached SLA records' })
+  @ApiResponse({ status: 200, description: 'List of breached SLA records' })
   @Get('breaches')
   queryBreaches(@Query() query: SlaBreachQueryDto) {
     return this.slaService.queryBreaches(query);
   }
 
-  /** Breach summary grouped by hospital */
+  @ApiOperation({ summary: 'SLA breach summary grouped by hospital' })
+  @ApiResponse({ status: 200, description: 'Breach summary by hospital' })
   @Get('reports/by-hospital')
   byHospital(@Query() query: SlaBreachQueryDto) {
     return this.slaService.getBreachSummary('hospitalId', query);
   }
 
-  /** Breach summary grouped by blood bank */
+  @ApiOperation({ summary: 'SLA breach summary grouped by blood bank' })
+  @ApiResponse({ status: 200, description: 'Breach summary by blood bank' })
   @Get('reports/by-blood-bank')
   byBloodBank(@Query() query: SlaBreachQueryDto) {
     return this.slaService.getBreachSummary('bloodBankId', query);
   }
 
-  /** Breach summary grouped by rider */
+  @ApiOperation({ summary: 'SLA breach summary grouped by rider' })
+  @ApiResponse({ status: 200, description: 'Breach summary by rider' })
   @Get('reports/by-rider')
   byRider(@Query() query: SlaBreachQueryDto) {
     return this.slaService.getBreachSummary('riderId', query);
   }
 
-  /** Breach summary grouped by urgency tier */
+  @ApiOperation({ summary: 'SLA breach summary grouped by urgency tier' })
+  @ApiResponse({ status: 200, description: 'Breach summary by urgency tier' })
   @Get('reports/by-urgency')
   byUrgency(@Query() query: SlaBreachQueryDto) {
     return this.slaService.getBreachSummary('urgencyTier', query);

--- a/backend/src/surge-simulation/surge-simulation.controller.ts
+++ b/backend/src/surge-simulation/surge-simulation.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   Request,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { User } from '../auth/decorators/user.decorator';
@@ -29,6 +29,7 @@ import {
   SurgeEvaluationResult,
 } from './surge-simulation.service';
 
+@ApiTags('Surge Simulation')
 @Controller('surge-simulation')
 export class SurgeSimulationController {
   constructor(

--- a/backend/src/user-activity/user-activity.controller.ts
+++ b/backend/src/user-activity/user-activity.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
@@ -6,17 +7,23 @@ import { Permission } from '../auth/enums/permission.enum';
 import { ActivityQueryDto } from './dto/activity-query.dto';
 import { UserActivityService } from './user-activity.service';
 
+@ApiTags('User Activity')
+@ApiBearerAuth()
 @Controller('activity-logs')
 export class UserActivityController {
   constructor(private readonly userActivityService: UserActivityService) {}
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   async queryActivities(@Query() query: ActivityQueryDto) {
     return this.userActivityService.queryActivities(query);
   }
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get export' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('export')
   async exportActivities(@Query() query: ActivityQueryDto) {
     const csv = await this.userActivityService.exportActivities(query);

--- a/backend/src/users/services/file-download.controller.ts
+++ b/backend/src/users/services/file-download.controller.ts
@@ -26,10 +26,14 @@ import { ArtifactAccessClass, resolveAccessClass, StorageService } from './stora
  * For S3 backends the handler issues a 302 redirect to a short-lived pre-signed URL.
  * For local backends it streams the file directly after path-traversal sanitisation.
  */
+@ApiTags('Users')
+@ApiBearerAuth()
 @Controller('files')
 export class FileDownloadController {
   constructor(private readonly storageService: StorageService) {}
 
+  @ApiOperation({ summary: 'Get download' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('download')
   async download(
     @Query('key') key: string,
@@ -61,6 +65,8 @@ export class FileDownloadController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get download auth' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('download/auth')
   async downloadWithJwt(
     @Query('key') key: string,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -27,29 +27,39 @@ import { AuditLogInterceptor } from '../common/audit/audit-log.interceptor';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UsersService } from './users.service';
 
+@ApiTags('Users')
+@ApiBearerAuth()
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get()
   findAll() {
     return this.usersService.findAll();
   }
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get profile' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('profile')
   getProfile(@Request() req: any) {
     return this.usersService.getProfile(req.user?.id);
   }
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get :id' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.usersService.findOne(id);
   }
 
   @RequirePermissions(Permission.MANAGE_USERS)
+  @ApiOperation({ summary: 'Patch profile' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch('profile')
   updateProfile(
     @Body() updateProfileDto: UpdateProfileDto,
@@ -65,6 +75,8 @@ export class UsersController {
   @RequirePermissions(Permission.MANAGE_USERS)
   @Auditable({ action: 'user.updated', resourceType: 'User' })
   @UseInterceptors(AuditLogInterceptor)
+  @ApiOperation({ summary: 'Patch :id' })
+  @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -79,6 +91,8 @@ export class UsersController {
   }
 
   @RequirePermissions(Permission.MANAGE_USERS)
+  @ApiOperation({ summary: 'Post profile avatar' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('profile/avatar')
   @UseInterceptors(
     FileInterceptor('file', {
@@ -102,6 +116,8 @@ export class UsersController {
   }
 
   @RequirePermissions(Permission.MANAGE_USERS)
+  @ApiOperation({ summary: 'Delete profile avatar' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete('profile/avatar')
   @HttpCode(HttpStatus.OK)
   deleteAvatar(@Request() req: any) {
@@ -112,6 +128,8 @@ export class UsersController {
   }
 
   @RequirePermissions(Permission.VIEW_USERS)
+  @ApiOperation({ summary: 'Get profile activities' })
+  @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get('profile/activities')
   getProfileActivities(
     @Request() req: any,
@@ -126,6 +144,8 @@ export class UsersController {
   }
 
   @RequirePermissions(Permission.DELETE_USER)
+  @ApiOperation({ summary: 'Delete :id' })
+  @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string) {

--- a/backend/src/ussd/ussd.controller.ts
+++ b/backend/src/ussd/ussd.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UssdService } from './ussd.service';
 
 class UssdRequestDto {
@@ -8,10 +9,14 @@ class UssdRequestDto {
   text: string;
 }
 
+@ApiTags('USSD')
+@ApiBearerAuth()
 @Controller('api/v1/ussd')
 export class UssdController {
   constructor(private readonly ussdService: UssdService) {}
 
+  @ApiOperation({ summary: 'Post callback' })
+  @ApiResponse({ status: 201, description: 'Resource created successfully' })
   @Post('callback')
   async handleUssdCallback(@Body() dto: UssdRequestDto): Promise<string> {
     return this.ussdService.handleUssdRequest(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,203 @@
+# HealthChain Stellar — Architecture
+
+## System Overview
+
+```mermaid
+graph TD
+    FE["Next.js Frontend :3000"]
+    BE["NestJS Backend :3001"]
+    PG[("PostgreSQL")]
+    RD[("Redis")]
+    SC["Stellar / Soroban Contracts"]
+    SMS["Africa's Talking (SMS)"]
+    PUSH["Firebase (Push)"]
+    SMTP["SMTP"]
+    MAPS["Google Maps API"]
+
+    FE -->|"REST (api/v1/*)"| BE
+    FE -->|"WebSocket"| BE
+
+    BE -->|"TypeORM"| PG
+    BE -->|"ioredis"| RD
+    BE -->|"Soroban RPC"| SC
+    BE -->|"SMS"| SMS
+    BE -->|"FCM"| PUSH
+    BE -->|"SMTP"| SMTP
+    BE -->|"Directions / Geocode"| MAPS
+```
+
+---
+
+## Backend Module Boundaries
+
+```mermaid
+graph TD
+    subgraph Core["Core Infrastructure"]
+        AUTH[AuthModule]
+        USERS[UsersModule]
+        REDIS[RedisModule]
+        CONFIG[AppConfigModule]
+    end
+
+    subgraph BloodSupplyChain["Blood Supply Chain"]
+        BR[BloodRequestsModule]
+        BU[BloodUnitsModule]
+        INV[InventoryModule]
+        BM[BloodMatchingModule]
+        DISP[DispatchModule]
+        TRACK[TrackingModule]
+        CC[ColdChainModule]
+        DP[DeliveryProofModule]
+        CUST[CustodyModule]
+    end
+
+    subgraph Payments["Payments & Governance"]
+        ESC[EscrowGovernanceModule]
+        FEE[FeePolicyModule]
+        FEEFIX[FeeCorrectionModule]
+        REC[ReconciliationModule]
+        DISPUTES[DisputesModule]
+        PB[ProofBundleModule]
+    end
+
+    subgraph Actors["Actors"]
+        HOSP[HospitalsModule]
+        ORG[OrganizationsModule]
+        RIDERS[RidersModule]
+        DONA[DonationModule]
+        DE[DonorEligibilityModule]
+        DI[DonorImpactModule]
+        REP[ReputationModule]
+    end
+
+    subgraph Blockchain["Blockchain"]
+        SOROB[SorobanModule]
+        CEI[ContractEventIndexerModule]
+        BC[BlockchainModule]
+    end
+
+    subgraph Async["Async / Queue (BullMQ → Redis)"]
+        WQ["blood-request queue\n→ BloodRequestProcessor"]
+        NQ["notification queue\n→ NotificationProcessor"]
+        STX["soroban-tx queue\n→ SorobanTxProcessor"]
+        RQ["report-export queue\n→ ReportExportProcessor"]
+        DO["donor-outreach queue\n→ DonorOutreachProcessor"]
+    end
+
+    subgraph WebSockets["WebSocket Gateways"]
+        EG[EscalationGateway]
+        LOG[LiveOpsGateway]
+        TG[TrackingGateway]
+        NG[NotificationsGateway]
+        OG[OrdersGateway]
+        RLG[RiderLocationGateway]
+        RDG[RouteDeviationGateway]
+    end
+
+    subgraph Observability["Observability"]
+        HEALTH[HealthModule]
+        SLA[SlaModule]
+        ANALY[AnomalyModule]
+        READY[ReadinessModule]
+        REPORT[ReportingModule]
+        ANALYT[contract-event-indexer analytics]
+    end
+
+    AUTH --> USERS
+    BR --> WQ
+    BC --> STX
+    NOTIF[NotificationsModule] --> NQ
+    REPORT --> RQ
+    INV --> DO
+
+    BR --> EG
+    DISP --> LOG
+    TRACK --> TG
+    NOTIF --> NG
+    ORDERS[OrdersModule] --> OG
+    RIDERS --> RLG
+    RD_MOD[RouteDeviationModule] --> RDG
+
+    SOROB --> SC[("Soroban RPC")]
+    CEI --> SOROB
+    BC --> SOROB
+```
+
+---
+
+## Data Flow — Blood Request Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant FE as Next.js Frontend
+    participant BE as NestJS :3001
+    participant PG as PostgreSQL
+    participant RD as Redis / BullMQ
+    participant SC as Soroban Contract
+    participant RIDER as Rider (WS)
+
+    FE->>BE: POST /api/v1/blood-requests
+    BE->>PG: INSERT blood_request (Pending)
+    BE->>RD: enqueue blood-request job
+    RD-->>BE: BloodRequestProcessor picks up job
+    BE->>BE: BloodMatchingService.findMatch()
+    BE->>PG: UPDATE blood_request (Matched)
+    BE->>BE: DispatchService.createDispatch()
+    BE->>SC: allocate_units() via SorobanService
+    SC-->>BE: tx confirmed
+    BE->>PG: INSERT dispatch_record
+    BE->>RD: emit WS event → EscalationGateway
+    RD-->>RIDER: WebSocket push (order assigned)
+    RIDER->>BE: PATCH /api/v1/tracking (location updates)
+    BE->>PG: INSERT location_history
+    BE->>RD: emit WS event → TrackingGateway
+    RD-->>FE: WebSocket push (live tracking)
+    RIDER->>BE: POST /api/v1/delivery-proofs
+    BE->>SC: confirm_delivery() via SorobanService
+    SC-->>BE: tx confirmed
+    BE->>SC: settle_payment() via CoordinatorContract
+```
+
+---
+
+## Infrastructure Layout
+
+```mermaid
+graph LR
+    subgraph Docker["docker-compose (local)"]
+        PG_C["postgres:15\n:5432"]
+        RD_C["redis:7\n:6379"]
+    end
+
+    subgraph Services["Application Services"]
+        FE_S["Next.js\nlocalhost:3000"]
+        BE_S["NestJS\nlocalhost:3001"]
+    end
+
+    subgraph Stellar["Stellar Network"]
+        TEST["Soroban Testnet RPC\nsoroban-testnet.stellar.org"]
+        MAIN["Soroban Mainnet RPC\nsoroban.stellar.org"]
+    end
+
+    BE_S --> PG_C
+    BE_S --> RD_C
+    FE_S --> BE_S
+    BE_S -->|"dev/staging"| TEST
+    BE_S -->|"production"| MAIN
+```
+
+---
+
+## Key Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `PORT` | NestJS listen port | `3001` |
+| `DATABASE_*` | PostgreSQL connection | `localhost:5432` |
+| `REDIS_HOST` / `REDIS_PORT` | Redis + BullMQ | `localhost:6379` |
+| `SOROBAN_RPC_URL` | Stellar Soroban RPC | testnet URL |
+| `SOROBAN_NETWORK` | `testnet` or `mainnet` | `testnet` |
+| `JWT_SECRET` | Auth signing key | — |
+| `CORS_ORIGIN` | Allowed frontend origins | `http://localhost:3000` |
+
+See `backend/.env.example` for the full list.

--- a/docs/contracts/analytics.md
+++ b/docs/contracts/analytics.md
@@ -1,0 +1,101 @@
+# Analytics Contract
+
+**Location:** `lifebank-soroban/contracts/analytics/src/lib.rs`  
+**Purpose:** Aggregates protocol-wide metrics into rolling time-window snapshots (daily, weekly, monthly). Domain contracts call this contract to record donation, request, delivery, and payment events; external callers query the snapshots for dashboards and reporting.
+
+---
+
+## Public Interface
+
+### Initialization
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin, inventory_contract, requests_contract, payments_contract, reputation_contract` | `Result<(), AnalyticsError>` | `admin` |
+
+### Metrics Recording (called by domain contracts)
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `record_donation` | `env, amount: u64` | `Result<(), AnalyticsError>` | Authorized caller |
+| `record_request` | `env` | `Result<(), AnalyticsError>` | Authorized caller |
+| `record_delivery` | `env` | `Result<(), AnalyticsError>` | Authorized caller |
+| `record_payment_released` | `env, volume: u64` | `Result<(), AnalyticsError>` | Authorized caller |
+
+### Query
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `get_snapshot` | `env, period: PeriodType` | `Result<MetricsSnapshot, AnalyticsError>` | Public |
+| `get_reporting_period` | `env, period: PeriodType` | `ReportingPeriod` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | TTL | Description |
+|---|---|---|---|
+| `DataKey::Config` | Instance | Instance lifetime | `AnalyticsConfig` (admin + contract addresses) |
+| `DataKey::Snapshot(period_index)` | Persistent | Min ~17 days, max ~365 days | `MetricsSnapshot` for the given period index |
+
+### TTL Constants (in ledgers, at ~5 s/ledger)
+
+| Constant | Ledgers | Wall-clock |
+|---|---|---|
+| `SNAPSHOT_TTL_MIN` | 290 000 | ~17 days |
+| `SNAPSHOT_TTL_MAX` | 6 307 200 | ~365 days |
+
+---
+
+## Types
+
+### `PeriodType`
+```rust
+pub enum PeriodType { Daily, Weekly, Monthly }
+```
+
+`Monthly` uses a fixed 30-day rolling window, not a calendar month.
+
+### `MetricsSnapshot`
+```rust
+pub struct MetricsSnapshot {
+    pub period_index: u64,
+    pub total_donations: u64,
+    pub total_requests: u64,
+    pub total_deliveries: u64,
+    pub total_payments_released: u64,
+    pub total_volume: u64,
+    pub last_updated: u64,  // Unix timestamp
+}
+```
+
+---
+
+## Events
+
+| Topics | Data Format | When |
+|---|---|---|
+| `["anlytcs", "init"]` | `admin: Address` | Contract initialized |
+
+---
+
+## Error Codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| — | `NotInitialized` | `initialize` has not been called |
+| — | `AlreadyInitialized` | `initialize` called more than once |
+| — | `Unauthorized` | Caller is not admin or an authorized domain contract |
+
+---
+
+## Access Control
+
+Metric-recording functions accept calls from:
+- `cfg.admin`
+- `cfg.inventory_contract`
+- `cfg.requests_contract`
+- `cfg.payments_contract`
+- `cfg.reputation_contract`
+
+All other callers receive `AnalyticsError::Unauthorized`.

--- a/docs/contracts/coordinator.md
+++ b/docs/contracts/coordinator.md
@@ -1,0 +1,116 @@
+# Coordinator Contract
+
+**Location:** `lifebank-soroban/contracts/coordinator/src/lib.rs`  
+**Purpose:** Orchestrates the three-step HealthDonor workflow across the Inventory, Requests, and Payments contracts in a single atomic sequence. Any step that finds a prerequisite state missing returns an error without making state changes.
+
+---
+
+## Canonical Workflow Sequence
+
+```
+1. allocate_units   — Request must be Pending; reserves inventory units.
+2. confirm_delivery — Workflow must be Allocated; marks units Delivered.
+3. settle_payment   — Workflow must be Delivered; releases escrowed payment.
+```
+
+A workflow expires if `confirm_delivery` is not called within 6 hours of `allocate_units`. Anyone may call `expire_workflow` after expiry to roll back.
+
+---
+
+## Public Interface
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin, inventory_contract, requests_contract, payments_contract` | `Result<(), CoordinatorError>` | `admin` |
+| `allocate_units` | `env, caller, request_id, unit_ids: Vec<u64>` | `Result<u64, CoordinatorError>` (workflow_id) | Authorized |
+| `confirm_delivery` | `env, caller, workflow_id, excursion_summary?: ExcursionSummary` | `Result<(), CoordinatorError>` | Authorized |
+| `settle_payment` | `env, caller, workflow_id` | `Result<(), CoordinatorError>` | Authorized |
+| `expire_workflow` | `env, caller, workflow_id` | `Result<(), CoordinatorError>` | Anyone (after timeout) |
+| `flag_temperature_breach` | `env, caller, payment_id, excursion_summary` | `Result<(), CoordinatorError>` | TemperatureContract |
+| `get_workflow` | `env, workflow_id` | `Result<WorkflowRecord, CoordinatorError>` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::InventoryContract` | Instance | Inventory contract address |
+| `DataKey::RequestsContract` | Instance | Requests contract address |
+| `DataKey::PaymentsContract` | Instance | Payments contract address |
+| `DataKey::WorkflowCounter` | Instance | Auto-increment workflow ID |
+| `DataKey::Workflow(u64)` | Persistent | `WorkflowRecord` by workflow ID |
+
+---
+
+## Types
+
+### `WorkflowStatus`
+```rust
+pub enum WorkflowStatus {
+    Allocated,
+    Delivered,
+    Settled,
+    Expired,
+    TemperatureBreach,
+}
+```
+
+### `WorkflowRecord`
+```rust
+pub struct WorkflowRecord {
+    pub id: u64,
+    pub request_id: u64,
+    pub unit_ids: Vec<u64>,
+    pub status: WorkflowStatus,
+    pub allocated_at: u64,
+    pub delivered_at: Option<u64>,
+    pub settled_at: Option<u64>,
+    pub expires_at: u64,
+}
+```
+
+### `ExcursionSummary`
+Passed by the Temperature contract to summarise cold-chain violations:
+```rust
+pub struct ExcursionSummary {
+    pub unit_id: u64,
+    pub violation_count: u32,
+    pub max_deviation_x100: i32,
+}
+```
+
+---
+
+## Events
+
+| Topics | When |
+|---|---|
+| `["workflow", "allocated"]` | `allocate_units` succeeds |
+| `["workflow", "delivered"]` | `confirm_delivery` succeeds |
+| `["workflow", "settled"]` | `settle_payment` succeeds |
+| `["workflow", "expired"]` | `expire_workflow` succeeds |
+| `["workflow", "breach"]` | Temperature breach flagged |
+
+---
+
+## Error Codes
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | Contract has not been initialized |
+| `AlreadyInitialized` | `initialize` called more than once |
+| `Unauthorized` | Caller not permitted for this action |
+| `WorkflowNotFound` | No workflow with the given ID |
+| `InvalidWorkflowStatus` | Step called out of sequence |
+| `WorkflowExpired` | Workflow timeout has elapsed |
+| `WorkflowNotExpired` | `expire_workflow` called before timeout |
+
+---
+
+## Constants
+
+| Name | Value | Meaning |
+|---|---|---|
+| `WORKFLOW_TIMEOUT_SECS` | `21600` (6 hours) | Window between allocate and confirm |

--- a/docs/contracts/delivery.md
+++ b/docs/contracts/delivery.md
@@ -1,0 +1,76 @@
+# Delivery Contract
+
+**Location:** `lifebank-soroban/contracts/delivery/src/lib.rs`  
+**Purpose:** Records compliance attestations for blood-unit deliveries, including temperature compliance, photo proof, and recipient signature requirements. Linked to a Requests contract that governs which deliveries are valid.
+
+---
+
+## Public Interface
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address, request_contract: Address` | `Result<(), Error>` | `admin` |
+| `set_temperature_thresholds` | `env, admin, min_celsius: i32, max_celsius: i32` | `Result<(), Error>` | Admin |
+| `set_proof_requirements` | `env, admin, requirements: ProofRequirements` | `Result<(), Error>` | Admin |
+| `attest_compliance` | `env, delivery_id: u64, compliance_hash: Bytes, is_compliant: bool` | `Result<(), Error>` | Any caller |
+| `get_compliance` | `env, delivery_id: u64` | `Result<ComplianceAttestation, Error>` | Public |
+| `is_initialized` | `env` | `bool` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::RequestContract` | Instance | Linked requests contract address |
+| `DataKey::DeliveryCounter` | Instance | Auto-increment delivery ID |
+| `DataKey::TemperatureThresholds` | Instance | `TemperatureThresholds` struct |
+| `DataKey::ProofRequirements` | Instance | `ProofRequirements` struct |
+| `DataKey::ComplianceAttestation(u64)` | Persistent | Attestation record per delivery ID |
+
+---
+
+## Types
+
+### `TemperatureThresholds`
+```rust
+pub struct TemperatureThresholds {
+    pub min_celsius: i32,  // default: 2
+    pub max_celsius: i32,  // default: 6
+}
+```
+
+### `ProofRequirements`
+```rust
+pub struct ProofRequirements {
+    pub requires_photo_proof: bool,           // default: true
+    pub requires_recipient_signature: bool,   // default: true
+    pub requires_temperature_log: bool,       // default: true
+}
+```
+
+---
+
+## Events
+
+| Topics | Data Format | When |
+|---|---|---|
+| `["delivery", "init"]` | `[admin, request_contract]` | Contract initialized |
+| `["comply"]` | `[delivery_id, compliance_hash, is_compliant]` | Compliance attested |
+
+---
+
+## Error Codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| 700 | `AlreadyInitialized` | `initialize` called more than once |
+| 701 | `NotInitialized` | `initialize` has not been called |
+| 702 | `DeliveryNotFound` | No delivery with the given ID |
+
+---
+
+## Default Values
+
+Temperature range is set to 2–6 °C (standard blood storage) on `initialize`. All three proof requirements default to `true`.

--- a/docs/contracts/health-chain.md
+++ b/docs/contracts/health-chain.md
@@ -1,0 +1,117 @@
+# HealthChain Registry Contract
+
+**Location:** `contracts/src/lib.rs`  
+**Purpose:** The root Soroban contract for the HealthDonor Protocol. It maintains a verified registry of blood banks and hospitals, tracks individual blood unit lifecycles, and records payment and dispute state on-chain.
+
+---
+
+## Public Interface
+
+### Lifecycle & Metadata
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Symbol` | `admin` |
+| `version` | `env` | `u32` | Public |
+| `get_metadata` | `env` | `Map<Symbol, String>` | Public |
+| `is_feature_supported` | `env, feature: Symbol` | `bool` | Public |
+
+### Actor Registry
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `register_blood_bank` | `env, bank_id: Address` | `Result<(), Error>` | Admin |
+| `register_hospital` | `env, hospital_id: Address` | `Result<(), Error>` | Admin |
+| `activate_blood_bank` | `env, bank_id: Address` | `Result<(), Error>` | Admin |
+| `deactivate_blood_bank` | `env, bank_id: Address` | `Result<(), Error>` | Admin |
+| `activate_hospital` | `env, hospital_id: Address` | `Result<(), Error>` | Admin |
+| `deactivate_hospital` | `env, hospital_id: Address` | `Result<(), Error>` | Admin |
+| `is_blood_bank` | `env, bank_id: Address` | `bool` | Public |
+| `get_blood_bank_state` | `env, bank_id: Address` | `LifecycleState` | Public |
+| `get_hospital_state` | `env, hospital_id: Address` | `LifecycleState` | Public |
+| `get_organization_state` | `env, org_id: Address` | `LifecycleState` | Public |
+
+### Blood Unit Operations
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `register_blood` | `env, bank_id, unit_id, blood_type, quantity_ml, expiration_date` | `Result<(), Error>` | Blood Bank |
+| `batch_register_blood` | `env, bank_id, units: Vec<...>` | `Result<(), Error>` | Blood Bank |
+| `allocate_blood` | `env, bank_id, unit_id, hospital_id` | `Result<(), Error>` | Blood Bank |
+| `batch_allocate_blood` | `env, bank_id, unit_ids, hospital_id` | `Result<(), Error>` | Blood Bank |
+| `cancel_allocation` | `env, bank_id, unit_id` | `Result<(), Error>` | Blood Bank |
+| `initiate_transfer` | `env, bank_id, unit_id` | `Result<String, Error>` | Blood Bank |
+| `confirm_delivery` | `env, hospital, unit_id` | `Result<(), Error>` | Hospital |
+| `confirm_transfer` | `env, hospital, event_id` | `Result<(), Error>` | Hospital |
+| `cancel_transfer` | `env, bank_id, event_id` | `Result<String, Error>` | Blood Bank |
+| `withdraw_blood` | `env, bank_id, unit_id, reason` | `Result<(), Error>` | Blood Bank |
+| `quarantine_blood` | `env, bank_id, unit_id, reason` | `Result<(), Error>` | Blood Bank |
+| `finalize_quarantine` | `env, bank_id, unit_id, disposition` | `Result<(), Error>` | Blood Bank |
+| `get_blood_unit` | `env, unit_id` | `Result<BloodUnit, Error>` | Public |
+| `get_blood_status` | `env, unit_id` | `Result<BloodStatus, Error>` | Public |
+| `is_expired` | `env, unit_id` | `Result<bool, Error>` | Public |
+| `get_units_by_donor` | `env, donor_id: Symbol` | `Vec<BloodUnit>` | Public |
+
+### Payments & Disputes
+
+See `contracts/src/payments.rs` for `initiate_payment`, `release_payment`, `refund_payment`, `open_dispute`, `resolve_dispute`.
+
+---
+
+## Storage Layout
+
+| Key Type | Storage Tier | Description |
+|---|---|---|
+| `Admin` | Instance | Contract admin address |
+| `BloodBank(Address)` | Persistent | Blood bank registry entry |
+| `Hospital(Address)` | Persistent | Hospital registry entry |
+| `BloodUnit(u64)` | Persistent | Individual unit state |
+| `Payment(u64)` | Persistent | Payment record |
+| `Dispute(u64)` | Persistent | Dispute record |
+| `UnitCounter` | Instance | Auto-increment unit ID |
+| `PaymentCounter` | Instance | Auto-increment payment ID |
+
+---
+
+## Events
+
+| Topic | Data | When |
+|---|---|---|
+| `["register", "bank"]` | `bank_id: Address` | Blood bank registered |
+| `["register", "hospital"]` | `hospital_id: Address` | Hospital registered |
+| `["register", "blood"]` | `{unit_id, bank_id, blood_type}` | Blood unit registered |
+| `["transfer", "initiated"]` | `{event_id, unit_id, bank_id}` | Transfer started |
+| `["transfer", "confirmed"]` | `{event_id, unit_id, hospital}` | Delivery confirmed |
+| `["payment", "released"]` | `{payment_id, amount}` | Payment settled |
+| `["dispute", "opened"]` | `{dispute_id, payment_id}` | Dispute raised |
+| `["dispute", "resolved"]` | `{dispute_id, outcome}` | Dispute resolved |
+
+---
+
+## Error Codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| 1 | `Unauthorized` | Caller is not authorised for this action |
+| 2 | `InvalidQuantity` | Blood quantity is zero or negative |
+| 3 | `InvalidExpiration` | Expiration date is in the past |
+| 4 | `DuplicateRegistration` | Unit or actor already registered |
+| 5 | `StorageError` | Internal storage failure |
+| 6 | `InvalidStatus` | Operation not valid in current status |
+| 7 | `UnitNotFound` | Blood unit does not exist |
+| 8 | `UnitExpired` | Blood unit has passed its expiration date |
+| 9 | `UnauthorizedHospital` | Hospital is not in the verified registry |
+| 10 | `InvalidTransition` | Status transition is not permitted |
+| 11 | `AlreadyAllocated` | Unit is already allocated to a hospital |
+| 12 | `BatchSizeExceeded` | Batch exceeds the maximum allowed size |
+| 13 | `DuplicateRequest` | Identical request already exists |
+| 14 | `InvalidDeliveryAddress` | Delivery address is missing or malformed |
+| 15 | `InvalidRequiredBy` | Required-by timestamp is invalid |
+| 16 | `TransferExpired` | Transfer window has elapsed |
+| 17 | `TransferNotExpired` | Transfer window has not yet elapsed |
+| 18 | `PaymentNotFound` | Payment record does not exist |
+| 19 | `DisputeNotFound` | Dispute record does not exist |
+| 20 | `InvalidDisputeStatus` | Operation invalid for dispute's current status |
+| 21 | `DisputeAlreadyExists` | A dispute already exists for this payment |
+| 22 | `InvalidPaymentStatus` | Operation invalid for payment's current status |
+| 25 | `UnitIdTooLong` | Unit ID string exceeds maximum length |

--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -1,0 +1,120 @@
+# Identity Contract
+
+**Location:** `lifebank-soroban/contracts/identity/src/lib.rs`  
+**Purpose:** Manages verified organization identities (blood banks and hospitals), role-based access control, fine-grained permission scopes, and performance badges. Supports pause/unpause for emergency governance.
+
+---
+
+## Public Interface
+
+### Initialization & Admin
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Result<(), Error>` | `admin` |
+| `pause` | `env, admin` | `Result<(), Error>` | Admin |
+| `unpause` | `env, admin` | `Result<(), Error>` | Admin |
+| `transfer_admin` | `env, current_admin, new_admin` | `Result<(), Error>` | Admin |
+
+### Organization Management
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `register_organization` | `env, admin, org_id, license_number: String, org_type: OrgType` | `Result<(), Error>` | Admin |
+| `verify_organization` | `env, admin, org_id` | `Result<(), Error>` | Admin |
+| `unverify_organization` | `env, admin, org_id, reason: String` | `Result<(), Error>` | Admin |
+| `get_organization` | `env, org_id` | `Result<Organization, Error>` | Public |
+| `is_verified` | `env, org_id` | `bool` | Public |
+
+### Roles & Permissions
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `assign_role` | `env, admin, target, role: Role` | `Result<(), Error>` | Admin |
+| `revoke_role` | `env, admin, target` | `Result<(), Error>` | Admin |
+| `grant_permission` | `env, admin, target, scope: PermissionScope` | `Result<(), Error>` | Admin |
+| `revoke_permission` | `env, admin, target, scope: PermissionScope` | `Result<(), Error>` | Admin |
+| `has_permission` | `env, target, scope` | `bool` | Public |
+| `get_role` | `env, target` | `Option<Role>` | Public |
+
+### Ratings & Badges
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `submit_rating` | `env, rater, org_id, score: u32` | `Result<(), Error>` | Any caller |
+| `award_badge` | `env, admin, org_id, badge: BadgeType` | `Result<(), Error>` | Admin |
+| `revoke_badge` | `env, admin, org_id, badge` | `Result<(), Error>` | Admin |
+| `get_badges` | `env, org_id` | `Vec<BadgeType>` | Public |
+| `get_average_rating` | `env, org_id` | `Option<u32>` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | TTL (ledgers) | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | Instance lifetime | Admin address |
+| `DataKey::Paused` | Instance | Instance lifetime | Pause flag |
+| `DataKey::Organization(Address)` | Persistent | Bumped on access | Organization record |
+| `DataKey::Role(Address)` | Persistent | Bumped on access | Role assignment |
+| `DataKey::Permission(Address, PermissionScope)` | Persistent | Bumped on access | Permission grant |
+| `DataKey::Badge(Address, BadgeType)` | Persistent | Bumped on access | Badge award |
+| `DataKey::Rating(Address)` | Persistent | Bumped on access | Rating aggregate |
+
+### TTL Constants
+- `TTL_THRESHOLD`: 518 400 ledgers (~30 days) — bump when remaining TTL falls below this
+- `TTL_EXTEND_TO`: 1 036 800 ledgers (~60 days) — extend to this value on bump
+
+---
+
+## Enums
+
+### `OrgType`
+```rust
+pub enum OrgType { BloodBank, Hospital }
+```
+
+### `Role`
+```rust
+pub enum Role { Admin, BloodBank, Hospital, Donor, Rider, Custom(u32) }
+```
+
+### `PermissionScope`
+```rust
+pub enum PermissionScope {
+    InventoryWrite,
+    DispatchOverride,
+    RequestApprove,
+    DisputeResolve,
+    VerificationAdmin,
+    SettlementRelease,
+}
+```
+
+### `BadgeType`
+```rust
+pub enum BadgeType {
+    TopRated, HighCompliance, FastResponse, LongService, VerifiedProvider,
+}
+```
+
+---
+
+## Error Codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| 200 | `InvalidInput` | Required field is empty or malformed |
+| 201 | `LicenseAlreadyRegistered` | License number already in use |
+| 202 | `InvalidOrgType` | Unrecognised organisation type |
+| 203 | `AlreadyInitialized` | `initialize` called more than once |
+| 204 | `Unauthorized` | Caller is not admin |
+| 205 | `InvalidRating` | Rating score out of 1–5 range |
+| 206 | `AlreadyRated` | Rater has already rated this organisation |
+| 207 | `OrganizationNotFound` | No organisation with this address |
+| 208 | `BadgeAlreadyAwarded` | Badge already held by this organisation |
+| 209 | `BadgeNotFound` | Badge not held; cannot revoke |
+| 210 | `InvalidDeliveryProof` | Proof hash is missing or malformed |
+| 211 | `AlreadyVerified` | Organisation already verified |
+| 212 | `AlreadyUnverified` | Organisation already unverified |
+| 213 | `ContractPaused` | All state mutations blocked while paused |

--- a/docs/contracts/inventory.md
+++ b/docs/contracts/inventory.md
@@ -1,0 +1,138 @@
+# Inventory Contract
+
+**Location:** `lifebank-soroban/contracts/inventory/src/lib.rs`  
+**Purpose:** Manages blood unit inventory on-chain. Blood banks register, update, and transfer units; reservations lock inventory for pending requests and are automatically released after the reservation window expires.
+
+---
+
+## Public Interface
+
+### Initialization & Admin
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Result<(), ContractError>` | `admin` |
+| `pause` | `env, admin` | `Result<(), ContractError>` | Admin |
+| `unpause` | `env, admin` | `Result<(), ContractError>` | Admin |
+| `is_paused` | `env` | `bool` | Public |
+| `authorize_bank` | `env, admin, bank: Address, authorized: bool` | `Result<(), ContractError>` | Admin |
+| `is_authorized_bank` | `env, bank` | `bool` | Public |
+
+### Blood Unit Operations
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `register_unit` | `env, caller, unit: BloodUnit` | `Result<u64, ContractError>` | Authorized bank |
+| `update_unit_status` | `env, caller, unit_id, new_status: BloodStatus` | `Result<(), ContractError>` | Authorized bank |
+| `get_blood_unit` | `env, blood_unit_id: u64` | `BloodUnit` | Public |
+| `get_units_by_blood_type` | `env, blood_type: BloodType` | `Vec<u64>` | Public |
+| `get_units_by_bank` | `env, bank: Address` | `Vec<u64>` | Public |
+
+### Reservations
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `reserve_unit` | `env, caller, unit_id, requester: Address, duration_secs?: u64` | `Result<u64, ContractError>` (reservation_id) | Authorized bank |
+| `release_reservation` | `env, caller, reservation_id: u64` | `Result<(), ContractError>` | Authorized bank or Requests contract |
+| `get_reservation` | `env, reservation_id` | `Option<Reservation>` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::Paused` | Instance | Pause flag |
+| `DataKey::AuthorizedBank(Address)` | Persistent | Whether a blood bank is authorized |
+| `DataKey::BloodUnit(u64)` | Persistent | `BloodUnit` record |
+| `DataKey::UnitsByBloodType(BloodType)` | Persistent | `Vec<u64>` of unit IDs per blood type |
+| `DataKey::UnitsByBank(Address)` | Persistent | `Vec<u64>` of unit IDs per bank |
+| `DataKey::Reservation(u64)` | Persistent | Reservation record |
+| `DataKey::UnitCounter` | Instance | Auto-increment unit ID |
+| `DataKey::ReservationCounter` | Instance | Auto-increment reservation ID |
+
+---
+
+## Types
+
+### `BloodType`
+```rust
+pub enum BloodType {
+    APositive, ANegative, BPositive, BNegative,
+    ABPositive, ABNegative, OPositive, ONegative,
+}
+```
+
+### `BloodStatus`
+```rust
+pub enum BloodStatus {
+    Available, Reserved, Allocated, InTransit,
+    Delivered, Quarantined, Expired, Withdrawn,
+}
+```
+
+### `BloodUnit`
+```rust
+pub struct BloodUnit {
+    pub id: u64,
+    pub blood_type: BloodType,
+    pub quantity_ml: u32,
+    pub expiration_date: u64,  // Unix timestamp
+    pub registered_at: u64,
+    pub blood_bank: Address,
+    pub status: BloodStatus,
+    pub component: BloodComponent,
+    pub donor_id: Option<String>,
+}
+```
+
+### `Reservation`
+```rust
+pub struct Reservation {
+    pub id: u64,
+    pub unit_id: u64,
+    pub requester: Address,
+    pub reserved_at: u64,
+    pub expires_at: u64,
+}
+```
+
+---
+
+## Constants
+
+| Name | Value | Meaning |
+|---|---|---|
+| `MAX_RESERVATION_DURATION_SECS` | `604 800` (7 days) | Maximum reservation window |
+
+---
+
+## Status Transition Rules
+
+Valid transitions are defined in `types::is_valid_transition`:
+
+| From | To |
+|---|---|
+| `Available` | `Reserved`, `Allocated`, `Quarantined`, `Withdrawn` |
+| `Reserved` | `Allocated`, `Available` (released), `Expired` |
+| `Allocated` | `InTransit`, `Available` (cancelled) |
+| `InTransit` | `Delivered`, `Quarantined` |
+| `Quarantined` | `Withdrawn` |
+
+---
+
+## Error Codes
+
+See `lifebank-soroban/contracts/inventory/src/error.rs` for the full `ContractError` enum. Key codes:
+
+| Name | Meaning |
+|---|---|
+| `AlreadyInitialized` | `initialize` called more than once |
+| `Unauthorized` | Caller is not admin or authorized bank |
+| `ContractPaused` | All mutations blocked |
+| `UnitNotFound` | Blood unit does not exist |
+| `InvalidTransition` | Status transition not permitted |
+| `UnitAlreadyReserved` | Unit already has an active reservation |
+| `ReservationNotFound` | Reservation ID does not exist |
+| `ReservationExpired` | Reservation window has elapsed |

--- a/docs/contracts/matching.md
+++ b/docs/contracts/matching.md
@@ -1,0 +1,121 @@
+# Matching Contract
+
+**Location:** `lifebank-soroban/contracts/matching/src/lib.rs`  
+**Purpose:** Implements ABO/Rh-compatible blood matching logic on-chain. Given a blood request, it queries the Inventory contract for available units, scores and sorts them by compatibility and urgency, and returns ranked match results.
+
+---
+
+## Public Interface
+
+### Initialization
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin, inventory_contract, requests_contract` | `Result<(), MatchingError>` | `admin` |
+| `pause` | `env, admin` | `Result<(), MatchingError>` | Admin |
+| `unpause` | `env, admin` | `Result<(), MatchingError>` | Admin |
+
+### Matching
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `find_matches` | `env, request_id: u64, max_results?: u32` | `Result<Vec<MatchResult>, MatchingError>` | Public |
+| `preview_matches` | `env, blood_type: BloodType, component: BloodComponent, quantity_ml: u32, urgency: Urgency` | `Result<Vec<MatchResult>, MatchingError>` | Public |
+
+### Query
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `is_compatible` | `env, donor: BloodType, recipient: BloodType` | `bool` | Public |
+| `compatible_donor_types` | `env, recipient: BloodType` | `Vec<BloodType>` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::InventoryContract` | Instance | Inventory contract address |
+| `DataKey::RequestsContract` | Instance | Requests contract address |
+| `DataKey::Initialized` | Instance | Initialization flag |
+| `DataKey::Paused` | Instance | Pause flag |
+
+---
+
+## Types
+
+### `MatchKind`
+```rust
+pub enum MatchKind {
+    Exact,       // Same ABO/Rh type
+    Compatible,  // Donor compatible, different type
+}
+```
+
+### `MatchResult`
+```rust
+pub struct MatchResult {
+    pub unit_id: u64,
+    pub score: u32,
+    pub kind: MatchKind,
+    pub blood_type: BloodType,
+    pub quantity_ml: u32,
+    pub expiration_date: u64,
+}
+```
+
+### `Urgency`
+```rust
+pub enum Urgency { Routine, Urgent, Critical }
+```
+
+---
+
+## Scoring Algorithm
+
+`score_unit` computes a score for each candidate unit:
+- **Exact match** adds a large bonus; compatible-only match scores lower.
+- **Expiration proximity** — units expiring sooner score higher (FIFO logic reduces wastage).
+- **Urgency multiplier** — `Critical` requests weight expiration proximity less heavily than `Routine`.
+
+Units are then sorted by score descending via `sort_by_expiration`.
+
+---
+
+## Compatibility Matrix
+
+Implements standard ABO/Rh donation rules:
+
+| Donor | Can donate to |
+|---|---|
+| O− | All types |
+| O+ | O+, A+, B+, AB+ |
+| A− | A±, AB± |
+| A+ | A+, AB+ |
+| B− | B±, AB± |
+| B+ | B+, AB+ |
+| AB− | AB± |
+| AB+ | AB+ |
+
+---
+
+## Cross-Contract Clients
+
+The Matching contract calls:
+- `InventoryContractClient::get_blood_unit(env, blood_unit_id)`
+- `InventoryContractClient::get_units_by_blood_type(env, blood_type)`
+- `RequestsContractClient::get_request(env, request_id)`
+
+---
+
+## Error Codes
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | `initialize` not called |
+| `AlreadyInitialized` | `initialize` called twice |
+| `Unauthorized` | Caller is not admin |
+| `ContractPaused` | All mutations blocked |
+| `RequestNotFound` | Request ID does not exist |
+| `NoCompatibleUnits` | No inventory matches the request |

--- a/docs/contracts/payments.md
+++ b/docs/contracts/payments.md
@@ -1,0 +1,150 @@
+# Payments Contract
+
+**Location:** `lifebank-soroban/contracts/payments/src/lib.rs`  
+**Purpose:** Manages the full payment lifecycle for blood-unit transactions: escrow lock, conditional release, refund, and dispute resolution. Supports both native XLM and arbitrary SEP-41 tokens.
+
+---
+
+## Public Interface
+
+### Initialization
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Result<(), PaymentsError>` | `admin` |
+
+### Payment Lifecycle
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `lock_payment` | `env, payer, payee, request_id, amount: i128, token?: Address` | `Result<u64, PaymentsError>` (payment_id) | `payer` |
+| `release_payment` | `env, caller, payment_id` | `Result<(), PaymentsError>` | Admin or Coordinator |
+| `refund_payment` | `env, caller, payment_id` | `Result<(), PaymentsError>` | Admin |
+| `cancel_payment` | `env, caller, payment_id` | `Result<(), PaymentsError>` | `payer` while Pending |
+
+### Disputes
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `open_dispute` | `env, caller, payment_id, reason: DisputeReason` | `Result<(), PaymentsError>` | `payer` or `payee` |
+| `resolve_dispute` | `env, admin, payment_id, release_to_payee: bool, case_id: String` | `Result<(), PaymentsError>` | Admin |
+
+### Query
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `get_payment` | `env, payment_id` | `Result<Payment, PaymentsError>` | Public |
+| `get_payments_by_request` | `env, request_id` | `Vec<Payment>` | Public |
+| `get_payments_paginated` | `env, page: u32, page_size: u32` | `PaymentPage` | Public |
+| `get_stats` | `env` | `PaymentStats` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::PaymentCounter` | Instance | Auto-increment payment ID |
+| `DataKey::Payment(u64)` | Persistent | `Payment` record by ID |
+| `DataKey::RequestPayments(u64)` | Persistent | `Vec<u64>` of payment IDs per request |
+| `DataKey::Stats` | Instance | Aggregate `PaymentStats` |
+
+---
+
+## Types
+
+### `PaymentStatus`
+```rust
+pub enum PaymentStatus {
+    Pending,    // Created, awaiting lock
+    Locked,     // Funds held in escrow
+    Released,   // Funds transferred to payee
+    Refunded,   // Funds returned to payer
+    Disputed,   // Dispute open
+    Cancelled,  // Cancelled before lock
+}
+```
+
+### `Payment`
+```rust
+pub struct Payment {
+    pub id: u64,
+    pub request_id: u64,
+    pub payer: Address,
+    pub payee: Address,
+    pub amount: i128,
+    pub status: PaymentStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub dispute_reason_code: Option<u32>,
+    pub dispute_case_id: Option<String>,
+    pub dispute_resolved: bool,
+    pub token: Option<Address>,   // None = native XLM
+}
+```
+
+### `DisputeReason`
+```rust
+pub enum DisputeReason {
+    FailedDelivery,           // code 1
+    TemperatureExcursion,     // code 2
+    PaymentContested,         // code 3
+    WrongItem,                // code 4
+    DamagedGoods,             // code 5
+    LateDelivery,             // code 6
+    Other,                    // code 7
+}
+```
+
+### `PaymentStats`
+```rust
+pub struct PaymentStats {
+    pub total_locked: i128,
+    pub total_released: i128,
+    pub total_refunded: i128,
+    pub count_locked: u32,
+    pub count_released: u32,
+    pub count_refunded: u32,
+}
+```
+
+---
+
+## Events
+
+| Topics | Data | When |
+|---|---|---|
+| `["payment", "locked"]` | `{payment_id, amount, payer, payee}` | Escrow locked |
+| `["payment", "released"]` | `{payment_id, amount}` | Funds released to payee |
+| `["payment", "refunded"]` | `{payment_id, amount}` | Funds returned to payer |
+| `["payment", "disputed"]` | `{payment_id, reason_code}` | Dispute opened |
+| `["payment", "resolved"]` | `{payment_id, case_id, released_to_payee}` | Dispute resolved |
+
+---
+
+## Status Transition Rules
+
+```
+Pending → Locked  (lock_payment)
+Pending → Cancelled  (cancel_payment)
+Locked  → Released  (release_payment)
+Locked  → Refunded  (refund_payment)
+Locked  → Disputed  (open_dispute)
+Disputed → Released  (resolve_dispute, release_to_payee=true)
+Disputed → Refunded  (resolve_dispute, release_to_payee=false)
+```
+
+---
+
+## Error Codes
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | Contract not initialized |
+| `AlreadyInitialized` | `initialize` called twice |
+| `Unauthorized` | Caller not permitted |
+| `PaymentNotFound` | Payment ID does not exist |
+| `InvalidStatus` | Transition not valid in current status |
+| `DisputeAlreadyOpen` | A dispute is already open for this payment |
+| `InsufficientFunds` | Payer balance too low to lock |

--- a/docs/contracts/reputation.md
+++ b/docs/contracts/reputation.md
@@ -1,0 +1,140 @@
+# Reputation Contract
+
+**Location:** `lifebank-soroban/contracts/reputation/src/lib.rs`  
+**Purpose:** Computes and maintains a composite reputation score (0–100) for each actor (rider, blood bank, hospital) in the HealthDonor network. Scores are derived from weighted ratings, completion rate, response time, consistency, activity decay, and fraud penalties.
+
+---
+
+## Public Interface
+
+### Initialization & Config
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Result<(), ReputationError>` | `admin` |
+| `set_config` | `env, admin, config: ReputationConfig` | `Result<(), ReputationError>` | Admin |
+
+### Score Updates
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `submit_rating` | `env, rater, entity, score: i64, timestamp: u64` | `Result<(), ReputationError>` | Any caller |
+| `record_completion` | `env, caller, entity, response_time_secs: u64` | `Result<(), ReputationError>` | Authorized caller |
+| `apply_violation` | `env, admin, entity, violation: ViolationType` | `Result<(), ReputationError>` | Admin |
+| `flag_fraud` | `env, admin, entity` | `Result<(), ReputationError>` | Admin |
+| `resolve_penalty` | `env, admin, entity, penalty_id: u32` | `Result<(), ReputationError>` | Admin |
+| `appeal_penalty` | `env, entity, penalty_id: u32` | `Result<(), ReputationError>` | Entity itself |
+
+### Score Query
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `get_score` | `env, entity` | `Result<i64, ReputationError>` | Public |
+| `get_profile` | `env, entity` | `Result<ReputationProfile, ReputationError>` | Public |
+| `get_leaderboard` | `env, limit: u32` | `Vec<(Address, i64)>` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::Config` | Instance | `ReputationConfig` |
+| `DataKey::Profile(Address)` | Persistent | Full `ReputationProfile` per entity |
+| `DataKey::Leaderboard` | Persistent | Sorted `Vec<(Address, i64)>` |
+
+---
+
+## Scoring Algorithm
+
+Score is calculated as a weighted sum (all arithmetic is integer, scaled ×100 for two decimal places):
+
+| Component | Weight |
+|---|---|
+| Weighted average rating (recency-adjusted) | 35% |
+| Completion rate | 25% |
+| Response time | 20% |
+| Consistency bonus | 10% |
+
+Additional adjustments:
+- **Activity decay**: −1 point per 30-day period of inactivity (cap: −20 points).
+- **Recency half-life**: ratings older than 90 days count at half weight.
+- **Fraud penalty**: −15 points per confirmed fraud flag (cap: −50 points).
+- **Violation penalties** (expire after 60 days):
+  - `Minor`: −5 points
+  - `Medium`: −15 points
+  - `Serious`: −40 points
+- **Consistency bonus**: +10 points if rating std-dev ≤ 0.5; +5 points if ≤ 1.0.
+
+Final score is clamped to [0, 100].
+
+---
+
+## Types
+
+### `ViolationType`
+```rust
+pub enum ViolationType { Minor = 0, Medium = 1, Serious = 2 }
+```
+
+### `RatingEvent`
+```rust
+pub struct RatingEvent {
+    pub score: i64,     // 1_00–5_00 (×100)
+    pub timestamp: u64, // Unix timestamp
+}
+```
+
+### `PenaltyRecord`
+```rust
+pub struct PenaltyRecord {
+    pub id: u32,
+    pub violation_type: ViolationType,
+    pub timestamp: u64,
+    pub is_resolved: bool,
+    pub is_appealed: bool,
+}
+```
+
+---
+
+## Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `W_RATING` | 35 | Rating component weight |
+| `W_COMPLETION` | 25 | Completion rate weight |
+| `W_RESPONSE` | 20 | Response time weight |
+| `W_CONSISTENCY` | 10 | Consistency bonus weight |
+| `DECAY_PERIOD_SECS` | 2 592 000 (30 days) | Inactivity decay period |
+| `MAX_DECAY` | 20_00 | Cap on inactivity decay |
+| `HALF_LIFE_SECS` | 7 776 000 (90 days) | Rating recency half-life |
+| `FRAUD_FLAG_PENALTY` | 15_00 | Per confirmed fraud flag |
+| `MAX_FRAUD_PENALTY` | 50_00 | Cap on total fraud penalty |
+| `PENALTY_EXPIRY_SECS` | 5 184 000 (60 days) | Violation penalty expiry |
+
+---
+
+## Events
+
+| Topics | Data | When |
+|---|---|---|
+| `["rating", "submitted"]` | `{entity, score, timestamp}` | Rating recorded |
+| `["violation", "applied"]` | `{entity, violation_type, penalty_id}` | Violation penalty applied |
+| `["fraud", "flagged"]` | `{entity}` | Fraud flag confirmed |
+| `["score", "updated"]` | `{entity, new_score}` | Score recalculated |
+
+---
+
+## Error Codes
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | Contract not initialized |
+| `AlreadyInitialized` | `initialize` called twice |
+| `Unauthorized` | Caller not permitted |
+| `EntityNotFound` | No profile for this address |
+| `InvalidRating` | Rating outside configured min/max |
+| `PenaltyNotFound` | Penalty ID does not exist |
+| `PenaltyAlreadyResolved` | Penalty is already resolved |

--- a/docs/contracts/requests.md
+++ b/docs/contracts/requests.md
@@ -1,0 +1,149 @@
+# Requests Contract
+
+**Location:** `lifebank-soroban/contracts/requests/src/lib.rs`  
+**Purpose:** Manages blood request records on-chain. Hospitals create requests; the contract enforces valid status transitions, appends an immutable history trail to each request, and integrates with the Inventory contract to release reservations on cancellation.
+
+---
+
+## Public Interface
+
+### Initialization
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin, inventory_contract` | `Result<(), ContractError>` | `admin` |
+
+### Request Lifecycle
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `create_request` | `env, hospital, blood_type, component, quantity_ml, urgency, required_by, notes` | `Result<u64, ContractError>` (request_id) | Hospital |
+| `approve_request` | `env, caller, request_id, reason: String` | `Result<(), ContractError>` | Admin / Blood Bank |
+| `reject_request` | `env, caller, request_id, reason: String` | `Result<(), ContractError>` | Admin / Blood Bank |
+| `start_fulfillment` | `env, caller, request_id, reason: String` | `Result<(), ContractError>` | Authorized caller |
+| `fulfill_request` | `env, caller, request_id, fulfilled_ml: u32, reason, reservation_id?: u64` | `Result<(), ContractError>` | Authorized caller |
+
+### Query
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `get_request` | `env, request_id: u64` | `BloodRequest` | Public |
+| `get_request_history` | `env, request_id` | `Vec<RequestHistoryEntry>` | Public |
+| `get_metadata` | `env` | `ContractMetadata` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | Description |
+|---|---|---|
+| `DataKey::Admin` | Instance | Admin address |
+| `DataKey::InventoryContract` | Instance | Inventory contract address |
+| `DataKey::RequestCounter` | Instance | Auto-increment request ID |
+| `DataKey::Request(u64)` | Persistent | Full `BloodRequest` record |
+
+---
+
+## Types
+
+### `RequestStatus`
+```rust
+pub enum RequestStatus {
+    Pending,
+    Approved,
+    Rejected,
+    InProgress,
+    Fulfilled,
+}
+```
+
+### `BloodRequest`
+```rust
+pub struct BloodRequest {
+    pub id: u64,
+    pub hospital: Address,
+    pub blood_type: BloodType,
+    pub component: BloodComponent,
+    pub quantity_ml: u32,
+    pub urgency: Urgency,
+    pub required_by: u64,        // Unix timestamp
+    pub notes: String,
+    pub status: RequestStatus,
+    pub fulfilled_ml: u32,
+    pub history: Vec<RequestHistoryEntry>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+```
+
+### `RequestHistoryEntry`
+```rust
+pub struct RequestHistoryEntry {
+    pub previous_status: RequestStatus,
+    pub is_initial_transition: bool,
+    pub new_status: RequestStatus,
+    pub actor: Address,
+    pub reason: String,
+    pub fulfilled_delta_ml: u32,
+    pub released_reservation: bool,
+    pub timestamp: u64,
+}
+```
+
+### `Urgency`
+```rust
+pub enum Urgency { Routine, Urgent, Critical }
+```
+
+### `BloodComponent`
+```rust
+pub enum BloodComponent {
+    WholeBlood, RedBloodCells, Platelets, Plasma, Cryoprecipitate,
+}
+```
+
+---
+
+## Status Transition Rules
+
+```
+Pending    → Approved
+Pending    → Rejected
+Approved   → Rejected
+Approved   → InProgress
+Approved   → Fulfilled
+InProgress → Fulfilled
+```
+
+Any other transition returns `ContractError::InvalidTransition`.
+
+---
+
+## Events
+
+Emitted via `RequestCreatedEvent`:
+```rust
+pub struct RequestCreatedEvent {
+    pub request_id: u64,
+    pub hospital: Address,
+    pub blood_type: BloodType,
+    pub urgency: Urgency,
+}
+```
+
+---
+
+## Error Codes
+
+See `lifebank-soroban/contracts/requests/src/error.rs`. Key codes:
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | Contract not initialized |
+| `AlreadyInitialized` | `initialize` called twice |
+| `Unauthorized` | Caller not permitted |
+| `RequestNotFound` | Request ID does not exist |
+| `InvalidTransition` | Status transition not allowed |
+| `InvalidReason` | Reason string is empty |
+| `InvalidRequiredBy` | `required_by` timestamp is in the past |
+| `FulfillmentExceedsRequest` | `fulfilled_ml` exceeds `quantity_ml` |

--- a/docs/contracts/temperature.md
+++ b/docs/contracts/temperature.md
@@ -1,0 +1,158 @@
+# Temperature Contract
+
+**Location:** `lifebank-soroban/contracts/temperature/src/lib.rs`  
+**Purpose:** Records cold-chain temperature readings for blood units in transit, detects excursions against configurable thresholds, and notifies the Coordinator contract when a breach is confirmed. Threshold changes are governed by a 7-day time-lock.
+
+---
+
+## Public Interface
+
+### Initialization & Oracles
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `initialize` | `env, admin: Address` | `Result<(), ContractError>` | `admin` |
+| `add_oracle` | `env, admin, oracle: Address` | `Result<(), ContractError>` | Admin |
+| `remove_oracle` | `env, admin, oracle: Address` | `Result<(), ContractError>` | Admin |
+| `is_oracle` | `env, address` | `bool` | Public |
+
+### Threshold Governance (time-lock)
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `propose_threshold` | `env, admin, unit_id: u64, min_celsius_x100: i32, max_celsius_x100: i32` | `Result<(), ContractError>` | Admin |
+| `apply_threshold` | `env, admin, unit_id: u64` | `Result<(), ContractError>` | Admin (after 7-day delay) |
+| `get_threshold` | `env, unit_id: u64` | `TemperatureThreshold` | Public |
+
+### Temperature Recording
+
+| Function | Parameters | Returns | Auth |
+|---|---|---|---|
+| `record_reading` | `env, oracle, unit_id: u64, celsius_x100: i32, payment_id: u64` | `Result<(), ContractError>` | Registered oracle |
+| `get_readings` | `env, unit_id: u64, page: u32` | `Vec<TemperatureReading>` | Public |
+| `get_summary` | `env, unit_id: u64` | `TemperatureSummary` | Public |
+| `get_excursion_summary` | `env, unit_id: u64` | `ExcursionSummary` | Public |
+
+---
+
+## Storage Layout
+
+| Key | Storage Tier | TTL (ledgers) | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | Instance lifetime | Admin address |
+| `DataKey::Oracle(Address)` | Persistent | Bumped on access | Oracle approval flag |
+| `DataKey::Threshold(u64)` | Persistent | Persistent | `TemperatureThreshold` per unit |
+| `DataKey::PendingThreshold(u64)` | Persistent | Persistent | `PendingThresholdChange` awaiting time-lock |
+| `DataKey::Readings(u64)` | Persistent | Persistent | `Vec<TemperatureReading>` per unit (paginated) |
+| `DataKey::Summary(u64)` | Persistent | Persistent | `TemperatureSummary` per unit |
+
+### Oracle TTL Constants
+
+| Name | Ledgers | Wall-clock |
+|---|---|---|
+| `ORACLE_BUMP_THRESHOLD` | 518 400 | ~30 days |
+| `ORACLE_BUMP_TO` | 1 036 800 | ~60 days |
+
+---
+
+## Types
+
+### `TemperatureThreshold`
+```rust
+pub struct TemperatureThreshold {
+    pub min_celsius_x100: i32,  // e.g. 200 = 2.00 °C
+    pub max_celsius_x100: i32,  // e.g. 600 = 6.00 °C
+}
+```
+
+All temperature values are stored as integers scaled ×100 to avoid floating-point on-chain.
+
+### `TemperatureReading`
+```rust
+pub struct TemperatureReading {
+    pub celsius_x100: i32,
+    pub timestamp: u64,
+    pub oracle: Address,
+    pub is_excursion: bool,
+}
+```
+
+### `TemperatureSummary`
+```rust
+pub struct TemperatureSummary {
+    pub unit_id: u64,
+    pub total_readings: u32,
+    pub excursion_count: u32,
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+}
+```
+
+### `ExcursionSummary` (shared with Coordinator)
+```rust
+pub struct ExcursionSummary {
+    pub unit_id: u64,
+    pub violation_count: u32,
+    pub max_deviation_x100: i32,
+}
+```
+
+### `PendingThresholdChange`
+```rust
+pub struct PendingThresholdChange {
+    pub min_celsius_x100: i32,
+    pub max_celsius_x100: i32,
+    pub effective_at: u64,  // Unix timestamp after 7-day delay
+}
+```
+
+---
+
+## Events
+
+| Topics | Data Format | When |
+|---|---|---|
+| `["threshold", "proposed"]` | `[unit_id, min, max, effective_at]` | Threshold change proposed |
+| `["threshold", "applied"]` | `[unit_id, min, max]` | Threshold change applied |
+| `["oracle", "added"]` | `oracle: Address` | Oracle registered |
+| `["oracle", "removed"]` | `oracle: Address` | Oracle deregistered |
+| `["tmp_excur"]` | `[unit_id, payment_id, violation_count]` | Temperature excursion detected |
+
+---
+
+## Constants
+
+| Name | Value | Meaning |
+|---|---|---|
+| `PAGE_SIZE` | 20 | Readings returned per page in `get_readings` |
+| Threshold time-lock | 7 days | Minimum delay before `apply_threshold` succeeds |
+
+---
+
+## Error Codes
+
+See `lifebank-soroban/contracts/temperature/src/error.rs`. Key codes:
+
+| Name | Meaning |
+|---|---|
+| `NotInitialized` | Contract not initialized |
+| `AlreadyInitialized` | `initialize` called twice |
+| `Unauthorized` | Caller is not admin |
+| `NotAnOracle` | Caller not in the oracle registry |
+| `ThresholdNotFound` | No threshold set for this unit |
+| `NoPendingThreshold` | `apply_threshold` called with no pending change |
+| `TimeLockNotExpired` | 7-day delay has not yet elapsed |
+
+---
+
+## Cross-Contract Integration
+
+When an excursion is detected during `record_reading`, the contract calls:
+
+```rust
+CoordinatorContractClient::flag_temperature_breach(
+    env, caller, payment_id, excursion_summary
+)
+```
+
+This notifies the Coordinator to update the workflow status to `TemperatureBreach`, which blocks automatic payment settlement.


### PR DESCRIPTION
## Summary

Resolves four documentation issues in one PR.

### Changes

**Contract reference docs (#1040)**
- Added `docs/contracts/<name>.md` for all 11 contracts covering public interface, storage layout, events, error codes, and access control matrix.

**End-to-end setup guide (#1038)**
- Expanded `CONTRIBUTING.md` with full local development setup: system dependencies, Docker infrastructure, backend `.env` configuration, migrations, frontend startup, and contract deployment to testnet.
- Updated root `README.md` Getting Started section with prerequisites table, quick-start commands, service ports, and links to `CONTRIBUTING.md` and `docs/`.

**OpenAPI/Swagger (#1039)**
- `backend/src/main.ts` already has `SwaggerModule` configured; Swagger UI served at `/docs`.
- Added `@ApiTags` to all controllers missing it (`BloodUnitsController`, `SurgeSimulationController`, and the 50+ other controllers touched in prior work).

**Architecture diagram (#1041)**
- Added `docs/architecture.md` with Mermaid diagrams: system overview, backend module boundaries, blood request lifecycle sequence, BullMQ queue topology, WebSocket gateways, and infrastructure layout.

## Issues closed

closes #1040
closes #1038
closes #1039
closes #1041