### PR TITLE
ci: fail fast on syntax errors across the workspace

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -47,6 +47,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Check all targets compile (fails fast on syntax errors)
+        working-directory: lifebank-soroban
+        run: |
+          cargo check --workspace --all-features --all-targets
+
       - name: Run contract tests
         working-directory: lifebank-soroban
         run: |


### PR DESCRIPTION
## Summary
Issue #1131 reported a stray closing paren in `temperature/src/lib.rs` (`test_large_streak`, `client.log_reading(&oracle, &unit_id, &100));`) that broke parsing of the entire crate, since Rust must fully parse a file before applying `#[cfg(test)]`.

On current `main`, that typo is already fixed — there's no extra paren anywhere in the file, and `cargo check`/`cargo test` for the temperature crate already succeed. The workspace `Cargo.toml` already globs in `contracts/*`, and CI's `cargo test --workspace --all-features` step already builds (and thus parses) every crate's test code, including temperature's.

## Change
Added an explicit `cargo check --workspace --all-features --all-targets` step in `.github/workflows/contracts-deploy.yml`, run before the test step. This directly addresses the issue's suggested follow-up ("add this crate to CI... so a syntax error fails the build immediately") by making that coverage explicit and giving a faster, clearer failure signal (a parse/type error surfaces in `cargo check`'s output rather than being buried inside the test step's build phase).

## Before / after
- Before: syntax errors in any workspace crate (including test code) would only surface as a build failure nested inside the `cargo test` step.
- After: a dedicated, faster `cargo check --all-targets` step fails first with an unambiguous "compile error" signal.

## Testing
Reviewed the updated workflow YAML for correctness; the new step mirrors the existing `cargo test` step's `working-directory` and flags. No contract code changed, so existing test suites are unaffected.

Closes #1131