### PR TITLE
  fix: prevent double-use in coordinator rollback, fix reputation compile error, wire fee netting 

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -2640,6 +2640,12 @@ impl HealthChainContract {
             return Err(Error::InvalidFeePayload);
         }
 
+        // `amount` is the gross amount supplied by the payer; `payment.amount`
+        // is documented as the net amount after fees, so net it down here.
+        let net_amount = fee_payload
+            .calculate_net_amount(amount)
+            .map_err(|_| Error::InvalidFeePayload)?;
+
         let mut payments: Map<u64, Payment> = env
             .storage()
             .persistent()
@@ -2657,7 +2663,7 @@ impl HealthChainContract {
             request_id,
             payer,
             payee,
-            amount,
+            amount: net_amount,
             asset,
             fee_structure: fee_payload,
             status: PaymentStatus::Pending,

--- a/lifebank-soroban/contracts/coordinator/src/lib.rs
+++ b/lifebank-soroban/contracts/coordinator/src/lib.rs
@@ -684,6 +684,14 @@ impl CoordinatorContract {
             return Err(CoordinatorError::CannotRollbackSettled);
         }
 
+        // Once delivery has been confirmed, units are physically at the hospital.
+        // Releasing them back to Available here would let the same physical unit
+        // be re-allocated elsewhere while a copy is already delivered, and would
+        // improperly refund a payment for blood that was in fact delivered.
+        if wf.status == WorkflowStatus::Delivered {
+            return Err(CoordinatorError::InvalidWorkflowState);
+        }
+
         let inv_addr: Address = env
             .storage()
             .instance()

--- a/lifebank-soroban/contracts/coordinator/src/test.rs
+++ b/lifebank-soroban/contracts/coordinator/src/test.rs
@@ -954,7 +954,7 @@ fn test_emergency_halt_blocks_settle_operations() {
     assert!(h.coord.is_emergency_halted());
 
     let result = h.coord.try_settle_payment(&1u64, &h.admin);
-    assert_eq!(result, Err(Ok(CoordinatorError::EmergencyHalt)));
+    assert_eq!(result, Err(Ok(CoordinatorError::EmergencyHalted)));
 }
 
 /// Only admin can trigger emergency halt.
@@ -1015,9 +1015,11 @@ fn test_clear_emergency_halt_non_admin_fails() {
     assert!(h.coord.is_emergency_halted());
 }
 
-/// Rollback transitions Delivered-but-unsettled workflow correctly.
+/// Rollback must reject an already-Delivered workflow: units have already
+/// been physically handed to a hospital, so releasing them back to Available
+/// (and refunding payment) would enable double-use of the same blood unit.
 #[test]
-fn test_rollback_delivered_workflow() {
+fn test_rollback_blocked_after_delivery() {
     let h = setup();
     seed_pending_request(&h, 1);
     let unit_id = register_unit(&h);
@@ -1039,8 +1041,16 @@ fn test_rollback_delivered_workflow() {
 
     assert_eq!(h.coord.get_workflow(&1u64).status, WorkflowStatus::Delivered);
 
-    h.coord.rollback(&1u64);
+    let result = h.coord.try_rollback(&1u64);
+    assert_eq!(result, Err(Ok(CoordinatorError::InvalidWorkflowState)));
 
+    // Workflow, unit, and payment state must remain unchanged.
     let wf = h.coord.get_workflow(&1u64);
-    assert_eq!(wf.status, WorkflowStatus::Locked);
+    assert_eq!(wf.status, WorkflowStatus::Delivered);
+
+    let unit = MockInventoryContractClient::new(&h.env, &h.inv_id).get_blood_unit(&unit_id);
+    assert_ne!(unit.status, BloodStatus::Available);
+
+    let payment = MockPaymentContractClient::new(&h.env, &h.pay_id).get_payment(&payment_id);
+    assert_eq!(payment.status, PaymentStatus::Locked);
 }

--- a/lifebank-soroban/contracts/reputation/src/lib.rs
+++ b/lifebank-soroban/contracts/reputation/src/lib.rs
@@ -290,6 +290,20 @@ impl ReputationContract {
         Ok(())
     }
 
+    /// Verify that `caller` is the configured admin and has authorized this call.
+    fn require_admin_auth(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
+        caller.require_auth();
+        if caller != &admin {
+            return Err(Error::NotAuthorized);
+        }
+        Ok(())
+    }
+
     /// Reject caller-supplied timestamps that lie in the future relative to
     /// the current ledger time. Rating/assignment/fraud timestamps feed
     /// directly into recency weighting (`weighted_rating_score`) and


### PR DESCRIPTION



## Summary
closes #1246: `rollback()` in the coordinator contract could revert an already-`Delivered` workflow back to `Available` and refund its payment, letting the same physical blood unit be re-allocated to a different hospital while a copy was already delivered. `rollback()` now rejects `WorkflowStatus::Delivered` the same way it already rejects `Settled`.
closes #1245: the reputation contract called `Self::require_admin_auth(...)` in four places (`submit_rating`, `record_assignment`, `flag_fraud`, `update_from_event`) but never defined it, so the crate failed to compile. Implemented `require_admin_auth`, matching the existing admin-check pattern used by `pause`/`unpause`.
closes  #1243: `FeeStructure::calculate_net_amount` was dead code — never called from any production path, despite `Payment.amount` being documented as "net after fees." Wired it into `create_payment` so the stored payment amount is actually netted against the fee structure.

## Test plan
- [x] `cargo check -p reputation-contract --lib` — compiles cleanly (previously failed with 4x `E0599`)
- [x] `cargo check --lib` (top-level `contracts` crate) — compiles cleanly
- [x] `cargo test --lib test_payments::` / `test_protocol_invariants::` (top-level `contracts` crate) — 39 + 10 tests pass unchanged
- [x] `cargo test -p coordinator-contract` — added `test_rollback_blocked_after_delivery`, asserting `rollback()` now returns `InvalidWorkflowState` on a `Delivered` workflow and leaves workflow/unit/payment state untouched; replaces the previous test which asserted the vulnerable behavior and didn't compile (referenced a nonexistent `WorkflowStatus::Locked` variant)
- Fixed one unrelated compile-blocking typo in coordinator tests (`CoordinatorError::EmergencyHalt` → `EmergencyHalted`) that was preventing the coordinator test suite from building at all
- Note: several other pre-existing, unrelated compile issues remain in the repo (duplicate enum discriminant in `lifebank-soroban/contracts/payments`, missing `PartialEq` derives in top-level `contracts` tests, stale test signatures in reputation/coordinator tests) — confirmed via `git stash` comparison to predate this change and left untouched as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)