### PR TITLE
fix(reputation): reject future-dated caller-supplied timestamps

### DIFF
--- a/lifebank-soroban/contracts/reputation/src/lib.rs
+++ b/lifebank-soroban/contracts/reputation/src/lib.rs
@@ -290,6 +290,20 @@ impl ReputationContract {
         Ok(())
     }
 
+    /// Reject caller-supplied timestamps that lie in the future relative to
+    /// the current ledger time. Rating/assignment/fraud timestamps feed
+    /// directly into recency weighting (`weighted_rating_score`) and
+    /// inactivity decay (`decay_penalty`) — an unbounded future timestamp
+    /// lets a caller force maximum recency weight and permanently defeat
+    /// decay, so it must be validated against ledger time rather than
+    /// trusted as-is.
+    fn require_valid_timestamp(env: &Env, timestamp: u64) -> Result<(), Error> {
+        if timestamp > env.ledger().timestamp() {
+            return Err(Error::InvalidInput);
+        }
+        Ok(())
+    }
+
     /// Backward-compatible initializer wrapper.
     pub fn init(env: Env, admin: Address) {
         Self::initialize(env, admin).unwrap();
@@ -346,6 +360,7 @@ impl ReputationContract {
         timestamp: u64,
     ) -> Result<ReputationScore, Error> {
         Self::require_not_paused(&env)?;
+        Self::require_valid_timestamp(&env, timestamp)?;
         if !(1..=5).contains(&score) {
             return Err(Error::InvalidRating);
         }
@@ -398,6 +413,7 @@ impl ReputationContract {
         timestamp: u64,
     ) -> Result<ReputationScore, Error> {
         Self::require_not_paused(&env)?;
+        Self::require_valid_timestamp(&env, timestamp)?;
         let mut input: ReputationInput = env
             .storage()
             .persistent()
@@ -431,6 +447,7 @@ impl ReputationContract {
     /// Flag an entity for fraud and recalculate score.
     pub fn flag_fraud(env: Env, entity_id: u64, timestamp: u64) -> Result<ReputationScore, Error> {
         Self::require_not_paused(&env)?;
+        Self::require_valid_timestamp(&env, timestamp)?;
         let mut input: ReputationInput = env
             .storage()
             .persistent()

--- a/lifebank-soroban/contracts/reputation/src/test.rs
+++ b/lifebank-soroban/contracts/reputation/src/test.rs
@@ -659,6 +659,7 @@ fn test_apply_penalty_requires_admin() {
     let _not_admin = Address::generate(&env);
 
     c.init(&admin);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
 
     // Seed entity
     c.submit_rating(&ENTITY, &5, &1000);
@@ -677,6 +678,7 @@ fn test_penalty_system_impacts_score() {
     c.init(&admin);
 
     env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     c.submit_rating(&ENTITY, &5, &1000);
     let score_before = c.get_score(&ENTITY).unwrap().score;
 
@@ -742,6 +744,7 @@ fn test_appeals_system() {
     c.init(&admin);
 
     env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     c.submit_rating(&ENTITY, &5, &1000);
 
     c.apply_penalty(&ENTITY, &ViolationType::Medium);
@@ -768,6 +771,7 @@ fn test_resolve_penalty_marks_as_resolved() {
     c.init(&admin);
 
     env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     c.submit_rating(&ENTITY, &5, &1000);
 
     c.apply_penalty(&ENTITY, &ViolationType::Minor);
@@ -806,6 +810,7 @@ fn test_reputation_pause_allows_get_score() {
     c.initialize(&admin);
 
     // Submit a rating before pausing
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     c.submit_rating(&ENTITY, &4i64, &1000u64);
     c.pause(&admin);
 
@@ -826,6 +831,7 @@ fn test_reputation_unpause_restores_writes() {
     assert!(!c.is_paused());
 
     // Should succeed after unpause
+    env.ledger().with_mut(|l| l.timestamp = 2000);
     c.submit_rating(&ENTITY, &5i64, &2000u64);
 }
 
@@ -839,4 +845,48 @@ fn test_reputation_non_admin_cannot_pause() {
 
     let attacker = Address::generate(&env);
     c.pause(&attacker);
+}
+
+// ── Timestamp validation ────────────────────────────────────────────────────────
+
+#[test]
+fn test_submit_rating_rejects_future_timestamp() {
+    let (env, cid) = setup();
+    let c = client(&env, &cid);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let result = c.try_submit_rating(&ENTITY, &5i64, &(1000 + 365 * DAY));
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_record_assignment_rejects_future_timestamp() {
+    let (env, cid) = setup();
+    let c = client(&env, &cid);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let result = c.try_record_assignment(&ENTITY, &true, &300u64, &(1000 + 365 * DAY));
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_flag_fraud_rejects_future_timestamp() {
+    let (env, cid) = setup();
+    let c = client(&env, &cid);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    // Seed entity so the timestamp check (not EntityNotFound) is what's exercised.
+    c.record_assignment(&ENTITY, &true, &300u64, &1000u64);
+
+    let result = c.try_flag_fraud(&ENTITY, &(1000 + 365 * DAY));
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_submit_rating_accepts_current_ledger_timestamp() {
+    let (env, cid) = setup();
+    let c = client(&env, &cid);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let result = c.try_submit_rating(&ENTITY, &5i64, &1000u64);
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
## Summary
submit_rating, record_assignment, and flag_fraud in the reputation contract now reject caller-supplied timestamps that lie in the future relative to ledger time, closing a way to permanently manipulate recency weighting and inactivity decay.

## Context / before-after
- Before: These functions took a raw timestamp: u64 argument and stored it directly (RatingEvent.timestamp, last_active_at) with no bounds check against env.ledger().timestamp(). weighted_rating_score and decay_penalty key their weighting purely off this attacker-controlled value - a far-future timestamp made age = now.saturating_sub(r.timestamp) evaluate to 0, guaranteeing max recency weight (2x) forever, and setting last_active_at far in the future permanently defeated the inactivity-decay penalty.
- After: Added require_valid_timestamp(env, timestamp), which rejects (Error::InvalidInput) any timestamp greater than current ledger time. Wired into submit_rating, record_assignment, and flag_fraud; update_from_event inherits the check since it delegates to those two.

## Testing
cargo test -p reputation-contract - 54 passed, 0 failed. Fixed 6 existing tests that called these functions with a literal timestamp without advancing the mock ledger to match (they now set env.ledger().with_mut(...) first, matching realistic usage). Added 4 new tests: future-timestamp rejection for submit_rating, record_assignment, and flag_fraud, plus one confirming a timestamp equal to current ledger time is still accepted.

Closes #1128