### PR TITLE
feat: Add Firebase & SMS health indicators and database migrations

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -84,6 +84,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
+    "@types/africastalking": "^0.3.2",
     "@types/babel__core": "^7.20.5",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -13,6 +13,8 @@ import { RequirePermissions } from '../auth/decorators/require-permissions.decor
 import { SorobanRpcHealthIndicator } from './indicators/soroban-rpc.health-indicator';
 import { BullMQHealthIndicator } from './indicators/bullmq.health-indicator';
 import { RedisHealthIndicator } from './indicators/redis.health-indicator';
+import { FirebaseHealthIndicator } from './indicators/firebase.health-indicator';
+import { SmsHealthIndicator } from './indicators/sms.health-indicator';
 
 @ApiTags('health')
 @Controller('health')
@@ -24,6 +26,8 @@ export class HealthController {
     private readonly soroban: SorobanRpcHealthIndicator,
     private readonly bullmq: BullMQHealthIndicator,
     private readonly memory: MemoryHealthIndicator,
+    private readonly firebase: FirebaseHealthIndicator,
+    private readonly sms: SmsHealthIndicator,
   ) {}
 
   /**
@@ -41,6 +45,8 @@ export class HealthController {
         () => this.redis.isHealthy('redis'),
         () => this.soroban.isHealthy('soroban_rpc'),
         () => this.bullmq.isHealthy('bullmq'),
+        () => this.firebase.isHealthy('firebase'),
+        () => this.sms.isHealthy('sms'),
       ]);
       return { status: 'ok' };
     } catch {
@@ -63,6 +69,8 @@ export class HealthController {
       () => this.redis.isHealthy('redis'),
       () => this.soroban.isHealthy('soroban_rpc'),
       () => this.bullmq.isHealthy('bullmq'),
+      () => this.firebase.isHealthy('firebase'),
+      () => this.sms.isHealthy('sms'),
       () => this.memory.checkHeap('memory_heap', 300 * 1024 * 1024),
     ]);
   }

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -7,6 +7,10 @@ import { HealthController } from './health.controller';
 import { SorobanRpcHealthIndicator } from './indicators/soroban-rpc.health-indicator';
 import { BullMQHealthIndicator } from './indicators/bullmq.health-indicator';
 import { RedisHealthIndicator } from './indicators/redis.health-indicator';
+import { FirebaseHealthIndicator } from './indicators/firebase.health-indicator';
+import { SmsHealthIndicator } from './indicators/sms.health-indicator';
+import { PushProvider } from '../notifications/providers/push.provider';
+import { SmsProvider } from '../notifications/providers/sms.provider';
 
 @Module({
   imports: [
@@ -20,6 +24,10 @@ import { RedisHealthIndicator } from './indicators/redis.health-indicator';
     SorobanRpcHealthIndicator,
     BullMQHealthIndicator,
     RedisHealthIndicator,
+    FirebaseHealthIndicator,
+    SmsHealthIndicator,
+    PushProvider,
+    SmsProvider,
   ],
 })
 export class HealthModule {}

--- a/backend/src/health/indicators/firebase.health-indicator.ts
+++ b/backend/src/health/indicators/firebase.health-indicator.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import { PushProvider } from '../../notifications/providers/push.provider';
+
+@Injectable()
+export class FirebaseHealthIndicator extends HealthIndicator {
+  constructor(private readonly pushProvider: PushProvider) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const isHealthy = this.pushProvider.isHealthy();
+
+    if (!isHealthy) {
+      throw new HealthCheckError(
+        'Firebase check failed',
+        this.getStatus(key, false, { message: 'Firebase credentials not initialized' }),
+      );
+    }
+
+    return this.getStatus(key, true);
+  }
+}

--- a/backend/src/health/indicators/sms.health-indicator.ts
+++ b/backend/src/health/indicators/sms.health-indicator.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import { SmsProvider } from '../../notifications/providers/sms.provider';
+
+@Injectable()
+export class SmsHealthIndicator extends HealthIndicator {
+  constructor(private readonly smsProvider: SmsProvider) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const isHealthy = this.smsProvider.isHealthy();
+
+    if (!isHealthy) {
+      throw new HealthCheckError(
+        'SMS check failed',
+        this.getStatus(key, false, { message: 'Africa Talking API key not configured' }),
+      );
+    }
+
+    return this.getStatus(key, true);
+  }
+}

--- a/backend/src/migrations/1973000000000-AddFulfillmentLegAndRequestStatusHistory.ts
+++ b/backend/src/migrations/1973000000000-AddFulfillmentLegAndRequestStatusHistory.ts
@@ -1,0 +1,275 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class AddFulfillmentLegAndRequestStatusHistory1973000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'fulfillment_legs',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'parent_request_id',
+            type: 'varchar',
+            length: '64',
+          },
+          {
+            name: 'leg_number',
+            type: 'int',
+          },
+          {
+            name: 'blood_bank_id',
+            type: 'varchar',
+            length: '64',
+          },
+          {
+            name: 'blood_bank_name',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'allocated_units',
+            type: 'text',
+          },
+          {
+            name: 'quantity_ml',
+            type: 'int',
+          },
+          {
+            name: 'rider_id',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+          },
+          {
+            name: 'rider_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            length: '24',
+            default: `'PENDING'`,
+          },
+          {
+            name: 'estimated_delivery_time',
+            type: 'bigint',
+            isNullable: true,
+          },
+          {
+            name: 'actual_delivery_time',
+            type: 'bigint',
+            isNullable: true,
+          },
+          {
+            name: 'pickup_location',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'delivery_location',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'failure_reason',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'notes',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'request_status_history',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'request_id',
+            type: 'uuid',
+          },
+          {
+            name: 'previous_status',
+            type: 'varchar',
+            length: '32',
+            isNullable: true,
+          },
+          {
+            name: 'new_status',
+            type: 'varchar',
+            length: '32',
+          },
+          {
+            name: 'reason',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'changed_by_user_id',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Add foreign keys and indexes
+    await queryRunner.createForeignKey(
+      'fulfillment_legs',
+      new TableForeignKey({
+        name: 'FK_fulfillment_legs_parent_request',
+        columnNames: ['parent_request_id'],
+        referencedTableName: 'blood_requests',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'fulfillment_legs',
+      new TableIndex({
+        name: 'idx_fulfillment_legs_parent_request',
+        columnNames: ['parent_request_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'fulfillment_legs',
+      new TableIndex({
+        name: 'idx_fulfillment_legs_status',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'fulfillment_legs',
+      new TableIndex({
+        name: 'idx_fulfillment_legs_blood_bank',
+        columnNames: ['blood_bank_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'fulfillment_legs',
+      new TableIndex({
+        name: 'idx_fulfillment_legs_rider',
+        columnNames: ['rider_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'request_status_history',
+      new TableForeignKey({
+        name: 'FK_request_status_history_request',
+        columnNames: ['request_id'],
+        referencedTableName: 'blood_requests',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'request_status_history',
+      new TableIndex({
+        name: 'IDX_REQUEST_STATUS_HISTORY_REQUEST_ID',
+        columnNames: ['request_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'request_status_history',
+      new TableIndex({
+        name: 'IDX_REQUEST_STATUS_HISTORY_CREATED_AT',
+        columnNames: ['created_at'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey(
+      'request_status_history',
+      'FK_request_status_history_request',
+    );
+    await queryRunner.dropIndex(
+      'request_status_history',
+      'IDX_REQUEST_STATUS_HISTORY_CREATED_AT',
+    );
+    await queryRunner.dropIndex(
+      'request_status_history',
+      'IDX_REQUEST_STATUS_HISTORY_REQUEST_ID',
+    );
+    await queryRunner.dropTable('request_status_history', true);
+
+    await queryRunner.dropForeignKey(
+      'fulfillment_legs',
+      'FK_fulfillment_legs_parent_request',
+    );
+    await queryRunner.dropIndex(
+      'fulfillment_legs',
+      'idx_fulfillment_legs_rider',
+    );
+    await queryRunner.dropIndex(
+      'fulfillment_legs',
+      'idx_fulfillment_legs_blood_bank',
+    );
+    await queryRunner.dropIndex(
+      'fulfillment_legs',
+      'idx_fulfillment_legs_status',
+    );
+    await queryRunner.dropIndex(
+      'fulfillment_legs',
+      'idx_fulfillment_legs_parent_request',
+    );
+    await queryRunner.dropTable('fulfillment_legs', true);
+  }
+}

--- a/backend/src/notifications/providers/push.provider.ts
+++ b/backend/src/notifications/providers/push.provider.ts
@@ -60,4 +60,8 @@ export class PushProvider {
       throw error;
     }
   }
+
+  isHealthy(): boolean {
+    return this.initialized;
+  }
 }

--- a/backend/src/notifications/providers/sms.provider.ts
+++ b/backend/src/notifications/providers/sms.provider.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-import AfricasTalking from 'africastalking';
+import AfricasTalking, { AfricasTalkingOptions } from 'africastalking';
 
 @Injectable()
 export class SmsProvider {
   private readonly logger = new Logger(SmsProvider.name);
-  private africastalking: any;
+  private africastalking: ReturnType<typeof AfricasTalking> | null = null;
 
   constructor(private configService: ConfigService) {
     const apiKey = this.configService.get<string>('AT_API_KEY');
@@ -40,5 +40,9 @@ export class SmsProvider {
       this.logger.error(`Failed to send SMS to ${to}`, error);
       throw error;
     }
+  }
+
+  isHealthy(): boolean {
+    return this.africastalking !== null;
   }
 }


### PR DESCRIPTION
## Summary

Resolves #1006, #1007, #1008, #1009 — Health endpoint now detects push notification and SMS provider failures.

## Changes

### #1006 — Firebase health indicator
- Add `PushProvider.isHealthy()` returning Firebase initialization state
- Create FirebaseHealthIndicator wired into /health endpoints

### #1007 — SMS health indicator  
- Add `SmsProvider.isHealthy()` returning Africa Talking client state
- Create SmsHealthIndicator wired into /health endpoints

### #1008 — SMS provider type safety
- Add `@types/africastalking` to devDependencies
- Replace `private africastalking: any` with proper ReturnType type

### #1009 — Database migrations
- Create fulfillment_legs table with status tracking, indexes, foreign key
- Create request_status_history table with audit trail, indexes, foreign key
- Ready to run: `npm run migration:run`

## Notes

- Operators can now programmatically detect push/SMS dry-run mode via /health/details
- All provider health checks integrated into public (/health) and admin (/health/details) endpoints
- Migrations generated with proper indexes and CASCADE delete constraints

Closes #1006, Closes #1007, Closes #1008, Closes #1009