### PR TITLE
fix: correct cross-contract auth check in release_reservation_by_contract

### DIFF
--- a/lifebank-soroban/contracts/inventory/src/lib.rs
+++ b/lifebank-soroban/contracts/inventory/src/lib.rs
@@ -808,12 +808,12 @@ impl InventoryContract {
     /// - Requests contract's admin authenticates the cancellation decision (via cancel_request
     ///   or update_request_status requiring caller.require_auth())
     /// - Requests contract invokes this function with its own address as `authorized_contract`
-    /// - Inventory verifies that the caller IS that contract, trusting it as a valid intermediary
+    /// - Inventory calls `authorized_contract.require_auth()` to verify the caller identity
     /// - This avoids requiring the requests contract's admin to re-sign at the inventory level
     ///
     /// # Arguments
     /// * `authorized_contract` - The address of the contract making the release decision
-    ///   (typically the requests contract). Must equal current_contract_address().
+    ///   (typically the requests contract).
     /// * `reservation_id` - ID of the reservation to release
     ///
     /// # Errors
@@ -827,15 +827,12 @@ impl InventoryContract {
     ) -> Result<(), ContractError> {
         Self::require_not_paused(&env)?;
 
-        // Verify that the caller is the contract we expect (requests contract).
-        // This establishes the cross-contract authorization chain:
-        // hospital/admin calls requests::cancel_request/update_request_status with require_auth()
-        // -> requests contract calls inventory::release_reservation_by_contract(requests_addr)
-        // -> we verify that env.current_contract_address() == authorized_contract
-        // The requests contract is trusted to make release decisions after its own authorization checks.
-        if &env.current_contract_address() != authorized_contract {
-            return Err(ContractError::Unauthorized);
-        }
+        // Verify that the caller is the expected contract using Soroban's
+        // standard cross-contract auth pattern. The requests contract passes
+        // its own address as `authorized_contract`; require_auth() on that
+        // address proves that the authenticated caller is indeed the requests
+        // contract (not a random contract or user).
+        authorized_contract.require_auth();
 
         let reservation = storage::get_reservation(&env, reservation_id)
             .ok_or(ContractError::ReservationNotFound)?;
@@ -892,7 +889,6 @@ impl InventoryContract {
         reservation: &Reservation,
         reservation_id: u64,
     ) -> Result<(), ContractError> {
-
         let registry_id: Option<Address> =
             env.storage().instance().get(&DataKey::RegistryContractId);
 

--- a/lifebank-soroban/contracts/inventory/src/test.rs
+++ b/lifebank-soroban/contracts/inventory/src/test.rs
@@ -2295,3 +2295,52 @@ fn test_reserve_blood_fails_on_mixed_ownership() {
     // Bank1 tries to reserve both units (but only owns one)
     client.reserve_blood(&bank1, &vec![&env, id1, id2], &123, &3600);
 }
+
+#[test]
+fn test_release_reservation_by_contract_releases_reservation() {
+    let (env, admin, client, _) = create_test_contract();
+    env.ledger().set_timestamp(1000u64);
+
+    let bank = admin.clone();
+    let hospital = Address::generate(&env);
+
+    // Register a blood unit
+    let unit_id = client.register_blood(
+        &bank,
+        &String::from_str(&env, "SN-REL-001"),
+        &BloodType::APositive,
+        &450u32,
+        &None,
+    );
+
+    // Reserve it
+    let reservation_id = client.reserve_blood(&bank, &vec![&env, unit_id], &42, &3600);
+
+    // Verify unit is Reserved
+    let stored = client.get_blood_unit(&unit_id);
+    assert_eq!(stored.status, BloodStatus::Reserved);
+
+    // Release via release_reservation_by_contract with the authorized contract
+    let authorized_addr = Address::generate(&env);
+    InventoryContract::release_reservation_by_contract(&env, &authorized_addr, reservation_id)
+        .unwrap();
+
+    // Verify unit is Available again
+    let released = client.get_blood_unit(&unit_id);
+    assert_eq!(released.status, BloodStatus::Available);
+
+    // Reservation should be removed
+    let result = client.get_reservation(&reservation_id);
+    assert_eq!(result, Err(ContractError::ReservationNotFound));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #150)")]
+fn test_release_reservation_by_contract_fails_on_unknown_reservation() {
+    let (env, admin, client, _) = create_test_contract();
+    env.ledger().set_timestamp(1000u64);
+
+    // Try to release a non-existent reservation
+    InventoryContract::release_reservation_by_contract(&env, &Address::generate(&env), 999)
+        .unwrap();
+}


### PR DESCRIPTION
﻿## Overview

The `release_reservation_by_contract` function in the inventory contract used `env.current_contract_address()` to verify the caller's identity. This always returns the **inventory contract's own address**, not the calling contract's address — so whenever the requests contract invoked this function, the comparison `env.current_contract_address() != authorized_contract` evaluated to `true`, and the function always returned `Unauthorized`. The cross-contract inventory-sync feature was therefore permanently broken (dead code).

## Root Cause

`env.current_contract_address()` returns the address of the contract currently executing — in this case, the inventory contract itself. Comparing it against `authorized_contract` (which is the requests contract's address, passed as a parameter) is logically incorrect: two different contracts will never have the same address.

The issue description references `inventory_reserve_unit` and `inventory_release_unit` in the legacy `contracts/src/lib.rs`, which no longer exist in the current codebase. The same bug pattern was present in `release_reservation_by_contract` in the active inventory contract (`lifebank-soroban/contracts/inventory/src/lib.rs`).

## Fix

Replaced the broken `env.current_contract_address()` comparison with `authorized_contract.require_auth()` — the standard Soroban pattern for cross-contract caller verification. When the requests contract (or any trusted contract) calls this function, Soroban's auth framework validates that the calling contract is indeed `authorized_contract`.

## Changes

### `lifebank-soroban/contracts/inventory/src/lib.rs`
- **`release_reservation_by_contract`**: Changed auth check from `if &env.current_contract_address() != authorized_contract { return Err(Unauthorized); }` to `authorized_contract.require_auth();`
- Updated doc comments and inline comments to reflect the correct pattern.

### `lifebank-soroban/contracts/inventory/src/test.rs`
- **Added** `test_release_reservation_by_contract_releases_reservation` — full lifecycle test: register a blood unit, reserve it, then release via `release_reservation_by_contract`.
- **Added** `test_release_reservation_by_contract_fails_on_unknown_reservation` — verifies `ReservationNotFound` (error #150) for invalid reservation IDs.

## Verification

`cargo test --package inventory-contract --lib` could not run in this environment (no Windows linker available). The changes are syntactically validated via `rustfmt`. All existing tests use `env.mock_all_auths()` which satisfies `require_auth()` — the new tests follow the same pattern used by every test in the repo.

Closes #1109
