### PR TITLE
fix(disputes): derive resolvedBy from authenticated caller, not client DTO

### DIFF
--- a/backend/src/disputes/disputes.controller.ts
+++ b/backend/src/disputes/disputes.controller.ts
@@ -75,8 +75,8 @@ export class DisputesController {
   @ApiResponse({ status: 200, description: 'Resource updated successfully' })
   @Patch(':id/resolve')
   @RequirePermissions(Permission.DISPUTE_RESOLVE)
-  resolve(@Param('id') id: string, @Body() dto: ResolveDisputeDto) {
-    return this.service.resolve(id, dto);
+  resolve(@Param('id') id: string, @Body() dto: ResolveDisputeDto, @User('id') userId: string) {
+    return this.service.resolve(id, dto, userId);
   }
 
   @ApiOperation({ summary: 'Post :id notes' })

--- a/backend/src/disputes/disputes.service.ts
+++ b/backend/src/disputes/disputes.service.ts
@@ -115,11 +115,11 @@ export class DisputesService {
     return this.disputeRepo.save(d);
   }
 
-  async resolve(id: string, dto: ResolveDisputeDto): Promise<DisputeEntity> {
+  async resolve(id: string, dto: ResolveDisputeDto, resolvedBy: string): Promise<DisputeEntity> {
     const d = await this.get(id);
     d.resolutionNotes = dto.resolutionNotes;
     d.outcome = dto.outcome;
-    d.resolvedBy = dto.resolvedBy;
+    d.resolvedBy = resolvedBy;
     d.status = DisputeStatus.RESOLVED;
     d.resolvedAt = new Date();
     d.timeoutProcessedAt = d.timeoutProcessedAt ?? new Date();

--- a/backend/src/disputes/dto/dispute.dto.ts
+++ b/backend/src/disputes/dto/dispute.dto.ts
@@ -29,10 +29,6 @@ export class ResolveDisputeDto {
   /** Structured outcome required for arbitration traceability (#585). */
   @IsEnum(DisputeOutcome)
   outcome: DisputeOutcome;
-
-  /** Identity of the arbitrator recording the resolution. */
-  @IsString()
-  resolvedBy: string;
 }
 
 export class AddNoteDto {


### PR DESCRIPTION
## Summary

`ResolveDisputeDto.resolvedBy` was a plain client-supplied string, allowing any caller with `DISPUTE_RESOLVE` to forge the arbitrator identity recorded on the dispute.

**Changes:**
- Removed `resolvedBy` from `ResolveDisputeDto` (no longer client-writable)
- Added `resolvedBy: string` parameter to `DisputesService.resolve()`
- Controller now passes `@User('id')` so `resolvedBy` always reflects the authenticated principal

## Validation

- No new TypeScript errors in modified files

Closes #1163