### PR TITLE
Fix/soroban contract issues

### DIFF
--- a/lifebank-soroban/contracts/coordinator/src/test.rs
+++ b/lifebank-soroban/contracts/coordinator/src/test.rs
@@ -890,3 +890,157 @@ fn test_set_temperature_oracle_rejects_non_admin_caller() {
     let result = h.coord.try_set_temperature_oracle(&attacker, &oracle);
     assert_eq!(result, Err(Ok(CoordinatorError::Unauthorized)));
 }
+
+// ── Admin transfer tests ───────────────────────────────────────────────────
+
+/// Successful two-step admin transfer: propose and accept.
+#[test]
+fn test_propose_and_accept_admin_transfer() {
+    let h = setup();
+    let new_admin = Address::generate(&h.env);
+
+    h.coord.propose_admin(&h.admin, &new_admin);
+    h.coord.accept_admin(&new_admin);
+}
+
+/// Accept_admin by non-pending address must fail.
+#[test]
+fn test_accept_admin_wrong_address_fails() {
+    let h = setup();
+    let new_admin = Address::generate(&h.env);
+    let wrong_address = Address::generate(&h.env);
+
+    h.coord.propose_admin(&h.admin, &new_admin);
+    let result = h.coord.try_accept_admin(&wrong_address);
+    assert_eq!(result, Err(Ok(CoordinatorError::Unauthorized)));
+}
+
+/// Only current admin can propose new admin.
+#[test]
+fn test_propose_admin_non_admin_fails() {
+    let h = setup();
+    let attacker = Address::generate(&h.env);
+    let new_admin = Address::generate(&h.env);
+
+    let result = h.coord.try_propose_admin(&attacker, &new_admin);
+    assert_eq!(result, Err(Ok(CoordinatorError::Unauthorized)));
+}
+
+// ── Emergency halt tests ───────────────────────────────────────────────────
+
+/// Emergency halt blocks confirm_delivery and settle_payment.
+#[test]
+fn test_emergency_halt_blocks_settle_operations() {
+    let h = setup();
+    seed_pending_request(&h, 1);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 1);
+
+    h.coord.allocate_units(
+        &1u64,
+        &vec![&h.env, unit_id],
+        &payment_id,
+        &h.admin,
+        &BloodType::OPositive,
+    );
+
+    h.coord.confirm_delivery(
+        &1u64,
+        &h.admin,
+        &String::from_str(&h.env, "Hospital-A-GPS"),
+    );
+
+    h.coord.emergency_halt(&h.admin);
+    assert!(h.coord.is_emergency_halted());
+
+    let result = h.coord.try_settle_payment(&1u64, &h.admin);
+    assert_eq!(result, Err(Ok(CoordinatorError::EmergencyHalt)));
+}
+
+/// Only admin can trigger emergency halt.
+#[test]
+fn test_emergency_halt_non_admin_fails() {
+    let h = setup();
+    let attacker = Address::generate(&h.env);
+
+    let result = h.coord.try_emergency_halt(&attacker);
+    assert_eq!(result, Err(Ok(CoordinatorError::Unauthorized)));
+    assert!(!h.coord.is_emergency_halted());
+}
+
+/// Clear emergency halt restores operation.
+#[test]
+fn test_clear_emergency_halt_restores_operation() {
+    let h = setup();
+    seed_pending_request(&h, 1);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 1);
+
+    h.coord.allocate_units(
+        &1u64,
+        &vec![&h.env, unit_id],
+        &payment_id,
+        &h.admin,
+        &BloodType::OPositive,
+    );
+
+    h.coord.confirm_delivery(
+        &1u64,
+        &h.admin,
+        &String::from_str(&h.env, "Hospital-A-GPS"),
+    );
+
+    h.coord.emergency_halt(&h.admin);
+    assert!(h.coord.is_emergency_halted());
+
+    h.coord.clear_emergency_halt(&h.admin);
+    assert!(!h.coord.is_emergency_halted());
+
+    h.coord.settle_payment(&1u64, &h.admin);
+
+    let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
+    assert_eq!(payment.status, PaymentStatus::Released);
+}
+
+/// Only admin can clear emergency halt.
+#[test]
+fn test_clear_emergency_halt_non_admin_fails() {
+    let h = setup();
+    let attacker = Address::generate(&h.env);
+
+    h.coord.emergency_halt(&h.admin);
+
+    let result = h.coord.try_clear_emergency_halt(&attacker);
+    assert_eq!(result, Err(Ok(CoordinatorError::Unauthorized)));
+    assert!(h.coord.is_emergency_halted());
+}
+
+/// Rollback transitions Delivered-but-unsettled workflow correctly.
+#[test]
+fn test_rollback_delivered_workflow() {
+    let h = setup();
+    seed_pending_request(&h, 1);
+    let unit_id = register_unit(&h);
+    let payment_id = create_locked_payment(&h, 1);
+
+    h.coord.allocate_units(
+        &1u64,
+        &vec![&h.env, unit_id],
+        &payment_id,
+        &h.admin,
+        &BloodType::OPositive,
+    );
+
+    h.coord.confirm_delivery(
+        &1u64,
+        &h.admin,
+        &String::from_str(&h.env, "Hospital-A-GPS"),
+    );
+
+    assert_eq!(h.coord.get_workflow(&1u64).status, WorkflowStatus::Delivered);
+
+    h.coord.rollback(&1u64);
+
+    let wf = h.coord.get_workflow(&1u64);
+    assert_eq!(wf.status, WorkflowStatus::Locked);
+}

--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -1077,7 +1077,7 @@ pub struct AccessControlContract;
 #[contractimpl]
 impl AccessControlContract {
     /// Initialize the contract with an administrator
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn ac_initialize(env: Env, admin: Address) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
@@ -1151,7 +1151,7 @@ impl AccessControlContract {
     }
 
     /// Check if an address has a specific non-expired role
-    pub fn has_role(env: Env, address: Address, role: Role) -> bool {
+    pub fn ac_has_role(env: Env, address: Address, role: Role) -> bool {
         Self::cleanup_expired_roles_internal(&env, &address);
 
         let key = DataKey::AddressRoles(address);

--- a/lifebank-soroban/contracts/identity/src/test.rs
+++ b/lifebank-soroban/contracts/identity/src/test.rs
@@ -22,7 +22,7 @@ fn test_initialize_sets_admin_counter_and_admin_role() {
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     assert!(client.is_initialized());
     assert_eq!(client.get_admin(), admin.clone());
@@ -39,7 +39,7 @@ fn test_initialize_emits_event() {
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     assert_eq!(env.events().all().len(), 1);
 }
@@ -53,7 +53,7 @@ fn test_initialize_cannot_run_twice() {
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let result = client.try_initialize(&admin);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
@@ -190,8 +190,8 @@ fn test_has_role() {
         &vec![&env],
     );
 
-    assert!(client.has_role(&owner, &Role::Hospital));
-    assert!(!client.has_role(&owner, &Role::BloodBank));
+    assert!(client.ac_has_role(&owner, &Role::Hospital));
+    assert!(!client.ac_has_role(&owner, &Role::BloodBank));
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn test_verify_organization() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let name = String::from_str(&env, "City Blood Bank");
@@ -316,7 +316,7 @@ fn test_verify_organization_not_admin() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let name = String::from_str(&env, "City Blood Bank");
@@ -347,7 +347,7 @@ fn test_verify_organization_already_verified() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let name = String::from_str(&env, "City Blood Bank");
@@ -380,7 +380,7 @@ fn test_verify_organization_not_found() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let fake_org = Address::generate(&env);
     let result = client.try_verify_organization(&admin, &fake_org);
@@ -396,7 +396,7 @@ fn test_unverify_organization() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let name = String::from_str(&env, "City Blood Bank");
@@ -440,7 +440,7 @@ fn test_unverify_organization_already_unverified() {
     let client = IdentityContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let name = String::from_str(&env, "City Blood Bank");
@@ -668,7 +668,7 @@ fn test_rate_organization_not_found() {
     let ghost = Address::generate(&env);
 
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
     client.set_requests_contract(&admin, &requests_id);
     requests_client.initialize(&admin, &requests_id);
     let result = client.try_rate_organization(&admin, &ghost, &3, &1_u64);
@@ -750,7 +750,7 @@ fn test_award_badge() {
     let contract_id = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let loc = BytesN::from_array(&env, &[0u8; 32]);
@@ -778,7 +778,7 @@ fn test_award_badge_duplicate_prevented() {
     let contract_id = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let loc = BytesN::from_array(&env, &[0u8; 32]);
@@ -804,7 +804,7 @@ fn test_revoke_badge() {
     let contract_id = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let loc = BytesN::from_array(&env, &[0u8; 32]);
@@ -832,7 +832,7 @@ fn test_revoke_badge_not_found() {
     let contract_id = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let owner = Address::generate(&env);
     let loc = BytesN::from_array(&env, &[0u8; 32]);
@@ -937,7 +937,7 @@ fn test_get_top_rated_organizations() {
     let contract_id = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let loc = BytesN::from_array(&env, &[0u8; 32]);
 
@@ -987,14 +987,14 @@ fn test_grant_and_has_role() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
     client.grant_role_with_expiry(&address, &Role::Admin, &None);
 
-    assert!(client.has_role(&address, &Role::Admin));
-    assert!(!client.has_role(&address, &Role::Hospital));
+    assert!(client.ac_has_role(&address, &Role::Admin));
+    assert!(!client.ac_has_role(&address, &Role::Hospital));
 }
 
 #[test]
@@ -1005,15 +1005,15 @@ fn test_revoke_role() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
     client.grant_role_with_expiry(&address, &Role::Donor, &None);
-    assert!(client.has_role(&address, &Role::Donor));
+    assert!(client.ac_has_role(&address, &Role::Donor));
 
     client.revoke_role(&address, &Role::Donor);
-    assert!(!client.has_role(&address, &Role::Donor));
+    assert!(!client.ac_has_role(&address, &Role::Donor));
 }
 
 #[test]
@@ -1024,7 +1024,7 @@ fn test_multiple_roles_single_entry() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1032,9 +1032,9 @@ fn test_multiple_roles_single_entry() {
     client.grant_role_with_expiry(&address, &Role::Hospital, &None);
     client.grant_role_with_expiry(&address, &Role::Donor, &None);
 
-    assert!(client.has_role(&address, &Role::Admin));
-    assert!(client.has_role(&address, &Role::Hospital));
-    assert!(client.has_role(&address, &Role::Donor));
+    assert!(client.ac_has_role(&address, &Role::Admin));
+    assert!(client.ac_has_role(&address, &Role::Hospital));
+    assert!(client.ac_has_role(&address, &Role::Donor));
 
     let roles = client.get_roles(&address);
     assert_eq!(roles.len(), 3);
@@ -1048,7 +1048,7 @@ fn test_no_duplicate_roles() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1068,7 +1068,7 @@ fn test_roles_sorted() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1093,7 +1093,7 @@ fn test_role_expiration() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1102,13 +1102,13 @@ fn test_role_expiration() {
     });
 
     client.grant_role_with_expiry(&address, &Role::Donor, &Some(2000));
-    assert!(client.has_role(&address, &Role::Donor));
+    assert!(client.ac_has_role(&address, &Role::Donor));
 
     env.ledger().with_mut(|li| {
         li.timestamp = 2001;
     });
 
-    assert!(!client.has_role(&address, &Role::Donor));
+    assert!(!client.ac_has_role(&address, &Role::Donor));
 
     let roles = client.get_roles(&address);
     assert_eq!(
@@ -1126,7 +1126,7 @@ fn test_get_roles_empty() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
     let roles = client.get_roles(&address);
@@ -1141,7 +1141,7 @@ fn test_revoke_one_of_multiple_roles() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1151,9 +1151,9 @@ fn test_revoke_one_of_multiple_roles() {
 
     client.revoke_role(&address, &Role::Hospital);
 
-    assert!(client.has_role(&address, &Role::Admin));
-    assert!(!client.has_role(&address, &Role::Hospital));
-    assert!(client.has_role(&address, &Role::Donor));
+    assert!(client.ac_has_role(&address, &Role::Admin));
+    assert!(!client.ac_has_role(&address, &Role::Hospital));
+    assert!(client.ac_has_role(&address, &Role::Donor));
 
     let roles = client.get_roles(&address);
     assert_eq!(roles.len(), 2);
@@ -1167,7 +1167,7 @@ fn test_storage_benchmark_comparison() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let addr1 = Address::generate(&env);
     let addr2 = Address::generate(&env);
@@ -1209,10 +1209,10 @@ fn test_storage_benchmark_comparison() {
 
     assert_eq!(storage_entry_count, 5);
 
-    assert!(client.has_role(&addr1, &Role::Admin));
-    assert!(client.has_role(&addr1, &Role::Hospital));
-    assert!(client.has_role(&addr2, &Role::Donor));
-    assert!(client.has_role(&addr3, &Role::BloodBank));
+    assert!(client.ac_has_role(&addr1, &Role::Admin));
+    assert!(client.ac_has_role(&addr1, &Role::Hospital));
+    assert!(client.ac_has_role(&addr2, &Role::Donor));
+    assert!(client.ac_has_role(&addr3, &Role::BloodBank));
 }
 
 #[test]
@@ -1223,7 +1223,7 @@ fn test_role_grant_metadata() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1250,7 +1250,7 @@ fn test_lazy_deletion_in_has_role() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1267,7 +1267,7 @@ fn test_lazy_deletion_in_has_role() {
         li.timestamp = 2001;
     });
 
-    assert!(!client.has_role(&address, &Role::Donor));
+    assert!(!client.ac_has_role(&address, &Role::Donor));
 
     let roles_after = client.get_roles(&address);
     assert_eq!(
@@ -1285,7 +1285,7 @@ fn test_lazy_deletion_preserves_other_roles() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1300,13 +1300,13 @@ fn test_lazy_deletion_preserves_other_roles() {
         li.timestamp = 2001;
     });
 
-    assert!(!client.has_role(&address, &Role::Donor));
+    assert!(!client.ac_has_role(&address, &Role::Donor));
 
     let roles = client.get_roles(&address);
     assert_eq!(roles.len(), 1);
     assert_eq!(roles.get(0).unwrap().role, Role::Admin);
 
-    assert!(client.has_role(&address, &Role::Admin));
+    assert!(client.ac_has_role(&address, &Role::Admin));
 }
 
 #[test]
@@ -1317,7 +1317,7 @@ fn test_cleanup_expired_roles_basic() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1339,9 +1339,9 @@ fn test_cleanup_expired_roles_basic() {
     let roles = client.get_roles(&address);
     assert_eq!(roles.len(), 2);
 
-    assert!(!client.has_role(&address, &Role::Donor));
-    assert!(client.has_role(&address, &Role::Rider));
-    assert!(client.has_role(&address, &Role::Hospital));
+    assert!(!client.ac_has_role(&address, &Role::Donor));
+    assert!(client.ac_has_role(&address, &Role::Rider));
+    assert!(client.ac_has_role(&address, &Role::Hospital));
 }
 
 #[test]
@@ -1352,7 +1352,7 @@ fn test_cleanup_expired_roles_removes_all_when_all_expired() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1385,7 +1385,7 @@ fn test_cleanup_expired_roles_no_roles() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
     let removed = client.cleanup_expired_roles(&address);
@@ -1400,7 +1400,7 @@ fn test_cleanup_expired_roles_none_expired() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     let address = Address::generate(&env);
 
@@ -1427,8 +1427,8 @@ fn test_already_initialized() {
     let admin = Address::generate(&env);
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
+    client.ac_initialize(&admin);
 }
 
 #[test]
@@ -1461,11 +1461,11 @@ fn test_attack_self_grant_rider_to_admin_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     // Give rider the Rider role legitimately.
     client.grant_role_with_expiry(&rider, &Role::Rider, &None);
-    assert!(client.has_role(&rider, &Role::Rider));
+    assert!(client.ac_has_role(&rider, &Role::Rider));
 
     // Now simulate the rider trying to grant themselves Admin.
     // We do NOT mock admin auth — only rider auth is present.
@@ -1479,7 +1479,7 @@ fn test_attack_self_grant_rider_to_admin_must_fail() {
     // Must fail — rider is not the admin.
     assert!(result.is_err(), "Self-grant attack must be rejected");
     // Admin role must NOT have been granted.
-    assert!(!client.has_role(&rider, &Role::Admin));
+    assert!(!client.ac_has_role(&rider, &Role::Admin));
 }
 
 /// Attack: A Hospital address calls a function that requires Admin role.
@@ -1495,7 +1495,7 @@ fn test_attack_role_spoofing_hospital_calls_admin_function_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     // Hospital has Hospital role, not Admin.
     client.grant_role_with_expiry(&hospital, &Role::Hospital, &None);
@@ -1505,7 +1505,7 @@ fn test_attack_role_spoofing_hospital_calls_admin_function_must_fail() {
     env.set_auths(&[]);
     let result = client.try_grant_role_with_expiry(&victim, &Role::Admin, &None);
     assert!(result.is_err(), "Role spoofing attack must be rejected");
-    assert!(!client.has_role(&victim, &Role::Admin));
+    assert!(!client.ac_has_role(&victim, &Role::Admin));
 }
 
 /// Attack: An address with an expired role attempts to use it.
@@ -1520,20 +1520,20 @@ fn test_attack_expired_role_reuse_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     env.ledger().with_mut(|l| l.timestamp = 1_000);
 
     // Grant BloodBank role with expiry at t=2000.
     client.grant_role_with_expiry(&blood_bank_admin, &Role::BloodBank, &Some(2_000));
-    assert!(client.has_role(&blood_bank_admin, &Role::BloodBank));
+    assert!(client.ac_has_role(&blood_bank_admin, &Role::BloodBank));
 
     // Advance time past expiry.
     env.ledger().with_mut(|l| l.timestamp = 2_001);
 
     // Expired role must not be recognized.
     assert!(
-        !client.has_role(&blood_bank_admin, &Role::BloodBank),
+        !client.ac_has_role(&blood_bank_admin, &Role::BloodBank),
         "Expired BloodBank role must not be usable after expiry"
     );
 }
@@ -1550,17 +1550,17 @@ fn test_attack_revoked_role_immediate_reuse_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     client.grant_role_with_expiry(&attacker, &Role::Donor, &None);
-    assert!(client.has_role(&attacker, &Role::Donor));
+    assert!(client.ac_has_role(&attacker, &Role::Donor));
 
     // Revoke the role.
     client.revoke_role(&attacker, &Role::Donor);
 
     // Immediate reuse attempt — must fail.
     assert!(
-        !client.has_role(&attacker, &Role::Donor),
+        !client.ac_has_role(&attacker, &Role::Donor),
         "Revoked role must not be usable in the same transaction"
     );
 }
@@ -1579,7 +1579,7 @@ fn test_attack_nomination_hijack_unauthorized_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     // Attacker (not admin) tries to grant Admin to fake_nominee.
     env.set_auths(&[]);
@@ -1588,7 +1588,7 @@ fn test_attack_nomination_hijack_unauthorized_must_fail() {
         result.is_err(),
         "Nomination hijack by unauthorized address must be rejected"
     );
-    assert!(!client.has_role(&fake_nominee, &Role::Admin));
+    assert!(!client.ac_has_role(&fake_nominee, &Role::Admin));
 }
 
 /// Attack: BloodBank("BANK_001") attempts to grant a role under a different
@@ -1605,7 +1605,7 @@ fn test_attack_scoped_role_cross_contamination_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     // bank_001 has BloodBank role.
     client.grant_role_with_expiry(&bank_001, &Role::BloodBank, &None);
@@ -1618,7 +1618,7 @@ fn test_attack_scoped_role_cross_contamination_must_fail() {
         result.is_err(),
         "Cross-bank role grant must be rejected — only admin may grant roles"
     );
-    assert!(!client.has_role(&bank_002, &Role::BloodBank));
+    assert!(!client.ac_has_role(&bank_002, &Role::BloodBank));
 }
 
 /// Attack: An authorized address attempts a write operation (grant_role) while
@@ -1635,7 +1635,7 @@ fn test_attack_paused_contract_write_must_fail() {
 
     let contract_id = env.register(AccessControlContract, ());
     let client = AccessControlContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
 
     client.grant_role_with_expiry(&authorized, &Role::Hospital, &None);
 
@@ -1660,7 +1660,7 @@ fn setup_identity<'a>() -> (Env, IdentityContractClient<'a>, Address) {
     let cid = env.register(IdentityContract, ());
     let client = IdentityContractClient::new(&env, &cid);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.ac_initialize(&admin);
     (env, client, admin)
 }
 

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -102,6 +102,7 @@ pub struct DonationPledge {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VestingSchedule {
     pub donor: Address,
+    pub reward_token: Address,
     pub total_amount: i128,
     pub cliff_timestamp: u64,
     pub vest_end_timestamp: u64,
@@ -1296,6 +1297,7 @@ impl PaymentContract {
         env: Env,
         admin: Address,
         donor: Address,
+        reward_token: Address,
         total_amount: i128,
         cliff_secs: u64,
         duration_secs: u64,
@@ -1331,6 +1333,7 @@ impl PaymentContract {
         let now = env.ledger().timestamp();
         let schedule = VestingSchedule {
             donor: donor.clone(),
+            reward_token: reward_token.clone(),
             total_amount,
             cliff_timestamp: now + cliff_secs,
             vest_end_timestamp: now + duration_secs,
@@ -1350,7 +1353,7 @@ impl PaymentContract {
         Ok(())
     }
 
-    pub fn claim_vested(env: Env, donor: Address, reward_token: Address) -> Result<i128, Error> {
+    pub fn claim_vested(env: Env, donor: Address) -> Result<i128, Error> {
         donor.require_auth();
         Self::require_not_paused(&env)?;
 
@@ -1383,7 +1386,7 @@ impl PaymentContract {
         schedule.claimed = new_claimed;
         store_vesting(&env, &schedule);
 
-        let token_client = token::Client::new(&env, &reward_token);
+        let token_client = token::Client::new(&env, &schedule.reward_token);
         token_client.transfer(&env.current_contract_address(), &donor, &claimable);
 
         VestingClaimed {

--- a/lifebank-soroban/contracts/payments/src/test.rs
+++ b/lifebank-soroban/contracts/payments/src/test.rs
@@ -800,16 +800,16 @@ fn test_vesting_pre_cliff_claim_fails() {
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
 
-    // cliff = now + 1000s, duration = 2000s
-    env.ledger().with_mut(|l| l.timestamp = 5000);
-    client.create_vesting(&admin, &donor, &1_000_000i128, &1000u64, &2000u64);
-
     // Deploy reward token and mint to contract so it can transfer
     let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000_000);
 
+    // cliff = now + 1000s, duration = 2000s
+    env.ledger().with_mut(|l| l.timestamp = 5000);
+    client.create_vesting(&admin, &donor, &token_id, &1_000_000i128, &1000u64, &2000u64);
+
     // Try to claim at t=5500 (before cliff at t=6000)
     env.ledger().with_mut(|l| l.timestamp = 5500);
-    let result = client.try_claim_vested(&donor, &token_id);
+    let result = client.try_claim_vested(&donor);
     assert_eq!(
         result,
         Err(Ok(Error::CliffNotReached)),
@@ -824,15 +824,15 @@ fn test_vesting_partial_claim_at_50_percent() {
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
 
+    let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000_000);
+
     // cliff = now + 0 (immediate), duration = 2000s → vest_end = now + 2000
     env.ledger().with_mut(|l| l.timestamp = 10_000);
-    client.create_vesting(&admin, &donor, &1_000_000i128, &0u64, &2000u64);
-
-    let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000_000);
+    client.create_vesting(&admin, &donor, &token_id, &1_000_000i128, &0u64, &2000u64);
 
     // Advance to 50% of vesting duration (cliff == vest_start == 10_000, vest_end == 12_000)
     env.ledger().with_mut(|l| l.timestamp = 11_000); // 1000s elapsed of 2000s
-    let claimed = client.claim_vested(&donor, &token_id);
+    let claimed = client.claim_vested(&donor);
     assert_eq!(
         claimed, 500_000i128,
         "50% vesting should yield half the total"
@@ -849,14 +849,14 @@ fn test_vesting_full_claim_after_vest_end() {
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
 
-    env.ledger().with_mut(|l| l.timestamp = 1_000);
-    client.create_vesting(&admin, &donor, &500_000i128, &0u64, &1000u64);
-
     let token_id = deploy_token_with_balance(&env, &admin, &cid, 500_000);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    client.create_vesting(&admin, &donor, &token_id, &500_000i128, &0u64, &1000u64);
 
     // Advance past vest_end
     env.ledger().with_mut(|l| l.timestamp = 3_000);
-    let claimed = client.claim_vested(&donor, &token_id);
+    let claimed = client.claim_vested(&donor);
     assert_eq!(claimed, 500_000i128, "Full amount claimable after vest end");
 
     let schedule = client.get_vesting(&donor);
@@ -871,18 +871,18 @@ fn test_vesting_cannot_exceed_total_amount() {
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
 
-    env.ledger().with_mut(|l| l.timestamp = 1_000);
-    client.create_vesting(&admin, &donor, &1_000_000i128, &0u64, &1000u64);
-
     let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000_000);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    client.create_vesting(&admin, &donor, &token_id, &1_000_000i128, &0u64, &1000u64);
 
     // Claim full amount after vest end
     env.ledger().with_mut(|l| l.timestamp = 5_000);
-    let first = client.claim_vested(&donor, &token_id);
+    let first = client.claim_vested(&donor);
     assert_eq!(first, 1_000_000i128);
 
     // Second claim should fail with NothingToClaim
-    let result = client.try_claim_vested(&donor, &token_id);
+    let result = client.try_claim_vested(&donor);
     assert_eq!(
         result,
         Err(Ok(Error::NothingToClaim)),
@@ -893,13 +893,14 @@ fn test_vesting_cannot_exceed_total_amount() {
 /// Non-admin cannot create a vesting schedule.
 #[test]
 fn test_vesting_only_admin_can_create() {
-    let (env, cid, _admin) = setup_with_admin();
+    let (env, cid, admin) = setup_with_admin();
     let client = PaymentContractClient::new(&env, &cid);
     let attacker = Address::generate(&env);
     let donor = Address::generate(&env);
+    let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000);
 
     env.ledger().with_mut(|l| l.timestamp = 1_000);
-    let result = client.try_create_vesting(&attacker, &donor, &1_000i128, &100u64, &500u64);
+    let result = client.try_create_vesting(&attacker, &donor, &token_id, &1_000i128, &100u64, &500u64);
     assert!(result.is_err(), "Non-admin must not create vesting");
 }
 
@@ -908,14 +909,15 @@ fn test_vesting_rejects_cliff_gte_duration() {
     let (env, cid, admin) = setup_with_admin();
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
+    let token_id = deploy_token_with_balance(&env, &admin, &cid, 1_000);
 
     env.ledger().with_mut(|l| l.timestamp = 1_000);
     // cliff_secs = 500, duration_secs = 500 (equal)
-    let result = client.try_create_vesting(&admin, &donor, &1_000i128, &500u64, &500u64);
+    let result = client.try_create_vesting(&admin, &donor, &token_id, &1_000i128, &500u64, &500u64);
     assert_eq!(result, Err(Ok(Error::InvalidVestingSchedule)));
 
     // cliff_secs = 600, duration_secs = 500 (cliff > duration)
-    let result = client.try_create_vesting(&admin, &donor, &1_000i128, &600u64, &500u64);
+    let result = client.try_create_vesting(&admin, &donor, &token_id, &1_000i128, &600u64, &500u64);
     assert_eq!(result, Err(Ok(Error::InvalidVestingSchedule)));
 }
 
@@ -1015,13 +1017,13 @@ fn test_vesting_events_emitted() {
     let client = PaymentContractClient::new(&env, &cid);
     let donor = Address::generate(&env);
 
-    env.ledger().with_mut(|l| l.timestamp = 1_000);
-    client.create_vesting(&admin, &donor, &200_000i128, &0u64, &1000u64);
-
     let token_id = deploy_token_with_balance(&env, &admin, &cid, 200_000);
 
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    client.create_vesting(&admin, &donor, &token_id, &200_000i128, &0u64, &1000u64);
+
     env.ledger().with_mut(|l| l.timestamp = 2_500); // past vest_end
-    client.claim_vested(&donor, &token_id);
+    client.claim_vested(&donor);
 
     // Events are published — verify no panic and schedule is updated
     let schedule = client.get_vesting(&donor);

--- a/lifebank-soroban/contracts/requests/src/lib.rs
+++ b/lifebank-soroban/contracts/requests/src/lib.rs
@@ -476,6 +476,30 @@ impl RequestContract {
         Ok(())
     }
 
+    /// Set or update the inventory reservation ID for a request. Admin only.
+    /// Called when units are reserved against a request so cancellation can release them.
+    pub fn set_reservation_id(
+        env: Env,
+        caller: Address,
+        request_id: u64,
+        reservation_id: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        storage::require_initialized(&env)?;
+
+        let admin = storage::get_admin(&env);
+        if caller != admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let mut request =
+            storage::get_request(&env, request_id).ok_or(ContractError::RequestNotFound)?;
+        request.reservation_id = Some(reservation_id);
+        storage::set_request(&env, &request);
+
+        Ok(())
+    }
+
     pub fn get_request_history(
         env: Env,
         request_id: u64,

--- a/lifebank-soroban/contracts/requests/src/test.rs
+++ b/lifebank-soroban/contracts/requests/src/test.rs
@@ -380,3 +380,42 @@ fn test_request_history_captures_transition_rationale() {
         String::from_str(&env, "Hospital no longer needs remaining units")
     );
 }
+
+#[test]
+fn test_cancel_request_with_reservation_id() {
+    let (env, client, _contract_id, admin, _inventory_contract) = create_initialized_contract();
+    let hospital = authorize_hospital(&env, &client);
+    env.ledger().set_timestamp(7_000);
+    let request_id = client.create_request(
+        &hospital,
+        &BloodType::OPositive,
+        &BloodComponent::RedCells,
+        &500u32,
+        &Urgency::Urgent,
+        &8_000u64,
+    );
+
+    let reservation_id = 42u64;
+    client.set_reservation_id(&admin, &request_id, &reservation_id);
+
+    client.update_request_status(
+        &admin,
+        &request_id,
+        &RequestStatus::Approved,
+        &String::from_str(&env, "Approved"),
+    );
+
+    client.cancel_request(
+        &hospital,
+        &request_id,
+        &String::from_str(&env, "Request cancelled"),
+    );
+
+    let request = client.get_request(&request_id);
+    assert_eq!(request.status, RequestStatus::Cancelled);
+    assert_eq!(request.reservation_id, None);
+
+    let history = client.get_request_history(&request_id);
+    let cancel_entry = history.get(2).unwrap();
+    assert_eq!(cancel_entry.released_reservation, true);
+}


### PR DESCRIPTION
 ## Summary

   This PR resolves four critical Soroban contract issues: duplicate symbol collision in WASM compilation, a security vulnerability in token vesting,
   dead code in reservation release, and missing test coverage for admin functions.

   ## Changes

   ### #1155 — Identity contract duplicate function names

   Renamed `initialize` and `has_role` in `AccessControlContract` to `ac_initialize` and `ac_has_role` to avoid symbol collision when compiling to
   `wasm32-unknown-unknown`.

   ### #1154 — Payments contract arbitrary token drain

   Added `reward_token` field to `VestingSchedule` and require it at creation time. Removed caller-supplied `reward_token` parameter from `claim_vested`
    to prevent donors from claiming against arbitrary escrowed tokens.

   ### #1156 — Requests contract dead code

   Implemented `set_reservation_id()` admin function to link blood requests to inventory reservations, enabling `cancel_request` and `reject` flows to
   actually release reserved units. Added test verifying reservation release.

   ### #1157 — Coordinator contract missing test coverage

   Added comprehensive tests for:
   - Successful `propose_admin`/`accept_admin` two-step transfer
   - Rejection of `accept_admin` from non-pending address
   - `emergency_halt` blocking `settle_payment`
   - `clear_emergency_halt` restoring operation
   - Non-admin rejection for admin functions
   - `rollback` for Delivered-but-unsettled workflows

   ## Notes

   - One commit per issue
   - All changes are code-only (no build/test scripts run during implementation)
   - Committer: Almikefred

   Closes #1155, Closes #1154, Closes #1156, Closes #1157