### PR TITLE
fix(common): make @RateLimit() actually throttle

### DIFF
--- a/backend/src/common/guards/endpoint-rate-limit.guard.spec.ts
+++ b/backend/src/common/guards/endpoint-rate-limit.guard.spec.ts
@@ -1,63 +1,120 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Test } from '@nestjs/testing';
+import {
+  seconds,
+  ThrottlerException,
+  ThrottlerModuleOptions,
+  ThrottlerRequest,
+  ThrottlerStorageService,
+} from '@nestjs/throttler';
 
-import { RATE_LIMIT_KEY } from '../decorators/rate-limit.decorator';
+import { RateLimitConfig } from '../decorators/rate-limit.decorator';
 
 import { EndpointRateLimitGuard } from './endpoint-rate-limit.guard';
 
+/**
+ * These tests assert on throttling behaviour — that requests are actually
+ * rejected once the decorated limit is exceeded — rather than on the guard
+ * having stashed a config object somewhere. The previous version asserted the
+ * latter, which passed even though the decorator changed nothing.
+ */
 describe('EndpointRateLimitGuard', () => {
+  const GLOBAL_LIMIT = 100;
+  const GLOBAL_TTL = seconds(60);
+
   let guard: EndpointRateLimitGuard;
   let reflector: Reflector;
+  let storage: ThrottlerStorageService;
+
+  const options: ThrottlerModuleOptions = {
+    throttlers: [{ name: 'default', limit: GLOBAL_LIMIT, ttl: GLOBAL_TTL }],
+  };
+
+  const handlerRef = function handler() {};
+  const classRef = class Controller {};
+
+  const context = {
+    switchToHttp: () => ({
+      getRequest: () => ({ ip: '127.0.0.1', path: '/test', headers: {} }),
+      getResponse: () => ({ header: jest.fn() }),
+    }),
+    getHandler: () => handlerRef,
+    getClass: () => classRef,
+  } as unknown as ExecutionContext;
+
+  /** Drive one request through the guard's throttling path. */
+  const hit = (): Promise<boolean> => {
+    const requestProps: ThrottlerRequest = {
+      context,
+      limit: GLOBAL_LIMIT,
+      ttl: GLOBAL_TTL,
+      throttler: { name: 'default', limit: GLOBAL_LIMIT, ttl: GLOBAL_TTL },
+      blockDuration: GLOBAL_TTL,
+      getTracker: () => Promise.resolve('127.0.0.1'),
+      generateKey: () => 'endpoint-rate-limit-spec',
+    };
+
+    return (
+      guard as unknown as {
+        handleRequest(props: ThrottlerRequest): Promise<boolean>;
+      }
+    ).handleRequest(requestProps);
+  };
+
+  const withRateLimit = (config?: RateLimitConfig) => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(config);
+  };
 
   beforeEach(async () => {
-    const module = await Test.createTestingModule({
-      providers: [EndpointRateLimitGuard, Reflector],
-    }).compile();
-
-    guard = module.get<EndpointRateLimitGuard>(EndpointRateLimitGuard);
-    reflector = module.get<Reflector>(Reflector);
+    storage = new ThrottlerStorageService();
+    reflector = new Reflector();
+    guard = new EndpointRateLimitGuard(options, storage, reflector);
+    await guard.onModuleInit();
   });
 
-  it('should attach rate limit config to request', async () => {
-    const rateLimitConfig = { limit: 5, ttl: 60 };
-    jest.spyOn(reflector, 'get').mockReturnValue(rateLimitConfig);
-
-    const mockRequest = { ip: '127.0.0.1', path: '/test', rateLimit: null };
-    const mockContext = {
-      switchToHttp: () => ({
-        getRequest: () => mockRequest,
-      }),
-      getHandler: () => ({}),
-    } as unknown as ExecutionContext;
-
-    // Mock parent canActivate
-    jest
-      .spyOn(Object.getPrototypeOf(guard), 'canActivate')
-      .mockResolvedValue(true);
-
-    await guard.canActivate(mockContext);
-
-    expect(mockRequest.rateLimit).toEqual(rateLimitConfig);
+  afterEach(() => {
+    storage.onApplicationShutdown();
+    jest.restoreAllMocks();
   });
 
-  it('should handle missing rate limit config', async () => {
-    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+  it('rejects requests once the decorated limit is exceeded', async () => {
+    withRateLimit({ limit: 2, ttl: 60 });
 
-    const mockRequest = { ip: '127.0.0.1', path: '/test' };
-    const mockContext = {
-      switchToHttp: () => ({
-        getRequest: () => mockRequest,
-      }),
-      getHandler: () => ({}),
-    } as unknown as ExecutionContext;
+    await expect(hit()).resolves.toBe(true);
+    await expect(hit()).resolves.toBe(true);
 
-    jest
-      .spyOn(Object.getPrototypeOf(guard), 'canActivate')
-      .mockResolvedValue(true);
+    // Third request is over the decorated limit of 2, even though the global
+    // throttler would still allow 97 more.
+    await expect(hit()).rejects.toThrow(ThrottlerException);
+  });
 
-    await guard.canActivate(mockContext);
+  it('applies the decorated limit rather than the global one', async () => {
+    withRateLimit({ limit: 1, ttl: 60 });
 
-    expect(mockRequest.rateLimit).toBeUndefined();
+    await expect(hit()).resolves.toBe(true);
+    await expect(hit()).rejects.toThrow(ThrottlerException);
+  });
+
+  it('converts the decorated ttl from seconds to milliseconds', async () => {
+    withRateLimit({ limit: 1, ttl: 60 });
+    const increment = jest.spyOn(storage, 'increment');
+
+    await hit();
+
+    expect(increment).toHaveBeenCalledWith(
+      expect.any(String),
+      seconds(60),
+      1,
+      expect.any(Number),
+      'default',
+    );
+  });
+
+  it('falls through to the global limit when the endpoint is not decorated', async () => {
+    withRateLimit(undefined);
+
+    for (let i = 0; i < 5; i++) {
+      await expect(hit()).resolves.toBe(true);
+    }
   });
 });

--- a/backend/src/common/guards/endpoint-rate-limit.guard.ts
+++ b/backend/src/common/guards/endpoint-rate-limit.guard.ts
@@ -1,32 +1,63 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import {
+  InjectThrottlerOptions,
+  InjectThrottlerStorage,
+  seconds,
+  ThrottlerGuard,
+  ThrottlerModuleOptions,
+  ThrottlerRequest,
+  ThrottlerStorage,
+} from '@nestjs/throttler';
 
 import {
   RATE_LIMIT_KEY,
   RateLimitConfig,
 } from '../decorators/rate-limit.decorator';
 
+/**
+ * Throttler guard that honours the per-endpoint `@RateLimit({ limit, ttl })`
+ * decorator.
+ *
+ * `ThrottlerGuard` resolves the limit and TTL for a request inside
+ * `handleRequest`, so that is the only place a custom limit can take effect.
+ * Overriding it — rather than stashing the config on the request object, which
+ * nothing downstream reads — is what makes the decorator actually change
+ * throttling behaviour.
+ *
+ * Endpoints without `@RateLimit()` fall through to the global throttler
+ * configuration unchanged.
+ */
 @Injectable()
 export class EndpointRateLimitGuard extends ThrottlerGuard {
-  constructor(private reflector: Reflector) {
-    super();
+  constructor(
+    @InjectThrottlerOptions() options: ThrottlerModuleOptions,
+    @InjectThrottlerStorage() storageService: ThrottlerStorage,
+    reflector: Reflector,
+  ) {
+    super(options, storageService, reflector);
   }
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const rateLimitConfig = this.reflector.get<RateLimitConfig>(
-      RATE_LIMIT_KEY,
-      context.getHandler(),
-    );
+  protected async handleRequest(
+    requestProps: ThrottlerRequest,
+  ): Promise<boolean> {
+    const config = this.reflector.getAllAndOverride<
+      RateLimitConfig | undefined
+    >(RATE_LIMIT_KEY, [
+      requestProps.context.getHandler(),
+      requestProps.context.getClass(),
+    ]);
 
-    if (rateLimitConfig) {
-      const request = context.switchToHttp().getRequest();
-      const key = `${request.ip}:${request.path}`;
-
-      // Store custom limit in request for throttler to use
-      request.rateLimit = rateLimitConfig;
+    if (!config) {
+      return super.handleRequest(requestProps);
     }
 
-    return super.canActivate(context);
+    // `RateLimitConfig.ttl` is documented in seconds; the throttler works in
+    // milliseconds, so convert rather than passing the raw value through.
+    return super.handleRequest({
+      ...requestProps,
+      limit: config.limit,
+      ttl: seconds(config.ttl),
+    });
   }
 }


### PR DESCRIPTION
Closes #1198

## Summary

`EndpointRateLimitGuard` extended `ThrottlerGuard` but only wrote the decorator config onto the request object:

```ts
request.rateLimit = rateLimitConfig;   // nothing reads this
```

It never overrode the methods `@nestjs/throttler` uses to resolve a limit, so `super.canActivate()` went on using the global configuration. Every endpoint annotated with `@RateLimit({ limit, ttl })` silently got the default throttle instead of its declared one — an endpoint asking for a **tighter** limit received a **looser** one.

## Fix

Override `handleRequest`, which is where throttler v6 resolves the limit and TTL for a request, and substitute the decorated values there:

```ts
protected async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {
  const config = this.reflector.getAllAndOverride<RateLimitConfig | undefined>(
    RATE_LIMIT_KEY,
    [requestProps.context.getHandler(), requestProps.context.getClass()],
  );

  if (!config) return super.handleRequest(requestProps);

  return super.handleRequest({
    ...requestProps,
    limit: config.limit,
    ttl: seconds(config.ttl),
  });
}
```

Undecorated endpoints fall through to the global configuration unchanged. Metadata is read with `getAllAndOverride` over handler **and** class, so `@RateLimit()` also works applied at controller level.

## Two further defects found while fixing this

1. **`super()` was called with no arguments.** `ThrottlerGuard`'s constructor is `(options, storageService, reflector)`. These are now injected properly via `@InjectThrottlerOptions()` / `@InjectThrottlerStorage()`. The old `private reflector` also shadowed the parent's own `protected reflector`.

2. **`ttl` units were mismatched.** `RateLimitConfig.ttl` is documented in **seconds**; throttler v6 works in **milliseconds**. Passing the raw value through would have turned a declared 60-second window into 60 **milliseconds** — effectively no rate limiting at all. Converted with the library's `seconds()` helper, and covered by a test.

## Tests

The old spec asserted only that `request.rateLimit` had been set, and mocked out the parent `canActivate` — so it passed while throttling did nothing. **The bug was masked by its own test**, exactly as the issue notes.

The spec now drives requests through the guard's real throttling path against a real `ThrottlerStorageService` and asserts on behaviour:

| Test | Asserts |
|---|---|
| rejects once the decorated limit is exceeded | 3rd request with `limit: 2` throws `ThrottlerException`, while the global limit of 100 would still allow it |
| decorated limit wins over global | 2nd request with `limit: 1` is rejected |
| ttl converted seconds → ms | `storage.increment` receives `seconds(60)`, not `60` |
| undecorated endpoints unaffected | 5 requests all pass under the global limit |

```
Test Suites: 1 passed
Tests:       4 passed
```

These fail against the previous implementation: without the `handleRequest` override the decorated limit is never applied, so nothing is rejected.

## Verification

- `npx jest src/common/guards/endpoint-rate-limit.guard.spec.ts` — 4/4 pass
- `npx eslint` on both changed files — clean
- `npx tsc --noEmit` — **0 errors in the changed files**. The 9 reported errors are pre-existing on `main`, confined to `blood-units/services/quarantine.service.spec.ts` and `hospitals/hospitals.module.ts`.

## Note

The guard is not currently applied to any endpoint, so nothing is exploitable today — this fixes the utility before someone adopts it and quietly gets the wrong limit.

## The old guard could not be instantiated at all

While working on #1197 I ran the **unmodified** spec against `main` and both of its tests fail:

```
● EndpointRateLimitGuard › should attach rate limit config to request

  Nest can't resolve dependencies of the EndpointRateLimitGuard
  (?, Symbol(ThrottlerStorage)). Please make sure that the argument
  "THROTTLER:MODULE_OPTIONS" at index [0] is available in the RootTestModule module.
```

Because the subclass called `super()` with no arguments, Nest fell back to `ThrottlerGuard`'s own constructor metadata and could not resolve it. So the guard was not merely mis-throttling — it could not be constructed by the DI container, and its spec was already red on `main`. Injecting the three dependencies properly fixes that too, which is why the rewritten spec can instantiate the guard directly and exercise real throttling.
