### PR TITLE
fix: org-ownership checks, transfer locking, order-split auth guards, leg-status validation

### DIFF
--- a/backend/src/blood-requests/controllers/order-splitting.controller.ts
+++ b/backend/src/blood-requests/controllers/order-splitting.controller.ts
@@ -8,12 +8,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RequirePermissions } from '../../auth/decorators/require-permissions.decorator';
+import { Permission } from '../../auth/enums/permission.enum';
 import { OrderSplittingService } from '../services/order-splitting.service';
-import { CreateSplitOrderDto } from '../dto/split-order.dto';
+import { CreateSplitOrderDto, UpdateLegStatusDto } from '../dto/split-order.dto';
 import { BloodRequestEntity } from '../entities/blood-request.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { FulfillmentLegStatus } from '../entities/fulfillment-leg.entity';
 
 @ApiTags('Blood Requests')
 @ApiBearerAuth()
@@ -28,6 +29,7 @@ export class OrderSplittingController {
 
   @ApiOperation({ summary: 'Post' })
   @ApiResponse({ status: 201, description: 'Resource created successfully' })
+  @RequirePermissions(Permission.CREATE_ORDER)
   @Post()
   async createSplitOrder(@Body() dto: CreateSplitOrderDto) {
     const parentRequest = await this.bloodRequestRepository.findOne({
@@ -46,6 +48,7 @@ export class OrderSplittingController {
 
   @ApiOperation({ summary: 'Get :parentRequestId progress' })
   @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
+  @RequirePermissions(Permission.VIEW_ORDER)
   @Get(':parentRequestId/progress')
   async getOrderProgress(@Param('parentRequestId') parentRequestId: string) {
     return this.orderSplittingService.getParentOrderProgress(parentRequestId);
@@ -53,6 +56,7 @@ export class OrderSplittingController {
 
   @ApiOperation({ summary: 'Get :parentRequestId legs' })
   @ApiResponse({ status: 200, description: 'Resource retrieved successfully' })
+  @RequirePermissions(Permission.VIEW_ORDER)
   @Get(':parentRequestId/legs')
   async getFulfillmentLegs(@Param('parentRequestId') parentRequestId: string) {
     return this.orderSplittingService.getFulfillmentLegs(parentRequestId);
@@ -60,15 +64,11 @@ export class OrderSplittingController {
 
   @ApiOperation({ summary: 'Patch legs :legId status' })
   @ApiResponse({ status: 200, description: 'Resource updated successfully' })
+  @RequirePermissions(Permission.UPDATE_ORDER)
   @Patch('legs/:legId/status')
   async updateLegStatus(
     @Param('legId') legId: string,
-    @Body()
-    body: {
-      status: FulfillmentLegStatus;
-      failureReason?: string;
-      deliveryTime?: number;
-    },
+    @Body() body: UpdateLegStatusDto,
   ) {
     return this.orderSplittingService.updateLegStatus(legId, body.status, {
       failureReason: body.failureReason,
@@ -78,6 +78,7 @@ export class OrderSplittingController {
 
   @ApiOperation({ summary: 'Post legs :legId fail' })
   @ApiResponse({ status: 201, description: 'Resource created successfully' })
+  @RequirePermissions(Permission.UPDATE_ORDER)
   @Post('legs/:legId/fail')
   async markLegAsFailed(
     @Param('legId') legId: string,

--- a/backend/src/blood-requests/dto/split-order.dto.ts
+++ b/backend/src/blood-requests/dto/split-order.dto.ts
@@ -1,4 +1,14 @@
-import { IsArray, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+import { FulfillmentLegStatus } from '../entities/fulfillment-leg.entity';
 
 export class AllocationSourceDto {
   @IsString()
@@ -29,4 +39,17 @@ export class CreateSplitOrderDto {
 
   @IsArray()
   allocationSources: AllocationSourceDto[];
+}
+
+export class UpdateLegStatusDto {
+  @IsEnum(FulfillmentLegStatus)
+  status: FulfillmentLegStatus;
+
+  @IsOptional()
+  @IsString()
+  failureReason?: string;
+
+  @IsOptional()
+  @IsNumber()
+  deliveryTime?: number;
 }

--- a/backend/src/blood-requests/services/order-splitting.service.ts
+++ b/backend/src/blood-requests/services/order-splitting.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -7,6 +7,33 @@ import {
   FulfillmentLegEntity,
   FulfillmentLegStatus,
 } from '../entities/fulfillment-leg.entity';
+
+export const ALLOWED_LEG_TRANSITIONS: Record<
+  FulfillmentLegStatus,
+  FulfillmentLegStatus[]
+> = {
+  [FulfillmentLegStatus.PENDING]: [
+    FulfillmentLegStatus.ALLOCATED,
+    FulfillmentLegStatus.CANCELLED,
+  ],
+  [FulfillmentLegStatus.ALLOCATED]: [
+    FulfillmentLegStatus.RIDER_ASSIGNED,
+    FulfillmentLegStatus.CANCELLED,
+    FulfillmentLegStatus.FAILED,
+  ],
+  [FulfillmentLegStatus.RIDER_ASSIGNED]: [
+    FulfillmentLegStatus.IN_TRANSIT,
+    FulfillmentLegStatus.CANCELLED,
+    FulfillmentLegStatus.FAILED,
+  ],
+  [FulfillmentLegStatus.IN_TRANSIT]: [
+    FulfillmentLegStatus.DELIVERED,
+    FulfillmentLegStatus.FAILED,
+  ],
+  [FulfillmentLegStatus.DELIVERED]: [],
+  [FulfillmentLegStatus.FAILED]: [],
+  [FulfillmentLegStatus.CANCELLED]: [],
+};
 
 export interface AllocationSource {
   bloodBankId: string;
@@ -87,8 +114,10 @@ export class OrderSplittingService {
     });
 
     if (!leg) {
-      throw new Error(`Fulfillment leg ${legId} not found`);
+      throw new NotFoundException(`Fulfillment leg ${legId} not found`);
     }
+
+    this.validateLegTransition(leg.status, status);
 
     leg.status = status;
 
@@ -136,6 +165,24 @@ export class OrderSplittingService {
       overallStatus,
       legs,
     };
+  }
+
+  private validateLegTransition(
+    from: FulfillmentLegStatus,
+    to: FulfillmentLegStatus,
+  ): void {
+    if (from === to) {
+      throw new BadRequestException(`Fulfillment leg is already in ${to} status`);
+    }
+
+    const allowed = ALLOWED_LEG_TRANSITIONS[from] ?? [];
+    if (!allowed.includes(to)) {
+      throw new BadRequestException(
+        `Invalid leg status transition from ${from} to ${to}. Allowed transitions: ${
+          allowed.join(', ') || 'none'
+        }`,
+      );
+    }
   }
 
   async handleLegFailure(

--- a/backend/src/blood-units/blood-status.service.ts
+++ b/backend/src/blood-units/blood-status.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   Logger,
   NotFoundException,
@@ -27,6 +28,7 @@ import { BloodStatus } from './enums/blood-status.enum';
 interface AuthenticatedUserContext {
   id: string;
   role: string;
+  organizationId?: string | null;
 }
 
 export const ALLOWED_TRANSITIONS: Record<BloodStatus, BloodStatus[]> = {
@@ -85,6 +87,8 @@ export class BloodStatusService {
     if (!unit) {
       throw new NotFoundException(`Blood unit ${unitId} not found`);
     }
+
+    this.assertOwnsUnit(unit, user);
 
     this.validateTransition(unit.status, dto.status);
 
@@ -167,6 +171,8 @@ export class BloodStatusService {
     if (!unit) {
       throw new NotFoundException(`Blood unit ${unitId} not found`);
     }
+
+    this.assertOwnsUnit(unit, user);
 
     if (unit.status !== BloodStatus.AVAILABLE) {
       throw new ConflictException(
@@ -277,6 +283,21 @@ export class BloodStatusService {
 
   isValidTransition(from: BloodStatus, to: BloodStatus): boolean {
     return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+  }
+
+  private assertOwnsUnit(
+    unit: BloodUnit,
+    user?: AuthenticatedUserContext,
+  ): void {
+    if (!user || user.role === 'admin') {
+      return;
+    }
+
+    if (unit.organizationId !== user.organizationId) {
+      throw new ForbiddenException(
+        `You do not have permission to modify blood unit ${unit.id}`,
+      );
+    }
   }
 
   private validateTransition(from: BloodStatus, to: BloodStatus): void {

--- a/backend/src/blood-units/blood-units.controller.ts
+++ b/backend/src/blood-units/blood-units.controller.ts
@@ -195,7 +195,9 @@ export class BloodUnitsController {
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: UpdateBloodStatusDto,
     @Req()
-    request: Request & { user?: { id: string; role: string } },
+    request: Request & {
+      user?: { id: string; role: string; organizationId?: string | null };
+    },
   ) {
     return this.bloodStatusService.updateStatus(id, dto, request.user);
   }
@@ -207,7 +209,9 @@ export class BloodUnitsController {
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: ReserveBloodUnitDto,
     @Req()
-    request: Request & { user?: { id: string; role: string } },
+    request: Request & {
+      user?: { id: string; role: string; organizationId?: string | null };
+    },
   ) {
     return this.bloodStatusService.reserveUnit(id, dto, request.user);
   }
@@ -224,7 +228,9 @@ export class BloodUnitsController {
   async bulkUpdateStatus(
     @Body() dto: BulkUpdateBloodStatusDto,
     @Req()
-    request: Request & { user?: { id: string; role: string } },
+    request: Request & {
+      user?: { id: string; role: string; organizationId?: string | null };
+    },
   ) {
     return this.bloodStatusService.bulkUpdateStatus(dto, request.user);
   }

--- a/backend/src/blood-units/blood-units.service.ts
+++ b/backend/src/blood-units/blood-units.service.ts
@@ -6,10 +6,10 @@ import {
   ServiceUnavailableException,
   Logger,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import * as QRCode from 'qrcode';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 import { PermissionsService } from '../auth/permissions.service';
 import { DonorEligibilityService } from '../donor-eligibility/donor-eligibility.service';
@@ -61,12 +61,12 @@ export class BloodUnitsService {
     private readonly trailRepository: Repository<BloodUnitTrail>,
     @InjectRepository(BloodUnitEntity)
     private readonly bloodUnitRepository: Repository<BloodUnitEntity>,
-    @InjectRepository(BloodUnit)
-    private readonly inventoryRepository: Repository<BloodUnit>,
     @InjectRepository(TransferRecord)
     private readonly transferRepository: Repository<TransferRecord>,
     @InjectRepository(OrganizationEntity)
     private readonly orgRepository: Repository<OrganizationEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
 
@@ -190,35 +190,52 @@ export class BloodUnitsService {
     reason?: string,
     user?: AuthenticatedUserContext,
   ) {
-    const unit = await this.inventoryRepository.findOne({
-      where: { id: unitId },
-    });
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    if (!unit) {
-      throw new NotFoundException(`Blood unit ${unitId} not found`);
+    let unit: BloodUnit;
+    let transfer: TransferRecord;
+
+    try {
+      unit = await queryRunner.manager.findOne(BloodUnit, {
+        where: { id: unitId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!unit) {
+        throw new NotFoundException(`Blood unit ${unitId} not found`);
+      }
+
+      // Must be owner org
+      if (unit.organizationId !== (user as any)?.organizationId && user?.role !== 'admin') {
+        throw new BadRequestException('Only the owner organization can initiate a transfer');
+      }
+
+      if (unit.status !== BloodStatus.AVAILABLE) {
+        throw new BadRequestException(`Unit must be AVAILABLE to transfer (current: ${unit.status})`);
+      }
+
+      unit.status = BloodStatus.IN_TRANSFER;
+      await queryRunner.manager.save(unit);
+
+      transfer = queryRunner.manager.create(TransferRecord, {
+        bloodUnitId: unitId,
+        sourceOrgId: unit.organizationId,
+        destinationOrgId,
+        reason,
+        status: TransferStatus.PENDING,
+        initiatedByUserId: user?.id,
+      });
+      await queryRunner.manager.save(transfer);
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
     }
-
-    // Must be owner org
-    if (unit.organizationId !== (user as any)?.organizationId && user?.role !== 'admin') {
-      throw new BadRequestException('Only the owner organization can initiate a transfer');
-    }
-
-    if (unit.status !== BloodStatus.AVAILABLE) {
-      throw new BadRequestException(`Unit must be AVAILABLE to transfer (current: ${unit.status})`);
-    }
-
-    unit.status = BloodStatus.IN_TRANSFER;
-    await this.inventoryRepository.save(unit);
-
-    const transfer = this.transferRepository.create({
-      bloodUnitId: unitId,
-      sourceOrgId: unit.organizationId,
-      destinationOrgId,
-      reason,
-      status: TransferStatus.PENDING,
-      initiatedByUserId: user?.id,
-    });
-    await this.transferRepository.save(transfer);
 
     this.eventEmitter.emit('blood-unit.transfer.initiated', {
       unitId,
@@ -241,40 +258,59 @@ export class BloodUnitsService {
    * Closes #465
    */
   async acceptOrganizationTransfer(unitId: string, user?: AuthenticatedUserContext) {
-    const unit = await this.inventoryRepository.findOne({
-      where: { id: unitId },
-    });
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    if (!unit) {
-      throw new NotFoundException(`Blood unit ${unitId} not found`);
+    let unit: BloodUnit;
+    let transfer: TransferRecord;
+    let previousOrgId: string;
+
+    try {
+      unit = await queryRunner.manager.findOne(BloodUnit, {
+        where: { id: unitId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!unit) {
+        throw new NotFoundException(`Blood unit ${unitId} not found`);
+      }
+
+      transfer = await queryRunner.manager.findOne(TransferRecord, {
+        where: {
+          bloodUnitId: unitId,
+          status: TransferStatus.PENDING,
+        },
+        order: { createdAt: 'DESC' },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!transfer) {
+        throw new BadRequestException('No pending transfer found for this unit');
+      }
+
+      // Must be destination org
+      if (transfer.destinationOrgId !== (user as any)?.organizationId && user?.role !== 'admin') {
+        throw new BadRequestException('Only the destination organization can accept the transfer');
+      }
+
+      previousOrgId = unit.organizationId;
+      unit.organizationId = transfer.destinationOrgId;
+      unit.status = BloodStatus.AVAILABLE;
+      await queryRunner.manager.save(unit);
+
+      transfer.status = TransferStatus.ACCEPTED;
+      transfer.acceptedByUserId = user?.id || null;
+      transfer.acceptedAt = new Date();
+      await queryRunner.manager.save(transfer);
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
     }
-
-    const transfer = await this.transferRepository.findOne({
-      where: {
-        bloodUnitId: unitId,
-        status: TransferStatus.PENDING,
-      },
-      order: { createdAt: 'DESC' },
-    });
-
-    if (!transfer) {
-      throw new BadRequestException('No pending transfer found for this unit');
-    }
-
-    // Must be destination org
-    if (transfer.destinationOrgId !== (user as any)?.organizationId && user?.role !== 'admin') {
-      throw new BadRequestException('Only the destination organization can accept the transfer');
-    }
-
-    const previousOrgId = unit.organizationId;
-    unit.organizationId = transfer.destinationOrgId;
-    unit.status = BloodStatus.AVAILABLE;
-    await this.inventoryRepository.save(unit);
-
-    transfer.status = TransferStatus.ACCEPTED;
-    transfer.acceptedByUserId = user?.id || null;
-    transfer.acceptedAt = new Date();
-    await this.transferRepository.save(transfer);
 
     // Update Soroban - publish custody transfer to blockchain
     try {


### PR DESCRIPTION
## Summary
- **#1170** — `BloodStatusService.updateStatus`/`reserveUnit` now assert `unit.organizationId === user.organizationId` (unless `role === 'admin'`) before mutating, closing the IDOR where any staff user with `UPDATE_BLOOD_STATUS` could discard/reserve another org's units. `bulkUpdateStatus` inherits the check since it delegates to `updateStatus` per unit.
- **#1171** — `initiateOrganizationTransfer` and `acceptOrganizationTransfer` in `BloodUnitsService` now run inside a single DB transaction (`QueryRunner`) with `pessimistic_write` row locks on the unit (and transfer record, for accept) before the status check and write, closing the TOCTOU race that allowed duplicate/interleaved transfers.
- **#1172** — `OrderSplittingController` routes were guarded only by `JwtAuthGuard`; added `@RequirePermissions` (`CREATE_ORDER` for split creation, `VIEW_ORDER` for reads, `UPDATE_ORDER` for leg status/fail mutations) so `PermissionsGuard` (already global) actually enforces role-based access.
- **#1173** — Added an `ALLOWED_LEG_TRANSITIONS` state machine in `OrderSplittingService` (mirroring `BloodStatusService.ALLOWED_TRANSITIONS`) and validate it in `updateLegStatus` before persisting. Replaced the inline, unvalidated request-body type on `PATCH legs/:legId/status` with `UpdateLegStatusDto` (`@IsEnum(FulfillmentLegStatus)`), enforced by the app's global `ValidationPipe`.

Closes #1170 
 closes #1171 
 closes #1172 
 closes #1173 

## Test plan
Per request, test suites were intentionally not added/run for this change — existing spec files for the touched services (`blood-status.service.spec.ts`, `blood-units.service.spec.ts`) were not updated and may need constructor/mock adjustments (e.g. new `DataSource`/`QueryRunner` dependency in `BloodUnitsService`) before they'll pass.

