### PR TITLE
fix(matching): exclude expired units from select_units

### DIFF
--- a/lifebank-soroban/contracts/matching/src/matching.rs
+++ b/lifebank-soroban/contracts/matching/src/matching.rs
@@ -206,6 +206,9 @@ pub fn select_units(
         if unit.status != BloodStatus::Available {
             continue;
         }
+        if unit.expiration_timestamp <= now_timestamp {
+            continue;
+        }
         if unit.blood_type == request_blood_type {
             exact.push_back(unit);
         } else if is_compatible(unit.blood_type, request_blood_type) {

--- a/lifebank-soroban/contracts/matching/src/test.rs
+++ b/lifebank-soroban/contracts/matching/src/test.rs
@@ -411,6 +411,31 @@ mod pure_matching {
     }
 
     #[test]
+    fn expired_but_available_status_unit_is_excluded() {
+        // Regression test: an Available unit whose expiration_timestamp has
+        // already passed must never be selected, even though its status
+        // hasn't been flipped to Expired yet by the inventory housekeeping job.
+        let env = env();
+        let mut candidates = soroban_sdk::Vec::new(&env);
+        candidates.push_back(make_unit(&env, 1, BloodType::ABNegative, 450, 500)); // expired
+        candidates.push_back(make_unit(&env, 2, BloodType::ABNegative, 450, 5000)); // fresh
+
+        let now_timestamp = 1000;
+        let result = select_units(
+            &env,
+            candidates,
+            BloodType::ABNegative,
+            Urgency::Routine,
+            450,
+            None,
+            now_timestamp,
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap().unit_id, 2);
+    }
+
+    #[test]
     fn no_candidates_returns_empty() {
         let env = env();
         let candidates = soroban_sdk::Vec::new(&env);


### PR DESCRIPTION
## Summary
`select_units` in the matching contract only filtered candidate blood units by `status != BloodStatus::Available` and never checked `expiration_timestamp` against `now_timestamp`. `score_unit` also used `saturating_sub` for the expiry countdown, which floors to 0 for already-expired units instead of excluding them — so an expired-but-still-`Available` unit actually scored highest in the FIFO tier (30 pts). This meant matching entirely trusted the inventory contract to have already flipped expired units to `BloodStatus::Expired`, with no defense-in-depth if that housekeeping was delayed or missed.

## Change
Added an explicit `unit.expiration_timestamp <= now_timestamp` skip in the candidate filter loop in `select_units`, alongside the existing status check, so an expired unit is excluded from matching regardless of its stored status.

## Before / after
- Before: an `Available` unit past its expiration could be selected and recommended to fulfil a blood request.
- After: any unit whose expiration has passed (by timestamp) is excluded from both exact and compatible match buckets, independent of status.

## Testing
Added `expired_but_available_status_unit_is_excluded` in `matching/src/test.rs`, which supplies one expired and one fresh candidate unit with `status = Available` for both, and asserts only the fresh unit is returned by `select_units`. Existing `pure_matching` unit tests continue to pass unaffected (they use `now_timestamp = 0` against non-zero expirations, so none become expired under the new check).

Closes #1125