### PR TITLE
test(requests): guard against duplicate ContractError discriminants

### DIFF
--- a/lifebank-soroban/contracts/requests/src/error.rs
+++ b/lifebank-soroban/contracts/requests/src/error.rs
@@ -22,3 +22,40 @@ pub enum ContractError {
     /// Transition requires a non-empty human-readable reason.
     InvalidReason = 313,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ContractError;
+
+    /// Regression test: every variant must have a unique discriminant, or the
+    /// crate fails to compile with E0081 (duplicate discriminant value).
+    #[test]
+    fn all_discriminants_are_unique() {
+        let all = [
+            ContractError::AlreadyInitialized,
+            ContractError::NotInitialized,
+            ContractError::Unauthorized,
+            ContractError::InvalidTimestamp,
+            ContractError::InvalidQuantity,
+            ContractError::NotAuthorizedHospital,
+            ContractError::RequestNotFound,
+            ContractError::UnauthorizedStatusTransition,
+            ContractError::InvalidStatusTransition,
+            ContractError::NotAuthorizedBloodBank,
+            ContractError::NotAuthorizedRider,
+            ContractError::InvalidRequestStatus,
+            ContractError::NotRequestOwner,
+            ContractError::InvalidReason,
+        ];
+
+        for i in 0..all.len() {
+            for j in (i + 1)..all.len() {
+                assert_ne!(
+                    all[i] as u32, all[j] as u32,
+                    "ContractError variants {:?} and {:?} share discriminant {}",
+                    all[i], all[j], all[i] as u32
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Issue #1130 reported that `UnauthorizedStatusTransition`/`InvalidRequestStatus` (307), `InvalidStatusTransition`/`NotRequestOwner` (308), and `NotAuthorizedBloodBank`/`InvalidReason` (309) shared `#[repr(u32)]` discriminants in `contracts/requests/src/error.rs`, which would fail to compile with `E0081: discriminant value assigned more than once`.

On current `main`, the enum was already renumbered by a prior fix — variants now run 300-313 with no duplicates, and `cargo check --manifest-path contracts/requests/Cargo.toml` already succeeds. What was still missing was the regression guard the issue explicitly asked for.

## Change
Added `all_discriminants_are_unique`, a unit test in `error.rs` that pairwise-compares every `ContractError` variant's `as u32` value and fails with a descriptive message if any two collide.

## Before / after
- Before: uniqueness of discriminants was accidental / unverified by tests — a future edit re-adding a duplicate would only be caught by the compiler at build time (or not at all, if two *different* numeric literals were reused incorrectly in a way that still compiled).
- After: an explicit, fast unit test documents and enforces the invariant.

## Testing
`cargo test --manifest-path lifebank-soroban/contracts/requests/Cargo.toml` — new test passes against the current (already-unique) discriminant set; verified by manual review of all 14 variant values.

Closes #1130