### PR TITLE
fix: batch size cap, toast context, analytics amount validation, delivery compliance enforcement

### DIFF
--- a/frontend/health-chain/components/providers/ToastProvider.tsx
+++ b/frontend/health-chain/components/providers/ToastProvider.tsx
@@ -8,19 +8,20 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Toast } from '../ui/Toast';
-import { useToast } from '../../lib/hooks/useToast';
+import { ToastContext, useToastState } from '../../lib/hooks/useToast';
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const { toasts, hideToast, error } = useToast();
+  const toastState = useToastState();
+  const { toasts, hideToast, error } = toastState;
   const searchParams = useSearchParams();
 
   useEffect(() => {
     // Check for session expiry reason in URL
     const reason = searchParams.get('reason');
-    
+
     if (reason === 'session_expired') {
       error('Your session has expired. Please sign in again.');
-      
+
       // Clean up URL
       if (typeof window !== 'undefined') {
         const url = new URL(window.location.href);
@@ -31,7 +32,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   }, [searchParams, error]);
 
   return (
-    <>
+    <ToastContext.Provider value={toastState}>
       {children}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
         {toasts.map((toast) => (
@@ -43,6 +44,6 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           />
         ))}
       </div>
-    </>
+    </ToastContext.Provider>
   );
 }

--- a/frontend/health-chain/lib/hooks/useToast.ts
+++ b/frontend/health-chain/lib/hooks/useToast.ts
@@ -1,8 +1,8 @@
 /**
- * Custom hook for managing toast notifications
+ * Shared toast context — single queue written by all callers, rendered once by ToastProvider.
  */
 
-import { useState, useCallback } from 'react';
+import { createContext, useCallback, useContext, useState } from 'react';
 import type { ToastType } from '../../components/ui/Toast';
 
 interface ToastState {
@@ -11,7 +11,20 @@ interface ToastState {
   id: number;
 }
 
-export function useToast() {
+export interface ToastContextValue {
+  toasts: ToastState[];
+  showToast: (message: string, type?: ToastType) => void;
+  hideToast: (id: number) => void;
+  success: (message: string) => void;
+  error: (message: string) => void;
+  warning: (message: string) => void;
+  info: (message: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+/** Called once by ToastProvider to own the shared toast state. */
+export function useToastState(): ToastContextValue {
   const [toasts, setToasts] = useState<ToastState[]>([]);
 
   const showToast = useCallback((message: string, type: ToastType = 'info') => {
@@ -23,13 +36,17 @@ export function useToast() {
     setToasts((prev) => prev.filter((toast) => toast.id !== id));
   }, []);
 
-  return {
-    toasts,
-    showToast,
-    hideToast,
-    success: (message: string) => showToast(message, 'success'),
-    error: (message: string) => showToast(message, 'error'),
-    warning: (message: string) => showToast(message, 'warning'),
-    info: (message: string) => showToast(message, 'info'),
-  };
+  const success = useCallback((message: string) => showToast(message, 'success'), [showToast]);
+  const error = useCallback((message: string) => showToast(message, 'error'), [showToast]);
+  const warning = useCallback((message: string) => showToast(message, 'warning'), [showToast]);
+  const info = useCallback((message: string) => showToast(message, 'info'), [showToast]);
+
+  return { toasts, showToast, hideToast, success, error, warning, info };
+}
+
+/** Consume the shared toast queue. Must be called within a ToastProvider. */
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within a ToastProvider');
+  return ctx;
 }

--- a/lifebank-soroban/contracts/analytics/src/error.rs
+++ b/lifebank-soroban/contracts/analytics/src/error.rs
@@ -10,4 +10,5 @@ pub enum AnalyticsError {
     InvalidPeriod = 903,
     PeriodNotFound = 904,
     MetricNotFound = 905,
+    InvalidAmount = 906,
 }

--- a/lifebank-soroban/contracts/analytics/src/lib.rs
+++ b/lifebank-soroban/contracts/analytics/src/lib.rs
@@ -231,11 +231,15 @@ impl AnalyticsContract {
 
     /// Record a released payment with its amount. Authorized callers only (admin or domain contracts).
     pub fn record_payment_released(env: Env, amount: i128) -> Result<(), AnalyticsError> {
+        if amount <= 0 {
+            return Err(AnalyticsError::InvalidAmount);
+        }
+
         let cfg = require_authorized_caller(&env)?;
         let idx = current_period_index(&env, cfg.reporting_period.duration_secs);
         let mut snap = load_snapshot(&env, idx);
         snap.total_payments_released += 1;
-        snap.total_volume += amount;
+        snap.total_volume = snap.total_volume.saturating_add(amount);
         snap.last_updated = env.ledger().timestamp();
         save_snapshot(&env, &snap);
 
@@ -244,7 +248,7 @@ impl AnalyticsContract {
             .persistent()
             .set(&DataKey::TotalPaymentsReleased, &total_payments);
 
-        let total_volume = get_counter_i128(&env, &DataKey::TotalVolume) + amount;
+        let total_volume = get_counter_i128(&env, &DataKey::TotalVolume).saturating_add(amount);
         env.storage()
             .persistent()
             .set(&DataKey::TotalVolume, &total_volume);

--- a/lifebank-soroban/contracts/delivery/src/lib.rs
+++ b/lifebank-soroban/contracts/delivery/src/lib.rs
@@ -29,6 +29,7 @@ pub enum Error {
     AlreadyInitialized = 700,
     NotInitialized = 701,
     DeliveryNotFound = 702,
+    Unauthorized = 703,
 }
 
 #[contracttype]
@@ -145,8 +146,56 @@ impl DeliveryContract {
             .ok_or(Error::NotInitialized)
     }
 
-    /// Record a compliance attestation hash for a completed delivery.
-    /// The hash is produced off-chain by the backend after evaluating telemetry.
+    /// Update the cold-chain temperature thresholds. Admin only.
+    pub fn set_temperature_thresholds(
+        env: Env,
+        admin: Address,
+        thresholds: TemperatureThresholds,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::TemperatureThresholds, &thresholds);
+        Ok(())
+    }
+
+    /// Update the proof requirements. Admin only.
+    pub fn set_proof_requirements(
+        env: Env,
+        admin: Address,
+        requirements: ProofRequirements,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ProofRequirements, &requirements);
+        Ok(())
+    }
+
+    /// Record a compliance attestation for a completed delivery.
+    ///
+    /// This function implements an **oracle attestation pattern**: the backend
+    /// evaluates the delivery's telemetry (temperature readings, photo proof,
+    /// recipient signature, temperature log) against the configured
+    /// `TemperatureThresholds` and `ProofRequirements` off-chain, produces a
+    /// `compliance_hash` committing to that evaluation, and then calls this
+    /// function to record the result on-chain. Only the stored admin may attest.
     pub fn record_compliance_attestation(
         env: Env,
         admin: Address,
@@ -155,6 +204,14 @@ impl DeliveryContract {
         is_compliant: bool,
     ) -> Result<(), Error> {
         admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
         if !Self::is_initialized(env.clone()) {
             return Err(Error::NotInitialized);
         }

--- a/lifebank-soroban/contracts/matching/src/error.rs
+++ b/lifebank-soroban/contracts/matching/src/error.rs
@@ -19,4 +19,7 @@ pub enum MatchingError {
 
     // Circuit breaker (630)
     ContractPaused = 630,
+
+    // Batch limits (631)
+    BatchTooLarge = 631,
 }

--- a/lifebank-soroban/contracts/matching/src/lib.rs
+++ b/lifebank-soroban/contracts/matching/src/lib.rs
@@ -28,6 +28,11 @@ use soroban_sdk::{contract, contractclient, contractimpl, Address, Env, Vec};
 /// Threshold chosen to stay within per-transaction compute limits with safety margin.
 const MAX_MATCH_CANDIDATES: usize = 500;
 
+/// Maximum number of request IDs accepted by `match_multiple_requests`.
+/// Enforces an explicit, graceful error instead of letting the transaction hit
+/// the instruction limit with an opaque failure.
+const MAX_BATCH_SIZE: u32 = 50;
+
 // ---------------------------------------------------------------------------
 // Cross-contract client interfaces
 // ---------------------------------------------------------------------------
@@ -255,14 +260,19 @@ impl MatchingContract {
     /// Within the same urgency level, requests with an earlier
     /// `required_by_timestamp` are processed first.
     ///
-    /// Uses insertion sort — O(n log n) average for nearly-sorted inputs,
-    /// acceptable for the small batches expected in practice (≤50 requests).
+    /// Uses insertion sort — O(n²) worst-case but acceptable for batches up to
+    /// `MAX_BATCH_SIZE`. Callers that exceed `MAX_BATCH_SIZE` receive
+    /// `MatchingError::BatchTooLarge` rather than hitting the instruction limit.
     pub fn match_multiple_requests(
         env: Env,
         request_ids: Vec<u64>,
     ) -> Result<Vec<MatchResult>, MatchingError> {
         Self::require_initialized(&env)?;
         Self::require_not_paused(&env)?;
+
+        if request_ids.len() > MAX_BATCH_SIZE {
+            return Err(MatchingError::BatchTooLarge);
+        }
 
         let req_addr: Address = env
             .storage()


### PR DESCRIPTION
## Summary

- **#1250** `match_multiple_requests` — added `MAX_BATCH_SIZE = 50` constant and `BatchTooLarge` error; callers supplying oversized `request_ids` now receive an explicit error instead of silently hitting the transaction instruction limit.
- **#1253** `useToast` — replaced the per-component `useState` implementation with a `ToastContext` + `useToastState` pattern; `ToastProvider` owns the single queue and all callers (`SignInPage`, `BloodDonorSignup`, `useBlockchainTransaction`) now share the same instance so their toasts actually appear.
- **#1252** `record_payment_released` — added `amount > 0` guard returning `InvalidAmount` on violation; switched `snap.total_volume` and the `TotalVolume` lifetime counter to `saturating_add` to prevent panic or silent corruption from extreme values.
- **#1251** `record_compliance_attestation` — added `Unauthorized = 703` error; attestation now validates the caller is the stored admin (not just a self-authenticated arbitrary address); added `set_temperature_thresholds` and `set_proof_requirements` admin-only setters so the compliance config is adjustable post-initialization; doc comment updated to make the oracle attestation pattern explicit.

## Test plan

- [ ] `cargo build -p matching-contract` passes with new `BatchTooLarge` variant visible
- [ ] `cargo build -p analytics-contract` passes; calling `record_payment_released` with `amount ≤ 0` returns `InvalidAmount`
- [ ] `cargo build -p delivery-contract` passes; non-admin call to `record_compliance_attestation` returns `Unauthorized`; setters available for both config structs
- [ ] Frontend: toast messages in `SignInPage`, `BloodDonorSignup`, and blockchain transaction hooks now render in the UI (previously silent)

closes #1250
closes #1251
closes #1252
closes #1253