### PR TITLE
fix(identity): replace deprecated Events::publish with #[contractevent] in revoke_badge

### DIFF
--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -138,6 +138,12 @@ pub struct BadgeAwarded {
     pub admin: Address,
 }
 
+#[contractevent(topics = ["badge_revoked"], data_format = "vec")]
+pub struct BadgeRevoked {
+    pub org_id: Address,
+    pub badge_type: BadgeType,
+}
+
 #[contractevent(topics = ["delivery_proof"], data_format = "vec")]
 pub struct DeliveryProofRecorded {
     pub request_id: u64,
@@ -883,10 +889,7 @@ impl IdentityContract {
         env.storage().persistent().set(&badges_key, &new_badges);
         env.storage().persistent().extend_ttl(&badges_key, TTL_THRESHOLD, TTL_EXTEND_TO);
 
-        env.events().publish(
-            (symbol_short!("badge"), symbol_short!("revoked")),
-            (org_id, badge_type),
-        );
+        BadgeRevoked { org_id, badge_type }.publish(&env);
 
         Ok(())
     }


### PR DESCRIPTION
## Problem
`revoke_badge` in `lifebank-soroban/contracts/identity/src/lib.rs` used the deprecated raw `env.events().publish()` API with `symbol_short!` macros. This caused two hard compilation errors:
- `symbol_short` was not imported
- `Events::publish` is deprecated and `#![deny(deprecated)]` is active

## Fix
- Added `BadgeRevoked` `#[contractevent(topics = ["badge_revoked"], data_format = "vec")]` struct
- Replaced the raw event call with `BadgeRevoked { org_id, badge_type }.publish(&env);`

This matches the pattern already used by `BadgeAwarded` and all other events in the file.

## Verification
```bash
cargo check -p identity-contract
# → Finished `dev` profile [unoptimized + debuginfo] target(s)
```
## Closes #1121 
