### PR TITLE
fix(escrow): wire token transfers into resolve_dispute for escrow-backed payments (#1113)

### DIFF
--- a/lifebank-soroban/contracts/payments/src/lib.rs
+++ b/lifebank-soroban/contracts/payments/src/lib.rs
@@ -50,6 +50,15 @@ pub struct Payment {
     pub token: Option<Address>,
 }
 
+/// Direction for dispute resolution — determines whether escrowed funds
+/// are released to the payee or refunded to the payer.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DisputeResolution {
+    ReleaseToPayee,
+    RefundToPayer,
+}
+
 fn dispute_reason_to_code(reason: DisputeReason) -> u32 {
     match reason {
         DisputeReason::FailedDelivery => 1,
@@ -130,6 +139,8 @@ pub enum Error {
     ActiveVestingExists = 517,
     /// The associated request is not in a state that permits payment.
     RequestNotPayable = 512,
+    /// Payment is not in Disputed status — cannot resolve.
+    PaymentNotDisputed = 521,
     /// The request referenced by this payment does not exist.
     RequestNotFound = 513,
     /// Payment has no escrowed token — cannot release or refund funds.
@@ -1120,17 +1131,87 @@ impl PaymentContract {
         Ok(())
     }
 
-    pub fn resolve_dispute(env: Env, payment_id: u64, caller: Address) -> Result<(), Error> {
+    /// Resolve a disputed payment: either release funds to the payee or refund
+    /// them to the payer, depending on `resolution`. For escrow-backed payments
+    /// the actual token transfer is executed atomically within this call.
+    /// For bookkeeping-only (non-escrow) payments the status is updated without
+    /// any token transfer — off-chain settlement is assumed.
+    pub fn resolve_dispute(
+        env: Env,
+        payment_id: u64,
+        resolution: DisputeResolution,
+        caller: Address,
+    ) -> Result<(), Error> {
         caller.require_auth();
         Self::require_not_paused(&env)?;
         Self::require_admin(&env, &caller)?;
+
         let mut payment = load_payment(&env, payment_id).ok_or(Error::PaymentNotFound)?;
-        if payment.dispute_case_id.is_some() {
-            payment.dispute_resolved = true;
+
+        if payment.status != PaymentStatus::Disputed {
+            return Err(Error::PaymentNotDisputed);
         }
+
+        // ── Escrow: execute the token transfer ────────────────────────────
+        if let Some(ref token_addr) = payment.token {
+            let token_client = token::Client::new(&env, token_addr);
+            match resolution {
+                DisputeResolution::ReleaseToPayee => {
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &payment.payee,
+                        &payment.amount,
+                    );
+                }
+                DisputeResolution::RefundToPayer => {
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &payment.payer,
+                        &payment.amount,
+                    );
+                }
+            }
+        }
+
+        // ── Update payment state ──────────────────────────────────────────
+        let old_status = payment.status;
+        let new_status = match resolution {
+            DisputeResolution::ReleaseToPayee => PaymentStatus::Released,
+            DisputeResolution::RefundToPayer => PaymentStatus::Refunded,
+        };
+
+        payment.status = new_status;
+        payment.dispute_resolved = true;
         payment.updated_at = env.ledger().timestamp();
         store_payment(&env, &payment);
+
+        remove_from_status_index(&env, old_status, payment_id);
+        index_by_status(&env, new_status, payment_id);
+        update_stats_on_transition(&env, payment.amount, old_status, new_status)?;
+        remove_from_request_index(&env, payment.request_id);
+
+        // ── Emit events ───────────────────────────────────────────────────
         PaymentResolved { payment_id }.publish(&env);
+
+        match resolution {
+            DisputeResolution::ReleaseToPayee => {
+                PaymentReleased {
+                    payment_id,
+                    payee: payment.payee.clone(),
+                    amount: payment.amount,
+                }
+                .publish(&env);
+            }
+            DisputeResolution::RefundToPayer => {
+                PaymentRefunded {
+                    payment_id,
+                    payer: payment.payer.clone(),
+                    amount: payment.amount,
+                }
+                .publish(&env);
+            }
+        }
+
         Ok(())
     }
 

--- a/lifebank-soroban/contracts/payments/src/test.rs
+++ b/lifebank-soroban/contracts/payments/src/test.rs
@@ -1010,6 +1010,109 @@ fn test_process_expired_disputes_skips_non_disputed_payments() {
     assert_eq!(refunded.len(), 0);
 }
 
+// ── resolve_dispute escrow settlement (#1113) ─────────────────────────────────
+
+#[test]
+fn test_resolve_dispute_releases_escrow_to_payee() {
+    let (env, cid, admin) = setup_with_admin();
+    let client = PaymentContractClient::new(&env, &cid);
+
+    let hospital = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let token_id = deploy_token_with_balance(&env, &admin, &hospital, 10_000);
+
+    // Create escrow payment: hospital deposits 1_000 tokens
+    let pid = client.create_escrow(&1u64, &hospital, &payee, &1_000i128, &token_id);
+
+    // Verify tokens moved from hospital to contract
+    let token_client = soroban_sdk::token::Client::new(&env, &token_id);
+    let contract_bal = token_client.balance(&cid);
+    assert_eq!(contract_bal, 1_000);
+    let payer_bal = token_client.balance(&hospital);
+    assert_eq!(payer_bal, 9_000); // started with 10_000
+
+    // Record a dispute
+    client.record_dispute(
+        &pid,
+        &DisputeReason::FailedDelivery,
+        &soroban_sdk::String::from_str(&env, "case-release"),
+        &hospital,
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Disputed);
+
+    // Resolve dispute in favor of payee -> release funds
+    client.resolve_dispute(&pid, &DisputeResolution::ReleaseToPayee, &admin);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Released);
+    assert!(p.dispute_resolved);
+
+    // Verify tokens transferred to payee
+    let payee_bal = token_client.balance(&payee);
+    assert_eq!(payee_bal, 1_000);
+    // Contract balance should be 0 after release
+    let contract_bal_after = token_client.balance(&cid);
+    assert_eq!(contract_bal_after, 0);
+}
+
+#[test]
+fn test_resolve_dispute_refunds_escrow_to_payer() {
+    let (env, cid, admin) = setup_with_admin();
+    let client = PaymentContractClient::new(&env, &cid);
+
+    let hospital = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let token_id = deploy_token_with_balance(&env, &admin, &hospital, 10_000);
+
+    // Create escrow payment: hospital deposits 1_000 tokens
+    let pid = client.create_escrow(&2u64, &hospital, &payee, &1_000i128, &token_id);
+
+    // Record a dispute
+    client.record_dispute(
+        &pid,
+        &DisputeReason::DamagedGoods,
+        &soroban_sdk::String::from_str(&env, "case-refund"),
+        &payee,
+    );
+
+    // Resolve dispute in favor of payer -> refund funds
+    client.resolve_dispute(&pid, &DisputeResolution::RefundToPayer, &admin);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert!(p.dispute_resolved);
+
+    // Verify tokens refunded to payer
+    let token_client = soroban_sdk::token::Client::new(&env, &token_id);
+    let payer_bal = token_client.balance(&hospital);
+    assert_eq!(payer_bal, 10_000); // full amount refunded
+    let contract_bal = token_client.balance(&cid);
+    assert_eq!(contract_bal, 0);
+}
+
+#[test]
+fn test_resolve_dispute_rejects_non_disputed_payment() {
+    let (env, cid, admin) = setup_with_admin();
+    let client = PaymentContractClient::new(&env, &cid);
+
+    let hospital = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let token_id = deploy_token_with_balance(&env, &admin, &hospital, 10_000);
+
+    // Create escrow payment (Locked, not Disputed)
+    let pid = client.create_escrow(&3u64, &hospital, &payee, &500i128, &token_id);
+
+    // Try to resolve a non-disputed payment -> must fail
+    let result = client.try_resolve_dispute(&pid, &DisputeResolution::ReleaseToPayee, &admin);
+    assert_eq!(result, Err(Ok(Error::PaymentNotDisputed)));
+
+    // Payment should still be Locked
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Locked);
+}
+
 /// VestingCreated and VestingClaimed events are emitted.
 #[test]
 fn test_vesting_events_emitted() {

--- a/lifebank-soroban/contracts/payments/src/test_security_fixes.rs
+++ b/lifebank-soroban/contracts/payments/src/test_security_fixes.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod security_tests {
-    use crate::{Error, PaymentStatus, PaymentContract};
+    use crate::{Error, PaymentStatus, PaymentContract, DisputeResolution};
     use soroban_sdk::{testutils::Address as _, Address, Env};
 
     /// #1152: Verify record_dispute requires caller to be payer or payee.
@@ -12,7 +12,6 @@ mod security_tests {
         let payer = Address::random(&env);
         let payee = Address::random(&env);
         let third_party = Address::random(&env);
-        let token = Address::random(&env);
 
         env.mock_all_auths();
 
@@ -20,11 +19,10 @@ mod security_tests {
 
         let payment_id = PaymentContract::create_payment(
             env.clone(),
+            1,
             payer.clone(),
             payee.clone(),
             100,
-            1,
-            None,
         )
         .unwrap();
 
@@ -53,11 +51,10 @@ mod security_tests {
 
         let payment_id = PaymentContract::create_payment(
             env.clone(),
+            1,
             payer.clone(),
             payee.clone(),
             100,
-            1,
-            None,
         )
         .unwrap();
 
@@ -86,11 +83,10 @@ mod security_tests {
 
         let payment_id = PaymentContract::create_payment(
             env.clone(),
+            1,
             payer.clone(),
             payee.clone(),
             100,
-            1,
-            None,
         )
         .unwrap();
 


### PR DESCRIPTION
## Overview

This PR fixes issue #1113 by wiring real token transfers into the \esolve_dispute\ function. Previously, \esolve_dispute\ only updated in-memory bookkeeping structs without ever calling \	oken::Client::transfer\, so escrowed funds remained permanently locked in the contract after dispute resolution with no economic enforcement.

## Related Issue

Closes #1113

## Changes

### Token Transfer Integration

- **[ADD]** \DisputeResolution\ enum (\ReleaseToPayee\ / \RefundToPayer\) — determines whether escrowed funds are released to the payee or refunded to the payer upon dispute resolution.
- **[ADD]** \PaymentNotDisputed\ error variant (code 521) — guards against calling \esolve_dispute\ on non-disputed payments, providing a clear error instead of silent no-ops.
- **[FIX]** \esolve_dispute\ — now executes the actual SAC token transfer for escrow-backed payments atomically within the call, updates payment status to \Released\/\Refunded\, maintains status indices and running stats, removes the request index for terminal states, and emits appropriate events (\PaymentResolved\ + \PaymentReleased\/\PaymentRefunded\).
- **[ADD]** 3 integration tests covering: release-to-payee with token balance verification, refund-to-payer with token balance verification, and rejection of non-disputed payments.

### Consistency

The fix follows the same \	oken::Client::transfer\ pattern already proven in \elease_escrow\, \efund_escrow\, \process_expired_disputes\, and \claim_vested\ — all of which correctly move tokens.