### PR TITLE
fix(payments): restrict update_status to non-terminal transitions

### DIFF
--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -141,6 +141,9 @@ pub enum Error {
     InvalidVestingSchedule = 518,
     /// Arithmetic overflow detected in running totals.
     Overflow = 518,
+    /// Invalid status transition — terminal states (Released/Refunded/Cancelled)
+    /// require fund-moving functions (release_escrow/refund_escrow).
+    InvalidStatusTransition = 519,
 }
 
 // ── Storage keys ───────────────────────────────────────────────────────────────
@@ -935,6 +938,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Admin-only status updater for NON-TERMINAL transitions only.
+    /// 
+    /// SECURITY FIX (issue #1120): This function now rejects terminal states
+    /// (Released, Refunded, Cancelled) to prevent bypassing escrow token transfers.
+    /// For fund-moving transitions, use `release_escrow` or `refund_escrow` instead.
+    /// 
+    /// Allowed transitions:
+    /// - Pending → Locked (manual escrow lock)
+    /// - Disputed → Locked (reset after dispute resolution)
+    /// - Any → Disputed (flag for review)
     pub fn update_status(
         env: Env,
         payment_id: u64,
@@ -944,17 +957,26 @@ impl PaymentContract {
         caller.require_auth();
         Self::require_not_paused(&env)?;
         Self::require_admin(&env, &caller)?;
+        
+        // SECURITY: Reject terminal states that require token transfers
+        if matches!(status, PaymentStatus::Released | PaymentStatus::Refunded | PaymentStatus::Cancelled) {
+            return Err(Error::InvalidStatusTransition);
+        }
+        
         let mut payment = load_payment(&env, payment_id).ok_or(Error::PaymentNotFound)?;
         let old_status = payment.status;
+        
+        // Additional validation: prevent transitioning FROM terminal states
+        if matches!(old_status, PaymentStatus::Released | PaymentStatus::Refunded | PaymentStatus::Cancelled) {
+            return Err(Error::InvalidStatusTransition);
+        }
+        
         payment.status = status;
         payment.updated_at = env.ledger().timestamp();
         store_payment(&env, &payment);
         remove_from_status_index(&env, old_status, payment_id);
         index_by_status(&env, status, payment_id);
         update_stats_on_transition(&env, payment.amount, old_status, status)?;
-        if matches!(status, PaymentStatus::Released | PaymentStatus::Refunded | PaymentStatus::Cancelled) {
-            remove_from_request_index(&env, payment.request_id);
-        }
 
         // Emit event on every status transition so off-chain indexers can stay
         // in sync without polling. Topics: ("payment", "status") so indexers can

--- a/lifebank-soroban/contracts/payments/src/test.rs
+++ b/lifebank-soroban/contracts/payments/src/test.rs
@@ -962,3 +962,102 @@ fn test_create_escrow_rejects_negative_amount() {
     let result = client.try_create_escrow(&1u64, &hospital, &payee, &-1i128, &token_id);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)), "Negative amount escrow must be rejected");
 }
+
+// ── Security fix: update_status bypass (issue #1120) ─────────────────────────
+
+/// update_status rejects terminal states (Released/Refunded/Cancelled) to prevent
+/// bypassing escrow token transfers.
+#[test]
+fn test_update_status_rejects_terminal_states() {
+    let (env, cid) = setup();
+    let client = PaymentContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let token_id = deploy_token_with_balance(&env, &admin, &admin, 10_000);
+    let hospital = Address::generate(&env);
+    let payee = Address::generate(&env);
+
+    // Create escrow payment (status = Locked)
+    let pid = client.create_escrow(&1u64, &hospital, &payee, &1_000i128, &token_id);
+
+    // Attempt to bypass release_escrow by calling update_status with Released
+    let result = client.try_update_status(&pid, &PaymentStatus::Released, &admin);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidStatusTransition)),
+        "update_status must reject Released (requires token transfer)"
+    );
+
+    // Attempt to bypass refund_escrow by calling update_status with Refunded
+    let result = client.try_update_status(&pid, &PaymentStatus::Refunded, &admin);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidStatusTransition)),
+        "update_status must reject Refunded (requires token transfer)"
+    );
+
+    // Attempt to set Cancelled
+    let result = client.try_update_status(&pid, &PaymentStatus::Cancelled, &admin);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidStatusTransition)),
+        "update_status must reject Cancelled (terminal state)"
+    );
+
+    // Verify payment is still Locked
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Locked, "Payment should remain Locked");
+}
+
+/// update_status rejects transitions FROM terminal states.
+#[test]
+fn test_update_status_rejects_transitions_from_terminal() {
+    let (env, cid) = setup();
+    let client = PaymentContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let token_id = deploy_token_with_balance(&env, &admin, &admin, 10_000);
+    let hospital = Address::generate(&env);
+    let payee = Address::generate(&env);
+
+    // Create and release escrow
+    let pid = client.create_escrow(&1u64, &hospital, &payee, &1_000i128, &token_id);
+    client.release_escrow(&admin, &pid);
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Released);
+
+    // Attempt to transition from Released to Disputed
+    let result = client.try_update_status(&pid, &PaymentStatus::Disputed, &admin);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidStatusTransition)),
+        "Cannot transition from Released to any other state"
+    );
+}
+
+/// update_status allows non-terminal transitions (e.g., Pending → Disputed).
+#[test]
+fn test_update_status_allows_non_terminal_transitions() {
+    let (env, cid) = setup();
+    let client = PaymentContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+
+    // Create non-escrow payment (status = Pending)
+    let pid = client.create_payment(&1u64, &payer, &payee, &1_000i128);
+
+    // Transition to Disputed (allowed)
+    client.update_status(&pid, &PaymentStatus::Disputed, &admin);
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Disputed, "Payment should be Disputed");
+
+    // Transition back to Pending (allowed)
+    client.update_status(&pid, &PaymentStatus::Pending, &admin);
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Pending, "Payment should be Pending again");
+}


### PR DESCRIPTION
## Summary

Fixes critical security vulnerability where `update_status` could bypass escrow token transfers by setting status to terminal states (Released/Refunded/Cancelled) without actually moving funds.

## Problem

The `update_status` function (lines 938-965) was an admin-callable generic status setter that updated `payment.status` for ANY target status — including `Released` and `Refunded` — but never called `token_client.transfer(...)`. This broke the escrow accounting invariant:

- Admin could call `update_status(payment_id, Released, admin)` on a Locked escrow payment
- Payment marked as `Released` and recorded in `total_released` stats
- Tokens remained sitting in contract balance — payee never received funds
- Could also "resolve" Disputed payments directly to Released/Refunded without transfers

## Solution

Restrict `update_status` to non-terminal transitions only:

1. **Reject terminal target states**: Return `InvalidStatusTransition` error if target status is Released/Refunded/Cancelled
2. **Reject transitions FROM terminal states**: Prevent any status change once payment reaches terminal state
3. **Add new error code**: `InvalidStatusTransition = 519`
4. **Comprehensive tests**: 3 test cases covering rejection of terminal states, rejection from terminal states, and allowance of non-terminal transitions

## Changes

- `contracts/payments/src/lib.rs`: Added validation checks and new error variant
- `contracts/payments/src/test.rs`: Added 3 security tests

## Testing

All tests verify:
- `update_status` rejects Released/Refunded/Cancelled as target status
- `update_status` rejects transitions from terminal states
- `update_status` still allows non-terminal transitions (Pending ↔ Disputed)

Closes #1120