### PR TITLE
fix: scope inventory stats, guard donor deferral routes, enforce eligibility rules, fix cold-chain breach math

### DIFF
--- a/backend/src/blood-units/blood-inventory-query.service.ts
+++ b/backend/src/blood-units/blood-inventory-query.service.ts
@@ -77,58 +77,83 @@ export class BloodInventoryQueryService {
     };
   }
 
-  async getStatistics(bankId?: string): Promise<InventoryStatistics> {
+  async getStatistics(bankId: string): Promise<InventoryStatistics> {
     const policy = await this.policyCenterService.getActivePolicySnapshot();
     const now = new Date();
     const soonThreshold = new Date(
       now.getTime() + policy.rules.inventory.expiringSoonHours * 60 * 60 * 1000,
     );
 
-    const qb = this.bloodUnitRepository.createQueryBuilder('u');
-    if (bankId) {
-      qb.where('u.organizationId = :bankId', { bankId });
-    }
+    const statusRows: { status: BloodStatus; count: string }[] =
+      await this.bloodUnitRepository
+        .createQueryBuilder('u')
+        .select('u.status', 'status')
+        .addSelect('COUNT(*)', 'count')
+        .where('u.organizationId = :bankId', { bankId })
+        .groupBy('u.status')
+        .getRawMany();
 
-    const units = await qb.getMany();
+    const byBloodTypeRows: { bloodType: BloodType; count: string }[] =
+      await this.bloodUnitRepository
+        .createQueryBuilder('u')
+        .select('u.bloodType', 'bloodType')
+        .addSelect('COUNT(*)', 'count')
+        .where('u.organizationId = :bankId', { bankId })
+        .groupBy('u.bloodType')
+        .getRawMany();
+
+    const byComponentRows: { component: string; count: string }[] =
+      await this.bloodUnitRepository
+        .createQueryBuilder('u')
+        .select('u.component', 'component')
+        .addSelect('COUNT(*)', 'count')
+        .where('u.organizationId = :bankId', { bankId })
+        .groupBy('u.component')
+        .getRawMany();
+
+    const totals: { total: string; totalVolumeMl: string | null } =
+      await this.bloodUnitRepository
+        .createQueryBuilder('u')
+        .select('COUNT(*)', 'total')
+        .addSelect('SUM(u.volumeMl)', 'totalVolumeMl')
+        .where('u.organizationId = :bankId', { bankId })
+        .getRawOne();
+
+    const expiringSoonCount: { count: string } | undefined =
+      await this.bloodUnitRepository
+        .createQueryBuilder('u')
+        .select('COUNT(*)', 'count')
+        .where('u.organizationId = :bankId', { bankId })
+        .andWhere('u.status = :status', { status: BloodStatus.AVAILABLE })
+        .andWhere('u.expiresAt > :now', { now })
+        .andWhere('u.expiresAt <= :soonThreshold', { soonThreshold })
+        .getRawOne();
 
     const byBloodType: Record<string, number> = {};
+    for (const row of byBloodTypeRows) {
+      byBloodType[row.bloodType] = Number(row.count);
+    }
+
     const byComponent: Record<string, number> = {};
-    let available = 0;
-    let reserved = 0;
-    let inTransit = 0;
-    let expired = 0;
-    let expiringSoon = 0;
-    let totalVolumeMl = 0;
+    for (const row of byComponentRows) {
+      byComponent[row.component] = Number(row.count);
+    }
 
-    for (const unit of units) {
-      byBloodType[unit.bloodType] = (byBloodType[unit.bloodType] ?? 0) + 1;
-      byComponent[unit.component] = (byComponent[unit.component] ?? 0) + 1;
-      totalVolumeMl += unit.volumeMl;
-
-      if (unit.status === BloodStatus.AVAILABLE) available++;
-      else if (unit.status === BloodStatus.RESERVED) reserved++;
-      else if (unit.status === BloodStatus.IN_TRANSIT) inTransit++;
-      else if (unit.status === BloodStatus.EXPIRED) expired++;
-
-      if (
-        unit.status === BloodStatus.AVAILABLE &&
-        unit.expiresAt > now &&
-        unit.expiresAt <= soonThreshold
-      ) {
-        expiringSoon++;
-      }
+    const statusCounts: Record<string, number> = {};
+    for (const row of statusRows) {
+      statusCounts[row.status] = Number(row.count);
     }
 
     return {
-      total: units.length,
-      available,
-      reserved,
-      inTransit,
-      expired,
-      expiringSoon,
+      total: Number(totals?.total ?? 0),
+      available: statusCounts[BloodStatus.AVAILABLE] ?? 0,
+      reserved: statusCounts[BloodStatus.RESERVED] ?? 0,
+      inTransit: statusCounts[BloodStatus.IN_TRANSIT] ?? 0,
+      expired: statusCounts[BloodStatus.EXPIRED] ?? 0,
+      expiringSoon: Number(expiringSoonCount?.count ?? 0),
       byBloodType,
       byComponent,
-      totalVolumeMl,
+      totalVolumeMl: Number(totals?.totalVolumeMl ?? 0),
       policyVersionRef: policy.policyVersionId,
     };
   }

--- a/backend/src/blood-units/blood-units.controller.ts
+++ b/backend/src/blood-units/blood-units.controller.ts
@@ -250,8 +250,21 @@ export class BloodUnitsController {
 
   @RequirePermissions(Permission.REGISTER_BLOOD_UNIT)
   @Get('inventory/statistics')
-  async getInventoryStatistics(@Query('bankId') bankId?: string) {
-    return this.inventoryQueryService.getStatistics(bankId);
+  async getInventoryStatistics(
+    @Query('bankId') bankId: string | undefined,
+    @Req()
+    request: Request & {
+      user?: { id: string; role: string; organizationId?: string };
+    },
+  ) {
+    const isAdmin = request.user?.role?.toLowerCase() === 'admin';
+    const scopedBankId = isAdmin ? bankId : request.user?.organizationId;
+    if (!scopedBankId) {
+      throw new BadRequestException(
+        'bankId is required (derived from your organization unless you are an admin).',
+      );
+    }
+    return this.inventoryQueryService.getStatistics(scopedBankId);
   }
 
   @RequirePermissions(Permission.REGISTER_BLOOD_UNIT)

--- a/backend/src/cold-chain/cold-chain.service.ts
+++ b/backend/src/cold-chain/cold-chain.service.ts
@@ -147,6 +147,7 @@ export class ColdChainService {
   private computeBreachDuration(samples: TemperatureSampleEntity[]): number {
     let totalMinutes = 0;
     let breachWindowStart: Date | null = null;
+    let breachWindowEnd: Date | null = null;
 
     for (const sample of samples) {
       if (sample.isExcursion) {
@@ -154,13 +155,20 @@ export class ColdChainService {
           breachWindowStart = sample.recordedAt;
         }
         // Extend window to this sample's timestamp
-        const windowEnd = sample.recordedAt;
-        totalMinutes =
-          (windowEnd.getTime() - breachWindowStart.getTime()) / 60_000;
-      } else {
-        // Safe sample — close any open breach window
+        breachWindowEnd = sample.recordedAt;
+      } else if (breachWindowStart && breachWindowEnd) {
+        // Safe sample — close the open breach window and accumulate its duration
+        totalMinutes +=
+          (breachWindowEnd.getTime() - breachWindowStart.getTime()) / 60_000;
         breachWindowStart = null;
+        breachWindowEnd = null;
       }
+    }
+
+    // Accumulate any breach window still open at the end of iteration
+    if (breachWindowStart && breachWindowEnd) {
+      totalMinutes +=
+        (breachWindowEnd.getTime() - breachWindowStart.getTime()) / 60_000;
     }
 
     return totalMinutes;

--- a/backend/src/donor-eligibility/donor-eligibility.controller.ts
+++ b/backend/src/donor-eligibility/donor-eligibility.controller.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagg
 import { User } from '../auth/decorators/user.decorator';
 import { RequirePermissions } from '../auth/decorators/require-permissions.decorator';
 import { Permission } from '../auth/enums/permission.enum';
+import { PermissionsService, UserContext } from '../auth/permissions.service';
 import { DonorEligibilityService } from './donor-eligibility.service';
 import { CreateDeferralDto, OverrideDeferralDto, SimulateEligibilityDto } from './dto/create-deferral.dto';
 import { EligibilityRuleVersionEntity } from './entities/eligibility-rule-version.entity';
@@ -11,19 +12,32 @@ import { EligibilityRuleVersionEntity } from './entities/eligibility-rule-versio
 @ApiBearerAuth()
 @Controller('donor-eligibility')
 export class DonorEligibilityController {
-  constructor(private readonly service: DonorEligibilityService) {}
+  constructor(
+    private readonly service: DonorEligibilityService,
+    private readonly permissionsService: PermissionsService,
+  ) {}
 
   @ApiOperation({ summary: 'Get :donorId' })
   @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':donorId')
-  checkEligibility(@Param('donorId') donorId: string) {
-    return this.service.checkEligibility(donorId);
+  checkEligibility(
+    @Param('donorId') donorId: string,
+    @User() user: UserContext,
+    @Query('dateOfBirth') dateOfBirth?: string,
+    @Query('lastDonationDate') lastDonationDate?: string,
+  ) {
+    this.permissionsService.assertIsAdminOrSelf(user, donorId);
+    return this.service.checkEligibility(donorId, undefined, {
+      dateOfBirth: dateOfBirth ? new Date(dateOfBirth) : undefined,
+      lastDonationDate: lastDonationDate ? new Date(lastDonationDate) : undefined,
+    });
   }
 
   @ApiOperation({ summary: 'Get :donorId deferrals' })
   @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
   @Get(':donorId/deferrals')
-  getDeferrals(@Param('donorId') donorId: string) {
+  getDeferrals(@Param('donorId') donorId: string, @User() user: UserContext) {
+    this.permissionsService.assertIsAdminOrSelf(user, donorId);
     return this.service.getDeferrals(donorId);
   }
 
@@ -46,6 +60,7 @@ export class DonorEligibilityController {
   @ApiOperation({ summary: 'Delete deferrals :id' })
   @ApiResponse({ status: 200, description: 'Resource deleted successfully' })
   @Delete('deferrals/:id')
+  @RequirePermissions(Permission.ADMIN_ACCESS)
   revokeDeferral(@Param('id') id: string) {
     return this.service.revokeDeferral(id);
   }

--- a/backend/src/donor-eligibility/donor-eligibility.module.ts
+++ b/backend/src/donor-eligibility/donor-eligibility.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { DonorDeferralEntity } from './entities/donor-deferral.entity';
 import { EligibilityRuleVersionEntity } from './entities/eligibility-rule-version.entity';
 import { DonorEligibilityService } from './donor-eligibility.service';
 import { DonorEligibilityController } from './donor-eligibility.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DonorDeferralEntity, EligibilityRuleVersionEntity])],
+  imports: [
+    TypeOrmModule.forFeature([DonorDeferralEntity, EligibilityRuleVersionEntity]),
+    AuthModule,
+  ],
   controllers: [DonorEligibilityController],
   providers: [DonorEligibilityService],
   exports: [DonorEligibilityService],

--- a/backend/src/donor-eligibility/donor-eligibility.service.ts
+++ b/backend/src/donor-eligibility/donor-eligibility.service.ts
@@ -38,6 +38,11 @@ export interface EligibilityResult {
   ruleVersionId: string;
 }
 
+export interface DonorProfile {
+  dateOfBirth?: Date;
+  lastDonationDate?: Date;
+}
+
 @Injectable()
 export class DonorEligibilityService {
   constructor(
@@ -75,7 +80,11 @@ export class DonorEligibilityService {
     return createHash('sha256').update(payload).digest('hex').slice(0, 16);
   }
 
-  async checkEligibility(donorId: string, asOfDate?: Date): Promise<EligibilityResult> {
+  async checkEligibility(
+    donorId: string,
+    asOfDate?: Date,
+    profile?: DonorProfile,
+  ): Promise<EligibilityResult> {
     const now = asOfDate ?? new Date();
     const active = await this.deferralRepo.find({
       where: { donorId, isActive: true },
@@ -134,8 +143,30 @@ export class DonorEligibilityService {
 
     // Evaluate versioned rule predicates
     for (const rule of rules) {
-      const predicateTrace = this.evaluatePredicate(rule, donorId, now);
+      const predicateTrace = this.evaluatePredicate(rule, now, profile);
       trace.push(predicateTrace);
+    }
+
+    const failedPredicate = trace.find(
+      (t) =>
+        !t.passed &&
+        (t.predicateType === RulePredicateType.AGE_RANGE ||
+          t.predicateType === RulePredicateType.DONATION_INTERVAL),
+    );
+    if (failedPredicate) {
+      const nextEligibleDate =
+        failedPredicate.predicateType === RulePredicateType.DONATION_INTERVAL &&
+        profile?.lastDonationDate
+          ? this.computeNextEligibleFromDonation(profile.lastDonationDate)
+          : null;
+      return {
+        donorId,
+        status: EligibilityStatus.DEFERRED,
+        nextEligibleDate,
+        activeDeferrals: [],
+        trace,
+        ruleVersionId,
+      };
     }
 
     return { donorId, status: EligibilityStatus.ELIGIBLE, nextEligibleDate: null, activeDeferrals: [], trace, ruleVersionId };
@@ -143,8 +174,8 @@ export class DonorEligibilityService {
 
   private evaluatePredicate(
     rule: EligibilityRuleVersionEntity,
-    donorId: string,
     now: Date,
+    profile?: DonorProfile,
   ): PredicateTrace {
     const base = {
       ruleKey: rule.ruleKey,
@@ -153,8 +184,43 @@ export class DonorEligibilityService {
       ruleVersionId: rule.id,
     };
 
-    // Predicates are evaluated structurally; domain-specific checks (age, interval)
-    // require caller to pass donor profile. Here we record the rule was considered.
+    if (rule.predicateType === RulePredicateType.AGE_RANGE) {
+      if (!profile?.dateOfBirth) {
+        return {
+          ...base,
+          passed: true,
+          reason: 'Donor date of birth not provided; age check skipped',
+        };
+      }
+      const isValidAge = this.validateAge(profile.dateOfBirth);
+      return {
+        ...base,
+        passed: isValidAge,
+        reason: isValidAge
+          ? `Donor age is within the allowed range (${MIN_AGE}-${MAX_AGE})`
+          : `Donor age is outside the allowed range (${MIN_AGE}-${MAX_AGE})`,
+      };
+    }
+
+    if (rule.predicateType === RulePredicateType.DONATION_INTERVAL) {
+      if (!profile?.lastDonationDate) {
+        return {
+          ...base,
+          passed: true,
+          reason: 'Donor last-donation date not provided; interval check skipped',
+        };
+      }
+      const nextEligible = this.computeNextEligibleFromDonation(profile.lastDonationDate);
+      const passed = nextEligible <= now;
+      return {
+        ...base,
+        passed,
+        reason: passed
+          ? `Minimum ${MIN_DONATION_INTERVAL_DAYS}-day donation interval satisfied`
+          : `Donor not eligible again until ${nextEligible.toISOString()}`,
+      };
+    }
+
     return {
       ...base,
       passed: true,
@@ -162,8 +228,8 @@ export class DonorEligibilityService {
     };
   }
 
-  async assertEligible(donorId: string): Promise<void> {
-    const result = await this.checkEligibility(donorId);
+  async assertEligible(donorId: string, profile?: DonorProfile): Promise<void> {
+    const result = await this.checkEligibility(donorId, undefined, profile);
     if (result.status !== EligibilityStatus.ELIGIBLE) {
       throw new ConflictException(
         `Donor '${donorId}' is not eligible for donation (status: ${result.status}).`,
@@ -221,7 +287,10 @@ export class DonorEligibilityService {
   /** Simulate eligibility against a proposed rule version without persisting */
   async simulateEligibility(dto: SimulateEligibilityDto): Promise<EligibilityResult> {
     const asOf = dto.asOfDate ? new Date(dto.asOfDate) : new Date();
-    return this.checkEligibility(dto.donorId, asOf);
+    return this.checkEligibility(dto.donorId, asOf, {
+      dateOfBirth: dto.dateOfBirth ? new Date(dto.dateOfBirth) : undefined,
+      lastDonationDate: dto.lastDonationDate ? new Date(dto.lastDonationDate) : undefined,
+    });
   }
 
   async getDeferrals(donorId: string): Promise<DonorDeferralEntity[]> {

--- a/backend/src/donor-eligibility/dto/create-deferral.dto.ts
+++ b/backend/src/donor-eligibility/dto/create-deferral.dto.ts
@@ -49,4 +49,14 @@ export class SimulateEligibilityDto {
   @IsDateString()
   @IsOptional()
   asOfDate?: string;
+
+  /** Donor date of birth (ISO string) — required to evaluate age-range rules */
+  @IsDateString()
+  @IsOptional()
+  dateOfBirth?: string;
+
+  /** Donor's last donation date (ISO string) — required to evaluate interval rules */
+  @IsDateString()
+  @IsOptional()
+  lastDonationDate?: string;
 }


### PR DESCRIPTION
## Summary
- Blood inventory statistics (`GET /blood-units/inventory/statistics`) now requires an organization-scoped `bankId` (derived from the caller unless admin) and computes aggregates with grouped SQL (`COUNT`/`SUM` + `GROUP BY`) instead of loading every row into memory.
- `donor-eligibility` routes `GET /donor-eligibility/:donorId` and `GET /donor-eligibility/:donorId/deferrals` now require admin-or-self (`PermissionsService.assertIsAdminOrSelf`); `DELETE /donor-eligibility/deferrals/:id` now requires `Permission.ADMIN_ACCESS`.
- `DonorEligibilityService.checkEligibility` now actually evaluates `AGE_RANGE` and `DONATION_INTERVAL` rule predicates against donor profile data (date of birth / last donation date, optionally supplied by callers) and downgrades status to `DEFERRED` when they fail, instead of unconditionally recording `passed: true`.
- `ColdChainService.computeBreachDuration` now accumulates (`+=`) each closed excursion window's duration instead of overwriting (`=`) it, so a delivery with multiple separate breach windows sums correctly against the suspension threshold.

Closes #1177 
closes #1176 
closes #1175 
closes #1174 

## Test plan
Per task instructions, automated tests were skipped for this change.