### PR TITLE
Fix/access control bounds coverage

### DIFF
--- a/lifebank-soroban/contracts/delivery/src/test.rs
+++ b/lifebank-soroban/contracts/delivery/src/test.rs
@@ -105,3 +105,51 @@ fn test_getters_fail_before_initialization() {
         Err(Ok(Error::NotInitialized))
     );
 }
+
+#[test]
+fn test_record_compliance_attestation_succeeds() {
+    let (env, client, _contract_id, admin, _request_contract) = create_initialized_contract();
+    let delivery_id = 42u64;
+    let compliance_hash = Bytes::from_slice(&env, b"hash_value");
+
+    let result = client.try_record_compliance_attestation(&admin, &delivery_id, &compliance_hash, &true);
+    assert!(result.is_ok());
+
+    let events = env.events().all();
+    assert!(events.len() >= 1);
+}
+
+#[test]
+fn test_get_compliance_attestation_roundtrip() {
+    let (env, client, _contract_id, admin, _request_contract) = create_initialized_contract();
+    let delivery_id = 99u64;
+    let compliance_hash = Bytes::from_slice(&env, b"test_hash_data");
+
+    client.record_compliance_attestation(&admin, &delivery_id, &compliance_hash, &false);
+
+    let (retrieved_hash, is_compliant) = client.get_compliance_attestation(&delivery_id);
+    assert_eq!(retrieved_hash, compliance_hash);
+    assert_eq!(is_compliant, false);
+}
+
+#[test]
+fn test_get_compliance_attestation_not_found() {
+    let (_env, client, _contract_id, _admin, _request_contract) = create_initialized_contract();
+    let unknown_delivery_id = 999u64;
+
+    let result = client.try_get_compliance_attestation(&unknown_delivery_id);
+    assert_eq!(result, Err(Ok(Error::DeliveryNotFound)));
+}
+
+#[test]
+fn test_record_compliance_attestation_requires_admin_auth() {
+    let (env, client, _contract_id, _admin, _request_contract) = create_initialized_contract();
+    env.mock_all_auths_allow_last_error();
+
+    let unauthorized_caller = Address::generate(&env);
+    let delivery_id = 55u64;
+    let compliance_hash = Bytes::from_slice(&env, b"hash");
+
+    let result = client.try_record_compliance_attestation(&unauthorized_caller, &delivery_id, &compliance_hash, &true);
+    assert!(result.is_err());
+}

--- a/lifebank-soroban/contracts/reputation/src/lib.rs
+++ b/lifebank-soroban/contracts/reputation/src/lib.rs
@@ -506,6 +506,16 @@ impl ReputationContract {
             is_appealed: false,
         });
 
+        // Keep only the 100 most recent penalties to bound storage
+        if input.penalties.len() > 100 {
+            let mut trimmed = Vec::new(&env);
+            let start = input.penalties.len() - 100;
+            for i in start..input.penalties.len() {
+                trimmed.push_back(input.penalties.get(i).unwrap());
+            }
+            input.penalties = trimmed;
+        }
+
         env.storage()
             .persistent()
             .set(&DataKey::Input(entity_id), &input);

--- a/lifebank-soroban/contracts/temperature/src/lib.rs
+++ b/lifebank-soroban/contracts/temperature/src/lib.rs
@@ -319,11 +319,17 @@ impl TemperatureContract {
         };
 
         env.storage().persistent().set(&streak_key, &new_streak);
+        env.storage()
+            .persistent()
+            .extend_ttl(&streak_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
 
         // Check if unit should be compromised (3 consecutive violations)
         if new_streak >= 3 {
             let compromised_key = DataKey::IsCompromised(unit_id);
             env.storage().persistent().set(&compromised_key, &true);
+            env.storage()
+                .persistent()
+                .extend_ttl(&compromised_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
         }
 
         let mut page_num: u32 = 0;
@@ -524,7 +530,13 @@ impl TemperatureContract {
     /// Current consecutive violation count
     pub fn get_consecutive_violation_streak(env: Env, unit_id: u64) -> u32 {
         let streak_key = DataKey::ConsecutiveViolationStreak(unit_id);
-        env.storage().persistent().get(&streak_key).unwrap_or(0)
+        let streak = env.storage().persistent().get(&streak_key).unwrap_or(0);
+        if streak > 0 {
+            env.storage()
+                .persistent()
+                .extend_ttl(&streak_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
+        }
+        streak
     }
 
     /// Check if a blood unit has been compromised due to consecutive violations
@@ -536,10 +548,16 @@ impl TemperatureContract {
     /// `true` if unit has 3 or more consecutive violations (compromised), `false` otherwise
     pub fn is_compromised(env: Env, unit_id: u64) -> bool {
         let compromised_key = DataKey::IsCompromised(unit_id);
-        env.storage()
+        let is_compromised = env.storage()
             .persistent()
             .get(&compromised_key)
-            .unwrap_or(false)
+            .unwrap_or(false);
+        if is_compromised {
+            env.storage()
+                .persistent()
+                .extend_ttl(&compromised_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
+        }
+        is_compromised
     }
 
     /// Reset the compromised status and violation streak for a blood unit (admin only)
@@ -567,7 +585,14 @@ impl TemperatureContract {
         let compromised_key = DataKey::IsCompromised(unit_id);
 
         env.storage().persistent().set(&streak_key, &0u32);
+        env.storage()
+            .persistent()
+            .extend_ttl(&streak_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
+
         env.storage().persistent().set(&compromised_key, &false);
+        env.storage()
+            .persistent()
+            .extend_ttl(&compromised_key, ORACLE_BUMP_THRESHOLD, ORACLE_BUMP_TO);
 
         CompromisedReset { unit_id }.publish(&env);
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                    
   
  Security and quality fixes addressing four critical issues across reputation, delivery, and temperature contracts:                                                                                            
                                                            
  - **#1149**: Access control hardening on quarantine operations (already addressed by custodian checks in this branch)                                                                                         
  - **#1148**: Bounded storage growth in reputation penalties
  - **#1147**: Test coverage for delivery compliance attestation
  - **#1146**: Persistent state safety via TTL extension on compromised unit flags                                                                                                                              
  
  ## Changes                                                                                                                                                                                                    
                                                            
  ### #1149 — Quarantine functions enforce custodian checks ✅
  - Addressed by commit on this branch: custodian-verified quarantine_blood/finalize_quarantine
  - Ensures only the unit's current custodian (bank_id or recipient_hospital) can quarantine/release                                                                                                            
  - Prevents unauthorized banks from quarantining or releasing each other's inventory
                                                                                                                                                                                                                
  ### #1148 — Cap penalties vector at 100 entries (prevents DoS via unbounded storage)                                                                                                                          
  - **File**: `lifebank-soroban/contracts/reputation/src/lib.rs`
  - **Fix**: `apply_penalty()` now trims penalties to 100 most recent entries after push                                                                                                                        
  - **Why**: Unbounded penalties vector could grow indefinitely with repeated violations, increasing per-call cost/latency and risking ledger-entry size limits
  - **Pattern**: Mirrors existing 100-entry cap on ratings vector                                                                                                                                               
  
  ### #1147 — Add compliance attestation test coverage (zero→four new tests)                                                                                                                                    
  - **File**: `lifebank-soroban/contracts/delivery/src/test.rs`
  - **Tests added**:                                                                                                                                                                                            
    - `test_record_compliance_attestation_succeeds`: success path + event emission
    - `test_get_compliance_attestation_roundtrip`: hash/compliance storage round-trip
    - `test_get_compliance_attestation_not_found`: DeliveryNotFound error path                                                                                                                                  
    - `test_record_compliance_attestation_requires_admin_auth`: authorization check
  - **Why**: Core contract functions had zero automated verification                                                                                                                                            
                                                                                                                                                                                                                
  ### #1146 — Extend TTL on compromised/violation-streak flags (prevents silent safety flag expiration)
  - **File**: `lifebank-soroban/contracts/temperature/src/lib.rs`                                                                                                                                               
  - **Fix**: Extended TTL on IsCompromised and ConsecutiveViolationStreak on both write and read
  - **Why**: Patient-safety critical — expired flags silently reset, allowing contaminated units to be transfused                                                                                               
  
  Closes #1149, Closes #1148, Closes #1147, Closes #1146        