### PR TITLE
fix(analytics): remove dead env.invoker()-era duplicate helper

### DIFF
--- a/lifebank-soroban/contracts/analytics/src/lib.rs
+++ b/lifebank-soroban/contracts/analytics/src/lib.rs
@@ -47,9 +47,9 @@ fn require_admin(env: &Env) -> Result<AnalyticsConfig, AnalyticsError> {
 }
 
 fn require_authorized_caller(env: &Env) -> Result<AnalyticsConfig, AnalyticsError> {
-    let cfg = require_initialized(env)?;
-    cfg.admin.require_auth();
-    Ok(cfg)
+    // No longer calls the nonexistent env.invoker() (soroban-sdk 23 removed it);
+    // delegates to require_admin so there's a single source of truth for auth.
+    require_admin(env)
 }
 
 fn current_period_index(env: &Env, duration_secs: u64) -> u64 {


### PR DESCRIPTION
## Summary
Issue #1129 reported that `require_authorized_caller()` in the analytics contract called `env.invoker()`, which doesn't exist on `Env` in soroban-sdk 23.x, so the crate failed to compile.

On inspection of current `main`, that specific call was already replaced with `cfg.admin.require_auth()` in an earlier commit (`e77107a`) — there is no `env.invoker()` call left anywhere in the workspace. What remained was dead weight from that earlier fix: `require_authorized_caller()` and `require_admin()` had become byte-identical functions, which is confusing and a maintenance hazard (a future edit to one is easy to forget for the other).

## Change
`require_authorized_caller()` now delegates to `require_admin()` instead of duplicating its body, so there's a single source of truth for caller authorization used by `record_donation`, `record_request`, `record_delivery`, and `record_payment_released`.

## Before / after
- Before: two functions with identical bodies (`cfg.admin.require_auth()`), diverging only in name.
- After: one function (`require_admin`) with `require_authorized_caller` as a thin, clearly-named wrapper over it.

## Testing
No behavior change — verified by reading through all four `record_*` call sites, which are unaffected. This is a compile-time-only refactor; the crate already compiled cleanly on `main` before this change.

Closes #1129