### PR TITLE
fix: security/correctness fixes for #1242 #1247 #1248 #1249

### DIFF
--- a/contracts/fuzz/Cargo.toml
+++ b/contracts/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.3", features = ["derive"] }
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { version = "27.0.2", features = ["testutils"] }
 
 [dependencies.health_chain_contract]
 path = ".."

--- a/lifebank-soroban/contracts/identity/src/lib.rs
+++ b/lifebank-soroban/contracts/identity/src/lib.rs
@@ -1081,6 +1081,9 @@ impl AccessControlContract {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
+        // Require the supplied admin address to sign this transaction so that
+        // an attacker cannot front-run initialization and claim admin rights.
+        admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage()
             .persistent()

--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -145,6 +145,8 @@ pub enum Error {
     /// Escrow payments must be settled via release_escrow/refund_escrow.
     /// update_status cannot move funds and would corrupt accounting invariants.
     EscrowSettlementRequired = 520,
+    /// Payment is not in a disputable state (must be Pending or Locked).
+    InvalidStatus = 521,
 }
 
 // ── Storage keys ───────────────────────────────────────────────────────────────
@@ -1100,6 +1102,13 @@ impl PaymentContract {
         let mut payment = load_payment(&env, payment_id).ok_or(Error::PaymentNotFound)?;
         if caller != payment.payer && caller != payment.payee {
             return Err(Error::Unauthorized);
+        }
+        // Only Pending or Locked payments may be disputed.  Raising a dispute
+        // on an already-Released or Refunded payment has no token backing and
+        // would silently corrupt aggregate statistics.
+        match payment.status {
+            PaymentStatus::Pending | PaymentStatus::Locked => {}
+            _ => return Err(Error::InvalidStatus),
         }
         let old_status = payment.status;
         payment.status = PaymentStatus::Disputed;

--- a/lifebank-soroban/contracts/temperature/src/lib.rs
+++ b/lifebank-soroban/contracts/temperature/src/lib.rs
@@ -110,6 +110,14 @@ impl TemperatureContract {
         max_celsius_x100: i32,
     ) -> Result<(), ContractError> {
         admin.require_auth();
+        // Verify the caller is the stored admin, not just that they signed
+        // their own address.  Without this check any address can pass itself
+        // as `admin`, satisfy require_auth(), and propose arbitrary threshold
+        // changes — identical to the pattern used by pause(), unpause(), etc.
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(ContractError::Unauthorized);
+        }
         if min_celsius_x100 >= max_celsius_x100 {
             return Err(ContractError::InvalidThreshold);
         }


### PR DESCRIPTION
## Summary

This PR fixes four independent security and correctness issues across two sub-projects.

---

### #1249 — payments: add status-transition guard to `record_dispute()`

**File:** `lifebank-soroban/contracts/payments/src/lib.rs`

`record_dispute()` never checked `payment.status` before transitioning to `Disputed`. Calling it on an already-`Released` or `Refunded` payment had no token backing but still called `update_stats_on_transition()`, silently decrementing `total_released` and corrupting all aggregate statistics permanently.

**Fix:** Added a `match` guard that returns `Error::InvalidStatus (521)` when the payment is not `Pending` or `Locked`. Also adds `InvalidStatus = 521` to the `Error` enum.

closes #1249

---

### #1248 — identity: add `admin.require_auth()` to `ac_initialize()`

**File:** `lifebank-soroban/contracts/identity/src/lib.rs`

`ac_initialize()` stored the caller-supplied admin address without verifying the caller actually controls that address. An attacker could front-run the legitimate deployer's initialization transaction and claim permanent admin rights over the entire role/permission-scope subsystem (`grant_role_with_expiry`, `revoke_role`, `grant_scope`, `revoke_scope`).

**Fix:** Added `admin.require_auth()` before persisting the admin address, matching the pattern already used by `initialize()`.

closes #1248

---

### #1247 — temperature: enforce stored-admin check in `propose_threshold_change()`

**File:** `lifebank-soroban/contracts/temperature/src/lib.rs`

`propose_threshold_change()` called `admin.require_auth()` but never compared the supplied address against `storage::get_admin(&env)`. Any address could pass itself as `admin`, satisfy `require_auth()` on itself, and permanently corrupt a blood unit's cold-chain safety thresholds. Since `apply_threshold_change` is callable by anyone after the 7-day timelock, no actual admin involvement was required.

**Fix:** Added the same `if admin != stored_admin { return Err(ContractError::Unauthorized); }` guard used by `pause()`, `unpause()`, `set_threshold()`, and all other admin-gated functions in this contract.

closes #1247

---

### #1242 — fuzz: align soroban-sdk version (22.0.0 → 27.0.2)

**File:** `contracts/fuzz/Cargo.toml`

The fuzz crate pinned `soroban-sdk = "22.0.0"` while its path-dependency on the `healthchain` contract crate pulled in `27.0.2` transitively. Both versions coexisted in `fuzz/Cargo.lock`, causing type incompatibilities between `Env`, `Address`, and `testutils` types — making the entire fuzz crate unbuildable.

**Fix:** Updated the explicit dependency to `27.0.2` to match `contracts/Cargo.toml`.

closes #1242

---

## Testing

- All changes follow the exact patterns used elsewhere in their respective contracts.
- Fixes are minimal and targeted — no behaviour changed for valid inputs.