### PR TITLE
fix: inventory build break, MFA login lockout, throttler Redis state, txHash validation

### DIFF
--- a/backend/src/auth/mfa/mfa.controller.ts
+++ b/backend/src/auth/mfa/mfa.controller.ts
@@ -15,9 +15,21 @@ import {
 } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
+import { Public } from '../decorators/public.decorator';
 import { MfaService } from './mfa.service';
 
 export class MfaVerifyDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{6}$/, { message: 'token must be a 6-digit number' })
+  token: string;
+}
+
+export class MfaLoginChallengeDto {
+  @IsString()
+  @IsNotEmpty()
+  user_id: string;
+
   @IsString()
   @IsNotEmpty()
   @Matches(/^\d{6}$/, { message: 'token must be a 6-digit number' })
@@ -69,6 +81,24 @@ export class MfaController {
     }
     // Subsequent logins: validate code and return mfaToken
     return this.mfaService.validateMfaCode(userId, dto.token);
+  }
+
+  @Public()
+  @Post('login-challenge')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Complete step-up MFA login',
+    description:
+      'Unauthenticated endpoint used after login() returns { mfa_required: true, user_id }. ' +
+      'Accepts the user_id and a valid TOTP code, and returns a short-lived mfaToken ' +
+      'that must be exchanged for a full access token via POST /auth/mfa/exchange.',
+  })
+  @ApiResponse({
+    status: 200,
+    schema: { example: { mfaToken: 'eyJ...' } },
+  })
+  async loginChallenge(@Body() dto: MfaLoginChallengeDto) {
+    return this.mfaService.validateMfaCode(dto.user_id, dto.token);
   }
 
   @Delete('disable')

--- a/backend/src/escrow-governance/dto/escrow-governance.dto.ts
+++ b/backend/src/escrow-governance/dto/escrow-governance.dto.ts
@@ -7,6 +7,7 @@ import {
     IsPositive,
     IsString,
     IsUUID,
+    Matches,
     Max,
     Min,
 } from 'class-validator';
@@ -126,4 +127,12 @@ export class EmergencySuspendDto {
     @IsString()
     @IsNotEmpty()
     reason: string;
+}
+
+export class MarkExecutedDto {
+    @ApiProperty({ description: 'On-chain Stellar/Soroban transaction hash (64-char hex)' })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/^[0-9a-f]{64}$/i, { message: 'txHash must be a 64-character hex string' })
+    txHash: string;
 }

--- a/backend/src/escrow-governance/escrow-governance.controller.ts
+++ b/backend/src/escrow-governance/escrow-governance.controller.ts
@@ -28,6 +28,7 @@ import {
     CreateEscrowProposalDto,
     CreateThresholdPolicyDto,
     EmergencySuspendDto,
+    MarkExecutedDto,
     RevokeSignerDto,
     SuspendSignerDto,
 } from './dto/escrow-governance.dto';
@@ -203,10 +204,10 @@ export class EscrowGovernanceController {
     @ApiOperation({ summary: 'Mark an approved proposal as executed with its on-chain tx hash' })
     markExecuted(
         @Param('id') id: string,
-        @Body('txHash') txHash: string,
+        @Body() dto: MarkExecutedDto,
         @Req() req: Request,
     ) {
         const user = (req as any).user;
-        return this.service.markExecuted(id, txHash, user.id, user.role);
+        return this.service.markExecuted(id, dto.txHash, user.id, user.role);
     }
 }

--- a/backend/src/inventory/inventory.service.ts
+++ b/backend/src/inventory/inventory.service.ts
@@ -127,16 +127,6 @@ export class InventoryService {
     return { data };
   }
 
-  async getLowStockItems(threshold: number = 10) {
-    const data = await this.inventoryRepo
-      .createQueryBuilder('inventory')
-      .where('inventory.availableUnits <= :threshold', { threshold })
-      .getMany();
-
-    return {
-      message: 'Low stock items retrieved successfully',
-      data,
-    };
   async getLowStockItems(threshold = 10) {
     const data = await this.stockRepo.getLowStock(threshold);
     return { message: 'Low stock items retrieved successfully', data };

--- a/backend/src/throttler/role-aware-throttler.guard.ts
+++ b/backend/src/throttler/role-aware-throttler.guard.ts
@@ -1,5 +1,13 @@
-import { Injectable, ExecutionContext, Logger } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { Inject, Injectable, ExecutionContext, Logger } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  ThrottlerGuard,
+  ThrottlerModuleOptions,
+  ThrottlerStorage,
+  THROTTLER_OPTIONS,
+} from '@nestjs/throttler';
+
+import type Redis from 'ioredis';
 
 import {
   ROLE_THROTTLE_LIMITS,
@@ -9,12 +17,24 @@ import {
   EMERGENCY_ROLES,
   EMERGENCY_WEIGHT
 } from '../config/throttle-limits.config';
+import { REDIS_CLIENT } from '../redis/redis.constants';
 import { throttleGetTracker } from './throttle-tracker.util';
+
+const ABUSE_TRACKER_KEY_PREFIX = 'throttle:abuse:';
+const ABUSE_TRACKER_TTL_SEC = 3600; // matches the 1-hour adaptive block cap
 
 @Injectable()
 export class RoleAwareThrottlerGuard extends ThrottlerGuard {
   private readonly logger = new Logger(RoleAwareThrottlerGuard.name);
-  private abuseTracker = new Map<string, { violations: number; lastViolation: number }>();
+
+  constructor(
+    @Inject(THROTTLER_OPTIONS) options: ThrottlerModuleOptions,
+    @Inject(ThrottlerStorage) storageService: ThrottlerStorage,
+    reflector: Reflector,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {
+    super(options, storageService, reflector);
+  }
 
   protected async getTracker(req: Record<string, any>): Promise<string> {
     return throttleGetTracker(req, null as any);
@@ -28,26 +48,24 @@ export class RoleAwareThrottlerGuard extends ThrottlerGuard {
     // Check base throttling
     const allowed = await super.canActivate(context);
 
+    // Adaptive penalty state lives in Redis so it is shared across all
+    // horizontally-scaled instances and evicted automatically via TTL.
+    const abuseKey = `${ABUSE_TRACKER_KEY_PREFIX}${tracker}`;
+
     if (!allowed) {
       // Adaptive penalty: track violations and increase block duration
-      const now = Date.now();
-      const abuseKey = tracker;
-      const abuseRecord = this.abuseTracker.get(abuseKey) || { violations: 0, lastViolation: 0 };
-
-      abuseRecord.violations++;
-      abuseRecord.lastViolation = now;
+      const violations = await this.redis.incr(abuseKey);
+      await this.redis.expire(abuseKey, ABUSE_TRACKER_TTL_SEC);
 
       // Adaptive block duration based on violation count
-      const adaptiveBlockMs = Math.min(THROTTLE_TTL_MS * Math.pow(2, abuseRecord.violations - 1), 3600000); // Max 1 hour
-
-      this.abuseTracker.set(abuseKey, abuseRecord);
+      const adaptiveBlockMs = Math.min(THROTTLE_TTL_MS * Math.pow(2, violations - 1), 3600000); // Max 1 hour
 
       // Log for observability
       this.logger.warn(`Rate limit exceeded for ${tracker}`, {
         role: user?.role || 'PUBLIC',
         tenantId: user?.orgId || 'unknown',
         endpoint: request.path,
-        violations: abuseRecord.violations,
+        violations,
         adaptiveBlockMs,
         userId: user?.id,
       });
@@ -56,13 +74,14 @@ export class RoleAwareThrottlerGuard extends ThrottlerGuard {
       const response = context.switchToHttp().getResponse();
       response.set('Retry-After', Math.ceil(adaptiveBlockMs / 1000));
     } else {
-      // Reset abuse counter on successful request
-      const abuseKey = tracker;
-      const abuseRecord = this.abuseTracker.get(abuseKey);
-      if (abuseRecord) {
-        abuseRecord.violations = Math.max(0, abuseRecord.violations - 1); // Gradual decay
-        if (abuseRecord.violations === 0) {
-          this.abuseTracker.delete(abuseKey);
+      // Reset abuse counter on successful request (gradual decay)
+      const exists = await this.redis.exists(abuseKey);
+      if (exists) {
+        const violations = await this.redis.decr(abuseKey);
+        if (violations <= 0) {
+          await this.redis.del(abuseKey);
+        } else {
+          await this.redis.expire(abuseKey, ABUSE_TRACKER_TTL_SEC);
         }
       }
     }
@@ -110,246 +129,3 @@ export class RoleAwareThrottlerGuard extends ThrottlerGuard {
     ];
   }
 }
-
-import { Controller, Get, INestApplication, Req } from '@nestjs/common';
-import { APP_GUARD } from '@nestjs/core';
-import { Test, TestingModule } from '@nestjs/testing';
-import { ThrottlerModule } from '@nestjs/throttler';
-
-import request from 'supertest';
-
-/** Minimal request shape the guard reads */
-interface FakeRequest {
-  user?: { id: string; role: string };
-}
-
-/**
- * Probe controller that injects a synthetic `req.user` so we can test
- * role-based limits without a real JWT stack.
- */
-@Controller('role-throttle-test')
-class RoleThrottleProbeController {
-  @Get('admin')
-  adminProbe(@Req() _req: FakeRequest) {
-    return { ok: true, role: 'ADMIN' };
-  }
-
-  @Get('hospital')
-  hospitalProbe(@Req() _req: FakeRequest) {
-    return { ok: true, role: 'HOSPITAL' };
-  }
-
-  @Get('public')
-  publicProbe(@Req() _req: FakeRequest) {
-    return { ok: true, role: 'PUBLIC' };
-  }
-
-  @Get('ussd')
-  ussdProbe(@Req() _req: FakeRequest) {
-    return { ok: true, role: 'USSD' };
-  }
-}
-
-/**
- * Build a test app where ThrottlerModule is seeded with a tiny base limit
- * and RoleAwareThrottlerGuard overrides it per-role.
- *
- * We monkey-patch `req.user` via a middleware so we don't need the full
- * JWT/auth stack — matching the pattern in throttler.integration.spec.ts.
- */
-async function buildApp(
-  role: string,
-  userId = 'test-user-1',
-): Promise<INestApplication> {
-  const moduleFixture: TestingModule = await Test.createTestingModule({
-    imports: [
-      ThrottlerModule.forRoot({
-        throttlers: [{ name: 'default', ttl: 60_000, limit: 1000 }],
-      }),
-    ],
-    controllers: [RoleThrottleProbeController],
-    providers: [{ provide: APP_GUARD, useClass: RoleAwareThrottlerGuard }],
-  }).compile();
-
-  const app = moduleFixture.createNestApplication();
-
-  // Inject synthetic req.user before the guard runs
-  app.use((_req: any, _res: any, next: () => void) => {
-    _req.user = { id: userId, role };
-    next();
-  });
-
-  await app.init();
-  return app;
-}
-
-// ─── ADMIN ──────────────────────────────────────────────────────────────────
-
-describe('RoleAwareThrottlerGuard — ADMIN role', () => {
-  let app: INestApplication;
-
-  beforeEach(async () => {
-    app = await buildApp('ADMIN');
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
-
-  it('never blocks admin requests regardless of volume', async () => {
-    // Fire 20 rapid requests — should all pass; ADMIN bypasses counting
-    for (let i = 0; i < 20; i++) {
-      await request(app.getHttpServer())
-        .get('/role-throttle-test/admin')
-        .expect(200);
-    }
-  });
-});
-
-// ─── PUBLIC ─────────────────────────────────────────────────────────────────
-
-describe('RoleAwareThrottlerGuard — PUBLIC role', () => {
-  let app: INestApplication;
-
-  beforeEach(async () => {
-    // Build with a tiny PUBLIC limit so tests run fast
-    app = await buildApp('PUBLIC', 'public-user-1');
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
-
-  it('returns 200 within limit', async () => {
-    await request(app.getHttpServer())
-      .get('/role-throttle-test/public')
-      .expect(200);
-  });
-
-  it('returns 429 with Retry-After header when PUBLIC limit is breached', async () => {
-    // Override the guard's getThrottlers to use limit=1 for this assertion
-    // by building a fresh tiny-limit app
-    const tinyApp = await (async () => {
-      const mod: TestingModule = await Test.createTestingModule({
-        imports: [
-          ThrottlerModule.forRoot({
-            throttlers: [{ name: 'default', ttl: 60_000, limit: 1 }],
-          }),
-        ],
-        controllers: [RoleThrottleProbeController],
-        providers: [
-          {
-            provide: APP_GUARD,
-            useClass: class extends RoleAwareThrottlerGuard {
-              protected override async getThrottlers() {
-                return [
-                  {
-                    name: 'role-aware',
-                    ttl: 60_000,
-                    limit: 1, // force limit=1 for PUBLIC
-                    blockDuration: 0,
-                    ignoreUserAgents: [],
-                  },
-                ];
-              }
-            },
-          },
-        ],
-      }).compile();
-
-      const a = mod.createNestApplication();
-      a.use((_req: any, _res: any, next: () => void) => {
-        _req.user = { id: 'pub-tiny', role: 'PUBLIC' };
-        next();
-      });
-      await a.init();
-      return a;
-    })();
-
-    await request(tinyApp.getHttpServer())
-      .get('/role-throttle-test/public')
-      .expect(200);
-
-    const blocked = await request(tinyApp.getHttpServer())
-      .get('/role-throttle-test/public')
-      .expect(429);
-
-    expect(blocked.headers['retry-after']).toBeDefined();
-    expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
-
-    await tinyApp.close();
-  });
-});
-
-// ─── USSD ────────────────────────────────────────────────────────────────────
-
-describe('RoleAwareThrottlerGuard — USSD role', () => {
-  let app: INestApplication;
-
-  beforeEach(async () => {
-    app = await buildApp('USSD', 'ussd-user-1');
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
-
-  it('returns 200 within limit', async () => {
-    await request(app.getHttpServer())
-      .get('/role-throttle-test/ussd')
-      .expect(200);
-  });
-});
-
-// ─── HOSPITAL ────────────────────────────────────────────────────────────────
-
-describe('RoleAwareThrottlerGuard — HOSPITAL role', () => {
-  let app: INestApplication;
-
-  beforeEach(async () => {
-    app = await buildApp('HOSPITAL', 'hospital-user-1');
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
-
-  it('returns 200 for hospital requests within limit', async () => {
-    await request(app.getHttpServer())
-      .get('/role-throttle-test/hospital')
-      .expect(200);
-  });
-
-  it('resolves higher limit than PUBLIC (200 vs 30)', () => {
-    // Limits are defined in config; assert the config values directly
-    // so the test doesn't need to exhaust 200 requests
-    const { ROLE_THROTTLE_LIMITS } = require('../config/throttle-limits.config');
-    expect(ROLE_THROTTLE_LIMITS['HOSPITAL'].limit).toBeGreaterThan(
-      ROLE_THROTTLE_LIMITS['PUBLIC'].limit,
-    );
-  });
-});
-
-// ─── RATE-LIMIT HEADERS ──────────────────────────────────────────────────────
-
-describe('RoleAwareThrottlerGuard — rate-limit response headers', () => {
-  let app: INestApplication;
-
-  beforeEach(async () => {
-    app = await buildApp('HOSPITAL', 'hosp-header-user');
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
-
-  it('includes x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-reset on 200', async () => {
-    const res = await request(app.getHttpServer())
-      .get('/role-throttle-test/hospital')
-      .expect(200);
-
-    expect(res.headers['x-ratelimit-limit']).toBeDefined();
-    expect(res.headers['x-ratelimit-remaining']).toBeDefined();
-    expect(res.headers['x-ratelimit-reset']).toBeDefined();
-  });
-});


### PR DESCRIPTION
## Summary
- **#1169** — `inventory.service.ts` had two merged/malformed `getLowStockItems` implementations with a missing closing brace, breaking `InventoryModule` compilation. Removed the dead query-builder implementation and kept the `stockRepo.getLowStock()`-based one, restoring valid brace nesting.
- **#1168** — MFA step-up login was unreachable: after `login()` returns `{ mfa_required: true, user_id }`, there was no unauthenticated path to `MfaService.validateMfaCode()`. Added `@Public() POST /auth/mfa/login-challenge` accepting `{ user_id, token }`, distinct from the authenticated `verify()` endpoint used for enabling MFA.
- **#1167** — `RoleAwareThrottlerGuard`'s adaptive-penalty `abuseTracker` was a local in-memory `Map`, so violations never accumulated consistently across horizontally-scaled instances and the map had no bound. Moved the counter into Redis (`INCR`/`EXPIRE`/`DECR`) via the existing `REDIS_CLIENT` provider, giving cross-instance consistency and TTL-based eviction. Also removed ~240 lines of stray spec/test code that had been erroneously appended to this non-spec file (would throw at runtime if the module were ever loaded outside Jest, since `describe`/`it`/`supertest` aren't available then); the equivalent coverage already lives in `role-aware-throttler.guard.spec.ts`.
- **#1166** — `EscrowGovernanceController.markExecuted()` read `txHash` via a raw `@Body('txHash')` extractor, bypassing `ValidationPipe` entirely, unlike every other mutating endpoint in the controller. Added `MarkExecutedDto` with `@IsString() @IsNotEmpty() @Matches(/^[0-9a-f]{64}$/i)` and switched the handler to `@Body() dto: MarkExecutedDto`.

Closes #1166 
 closes #1167 
 closes #1168 
 closes #1169 

## Test plan
Per task instructions, test changes were skipped for this PR — existing suites (`inventory.service.spec.ts`, `mfa.controller` specs, `role-aware-throttler.guard.spec.ts`, `escrow-governance` specs) cover the affected surfaces and should be run in CI.

