### PR TITLE
fix(maps): authenticate live-ops gateway and verify rider identity

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -29,6 +29,7 @@ import { PermissionsService } from './permissions.service';
 import { AuthSessionRepository } from './repositories/auth-session.repository';
 import { ScopeResolutionService } from './scope-resolution.service';
 import { SessionRiskService } from './session-risk.service';
+import { WsAuthService } from './ws-auth.service';
 
 import type { JwtModuleOptions } from '@nestjs/jwt';
 
@@ -83,6 +84,7 @@ import type { JwtModuleOptions } from '@nestjs/jwt';
     AuthSessionRepository,
     ScopeResolutionService,
     SessionRiskService,
+    WsAuthService,
   ],
   exports: [
     AuthService,
@@ -97,6 +99,7 @@ import type { JwtModuleOptions } from '@nestjs/jwt';
     JwtModule,
     AuthSessionRepository,
     SessionRiskService,
+    WsAuthService,
   ],
 })
 export class AuthModule {}

--- a/backend/src/maps/gateways/live-ops.gateway.spec.ts
+++ b/backend/src/maps/gateways/live-ops.gateway.spec.ts
@@ -1,0 +1,203 @@
+import { Server } from 'socket.io';
+
+import { AuthenticatedSocket, WsAuthService } from '../../auth/ws-auth.service';
+
+import { LiveOpsGateway, LiveRiderPosition } from './live-ops.gateway';
+
+interface TestClient {
+  client: AuthenticatedSocket;
+  join: jest.Mock;
+  emit: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+describe('LiveOpsGateway', () => {
+  let gateway: LiveOpsGateway;
+  let wsAuthService: { authenticate: jest.Mock };
+  let middleware: jest.Mock;
+
+  const makeClient = (
+    user?: Partial<NonNullable<AuthenticatedSocket['user']>>,
+  ): TestClient => {
+    const join = jest.fn();
+    const emit = jest.fn();
+    const disconnect = jest.fn();
+
+    const client = {
+      id: 'socket-1',
+      user: user ? { userId: 'user-1', tenantId: 't-1', ...user } : undefined,
+      join,
+      emit,
+      disconnect,
+      handshake: { address: '127.0.0.1' },
+    } as unknown as AuthenticatedSocket;
+
+    return { client, join, emit, disconnect };
+  };
+
+  const position = (
+    over: Partial<LiveRiderPosition> = {},
+  ): LiveRiderPosition => ({
+    riderId: 'user-1',
+    lat: 6.5244,
+    lng: 3.3792,
+    status: 'en_route',
+    timestamp: new Date(),
+    ...over,
+  });
+
+  beforeEach(() => {
+    middleware = jest.fn();
+    wsAuthService = { authenticate: jest.fn().mockReturnValue(middleware) };
+    gateway = new LiveOpsGateway(wsAuthService as unknown as WsAuthService);
+    gateway.server = {
+      to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+    } as unknown as Server;
+  });
+
+  describe('authentication', () => {
+    it('installs the JWT handshake middleware on init', () => {
+      const use = jest.fn();
+      gateway.afterInit({ use } as unknown as Server);
+
+      expect(wsAuthService.authenticate).toHaveBeenCalled();
+      expect(use).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes handshakes through the auth middleware', () => {
+      const use = jest.fn();
+      gateway.afterInit({ use } as unknown as Server);
+
+      const calls = use.mock.calls as Array<
+        [(socket: unknown, next: () => void) => void]
+      >;
+      const registered = calls[0][0];
+      const next = jest.fn();
+      registered({ id: 'socket-1' }, next);
+
+      expect(middleware).toHaveBeenCalledWith({ id: 'socket-1' }, next);
+    });
+
+    it('disconnects a socket that arrives without an authenticated user', () => {
+      const { client, disconnect } = makeClient();
+
+      gateway.handleConnection(client);
+
+      expect(disconnect).toHaveBeenCalledWith(true);
+    });
+
+    it('keeps an authenticated socket connected', () => {
+      const { client, disconnect } = makeClient({ role: 'admin' });
+
+      gateway.handleConnection(client);
+
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ops.subscribe', () => {
+    it('rejects a non-operator role', () => {
+      const { client, join, emit } = makeClient({ role: 'donor' });
+
+      gateway.handleSubscribe(client, {});
+
+      expect(join).not.toHaveBeenCalled();
+      expect(emit).toHaveBeenCalledWith(
+        'auth_error',
+        expect.stringContaining('Insufficient permissions'),
+      );
+    });
+
+    it('rejects an unauthenticated client', () => {
+      const { client, join } = makeClient();
+
+      gateway.handleSubscribe(client, {});
+
+      expect(join).not.toHaveBeenCalled();
+    });
+
+    it('admits an operator to the global room', () => {
+      const { client, join, emit } = makeClient({ role: 'admin' });
+
+      gateway.handleSubscribe(client, {});
+
+      expect(join).toHaveBeenCalledWith('ops:global');
+      expect(emit).toHaveBeenCalledWith('ops.subscribed', {
+        room: 'ops:global',
+      });
+    });
+
+    it('admits an operator to a region room', () => {
+      const { client, join } = makeClient({ role: 'dispatcher' });
+
+      gateway.handleSubscribe(client, { region: 'lagos' });
+
+      expect(join).toHaveBeenCalledWith('ops:region:lagos');
+    });
+  });
+
+  describe('ops.rider.location', () => {
+    it('refuses to broadcast a position for another rider', () => {
+      const { client, emit } = makeClient({ userId: 'rider-1', role: 'rider' });
+      const broadcast = jest.spyOn(gateway, 'broadcastRiderPosition');
+
+      gateway.handleRiderLocation(client, position({ riderId: 'rider-2' }));
+
+      expect(broadcast).not.toHaveBeenCalled();
+      expect(emit).toHaveBeenCalledWith(
+        'auth_error',
+        expect.stringContaining('cannot publish another rider position'),
+      );
+    });
+
+    it('broadcasts a rider its own position', () => {
+      const { client } = makeClient({ userId: 'rider-1', role: 'rider' });
+      const broadcast = jest.spyOn(gateway, 'broadcastRiderPosition');
+
+      gateway.handleRiderLocation(client, position({ riderId: 'rider-1' }));
+
+      expect(broadcast).toHaveBeenCalled();
+    });
+
+    it('rejects an unauthenticated publisher', () => {
+      const { client } = makeClient();
+      const broadcast = jest.spyOn(gateway, 'broadcastRiderPosition');
+
+      gateway.handleRiderLocation(client, position());
+
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['latitude above range', { lat: 91 }],
+      ['latitude below range', { lat: -91 }],
+      ['longitude above range', { lng: 181 }],
+      ['longitude below range', { lng: -181 }],
+      ['non-numeric latitude', { lat: 'here' as unknown as number }],
+      ['NaN longitude', { lng: Number.NaN }],
+    ])('rejects %s', (_label, over) => {
+      const { client, emit } = makeClient({ userId: 'rider-1', role: 'rider' });
+      const broadcast = jest.spyOn(gateway, 'broadcastRiderPosition');
+
+      gateway.handleRiderLocation(
+        client,
+        position({ riderId: 'rider-1', ...over }),
+      );
+
+      expect(broadcast).not.toHaveBeenCalled();
+      expect(emit).toHaveBeenCalledWith('ops.error', 'Invalid coordinates');
+    });
+
+    it('rejects a malformed payload', () => {
+      const { client } = makeClient({ userId: 'rider-1', role: 'rider' });
+      const broadcast = jest.spyOn(gateway, 'broadcastRiderPosition');
+
+      gateway.handleRiderLocation(
+        client,
+        undefined as unknown as LiveRiderPosition,
+      );
+
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/maps/gateways/live-ops.gateway.ts
+++ b/backend/src/maps/gateways/live-ops.gateway.ts
@@ -1,15 +1,19 @@
+import { Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 import {
   WebSocketGateway,
   WebSocketServer,
   SubscribeMessage,
+  OnGatewayInit,
   OnGatewayConnection,
   OnGatewayDisconnect,
   ConnectedSocket,
   MessageBody,
 } from '@nestjs/websockets';
-import { Logger } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
+
 import { Server, Socket } from 'socket.io';
+
+import { AuthenticatedSocket, WsAuthService } from '../../auth/ws-auth.service';
 
 export interface LiveRiderPosition {
   riderId: string;
@@ -30,36 +34,153 @@ export interface LiveIncidentUpdate {
   timestamp: Date;
 }
 
+/**
+ * Roles permitted to observe the live-ops feed.
+ *
+ * Subscribers receive live rider GPS, order IDs, hospital IDs and blood-request
+ * urgency, so this is restricted to operator roles rather than any
+ * authenticated user. Mirrors the role list used by DispatchGateway.
+ */
+const OPS_VIEWER_ROLES = ['admin', 'super_admin', 'dispatcher'];
+
+/**
+ * Live operations feed.
+ *
+ * Every connection is authenticated by `WsAuthService` before any handler runs
+ * (see `afterInit`). On top of that:
+ * - subscribing is limited to operator roles, because the feed carries rider
+ *   locations and hospital/blood-request details;
+ * - a rider position may only be published by the authenticated rider it
+ *   describes, so a client cannot fabricate another rider's position;
+ * - coordinates are range-checked before being broadcast.
+ */
 @WebSocketGateway({ cors: { origin: '*' }, namespace: '/ops' })
-export class LiveOpsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class LiveOpsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
   @WebSocketServer() server: Server;
   private readonly logger = new Logger(LiveOpsGateway.name);
 
-  handleConnection(client: Socket) {
-    this.logger.log(`Ops client connected: ${client.id}`);
+  constructor(private readonly wsAuthService: WsAuthService) {}
+
+  /**
+   * Install the JWT handshake middleware.
+   *
+   * Sockets that fail authentication are rejected before `handleConnection`,
+   * so no handler on this namespace can be reached unauthenticated.
+   */
+  afterInit(server: Server) {
+    const authenticate = this.wsAuthService.authenticate();
+    server.use((socket, next) => {
+      void authenticate(socket as AuthenticatedSocket, next);
+    });
+    this.logger.log('LiveOpsGateway initialised with JWT authentication');
   }
 
-  handleDisconnect(client: Socket) {
-    this.logger.log(`Ops client disconnected: ${client.id}`);
+  handleConnection(client: AuthenticatedSocket) {
+    const user = client.user;
+
+    // Defence in depth: the middleware should already have rejected this.
+    if (!user) {
+      this.logger.warn(
+        `Ops client ${client.id} reached handleConnection unauthenticated — disconnecting`,
+      );
+      client.disconnect(true);
+      return;
+    }
+
+    this.logger.log(
+      `Ops client connected: socketId=${client.id} userId=${user.userId} role=${user.role}`,
+    );
+  }
+
+  handleDisconnect(client: AuthenticatedSocket) {
+    this.logger.log(
+      `Ops client disconnected: socketId=${client.id} userId=${client.user?.userId}`,
+    );
   }
 
   /** Operators subscribe to a region filter */
   @SubscribeMessage('ops.subscribe')
   handleSubscribe(
-    @ConnectedSocket() client: Socket,
+    @ConnectedSocket() client: AuthenticatedSocket,
     @MessageBody() data: { region?: string },
   ) {
-    const room = data.region ? `ops:region:${data.region}` : 'ops:global';
-    client.join(room);
+    const user = client.user;
+
+    if (!user) {
+      client.emit('auth_error', 'User not authenticated');
+      return;
+    }
+
+    if (!OPS_VIEWER_ROLES.includes(user.role || '')) {
+      this.logger.warn(
+        `Ops subscribe denied for userId=${user.userId} role=${user.role}`,
+      );
+      client.emit(
+        'auth_error',
+        'Insufficient permissions: live-ops feed is restricted to operators',
+      );
+      return;
+    }
+
+    const room = data?.region ? `ops:region:${data.region}` : 'ops:global';
+    void client.join(room);
     client.emit('ops.subscribed', { room });
   }
 
   /** Riders push location updates via this event */
   @SubscribeMessage('ops.rider.location')
   handleRiderLocation(
+    @ConnectedSocket() client: AuthenticatedSocket,
     @MessageBody() payload: LiveRiderPosition,
   ) {
+    const user = client.user;
+
+    if (!user) {
+      client.emit('auth_error', 'User not authenticated');
+      return;
+    }
+
+    if (!payload || typeof payload.riderId !== 'string') {
+      client.emit('ops.error', 'Invalid rider position payload');
+      return;
+    }
+
+    // A client may only report its own position. Without this, any connected
+    // client could broadcast a fabricated location for any rider.
+    if (payload.riderId !== user.userId) {
+      this.logger.warn(
+        `Rejected rider position for riderId=${payload.riderId} from userId=${user.userId}`,
+      );
+      client.emit(
+        'auth_error',
+        'Insufficient permissions: cannot publish another rider position',
+      );
+      return;
+    }
+
+    if (!this.hasValidCoordinates(payload)) {
+      client.emit('ops.error', 'Invalid coordinates');
+      return;
+    }
+
     this.broadcastRiderPosition(payload);
+  }
+
+  /** Latitude/longitude must be real, finite, in-range values. */
+  private hasValidCoordinates(payload: LiveRiderPosition): boolean {
+    const { lat, lng } = payload;
+    return (
+      typeof lat === 'number' &&
+      typeof lng === 'number' &&
+      Number.isFinite(lat) &&
+      Number.isFinite(lng) &&
+      lat >= -90 &&
+      lat <= 90 &&
+      lng >= -180 &&
+      lng <= 180
+    );
   }
 
   /** Broadcast rider position to all ops subscribers */
@@ -79,7 +200,10 @@ export class LiveOpsGateway implements OnGatewayConnection, OnGatewayDisconnect 
   }
 
   /** Emit current snapshot to a newly connected operator */
-  emitSnapshot(client: Socket, snapshot: { riders: LiveRiderPosition[]; incidents: LiveIncidentUpdate[] }) {
+  emitSnapshot(
+    client: Socket,
+    snapshot: { riders: LiveRiderPosition[]; incidents: LiveIncidentUpdate[] },
+  ) {
     client.emit('ops.snapshot', snapshot);
   }
 }

--- a/backend/src/maps/maps.module.ts
+++ b/backend/src/maps/maps.module.ts
@@ -1,16 +1,17 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { AuthModule } from '../auth/auth.module';
 import { RedisModule } from '../redis/redis.module';
 
+import { RoutePlanningController } from './controllers/route-planning.controller';
 import { LiveOpsGateway } from './gateways/live-ops.gateway';
 import { MapsController } from './maps.controller';
 import { MapsService } from './maps.service';
-import { RoutePlanningController } from './controllers/route-planning.controller';
 import { RoutePlanningService } from './services/route-planning.service';
 
 @Module({
-  imports: [ConfigModule, RedisModule],
+  imports: [ConfigModule, RedisModule, AuthModule],
   controllers: [MapsController, RoutePlanningController],
   providers: [MapsService, LiveOpsGateway, RoutePlanningService],
   exports: [MapsService, LiveOpsGateway, RoutePlanningService],


### PR DESCRIPTION
Closes #1197

## Summary

`LiveOpsGateway` had no guards and `handleConnection` performed no token check, so anyone able to reach `/ops` could:

- **read** — join `ops:global` or any `ops:region:<region>` via `ops.subscribe` and passively watch live rider GPS, order IDs, hospital IDs and blood-request urgency;
- **write** — emit `ops.rider.location` with any `LiveRiderPosition`, rebroadcast verbatim to every subscriber, letting an unauthenticated client fake a rider's position to real dispatchers mid-delivery.

## Changes

**Authentication.** `afterInit` installs the existing `WsAuthService` JWT handshake middleware, so unauthenticated sockets are rejected before any handler runs. `handleConnection` disconnects a socket arriving without a user as defence in depth.

**Authorisation on read.** `ops.subscribe` is restricted to operator roles (`admin`, `super_admin`, `dispatcher`), matching `DispatchGateway`. Being authenticated is not sufficient — the feed carries rider locations and hospital/blood-request details, so a `donor` or `vendor` account should not see it.

**Identity on write.** `ops.rider.location` requires `payload.riderId === user.userId`. A client can only report its own position; publishing for another rider is refused and logged.

**Input validation.** Coordinates must be finite numbers within `lat ∈ [-90, 90]` and `lng ∈ [-180, 180]`; malformed payloads are rejected before broadcast.

## `WsAuthService` was never wired up

Worth flagging separately: `WsAuthService` already existed, complete and documented with the exact usage pattern I followed — but it is **not provided or exported by any module**:

```
$ grep -rn "WsAuthService" backend/src --include='*.module.ts'
# (no results)
```

So it could not be injected anywhere. `DispatchGateway` and `OrdersGateway` both import it and would fail dependency resolution — `DispatchGateway` is not registered in any module, so this has gone unnoticed.

This PR provides and exports it from `AuthModule`, whose imports (`JwtModule`, `RedisModule`, `UserActivityModule`, `ConfigModule`) already satisfy its dependencies, and has `MapsModule` import `AuthModule`. I verified no import cycle is introduced — nothing in `AuthModule`'s import chain reaches `MapsModule`.

That wiring also unblocks the other gateways, should you want to register them.

## Tests

New `live-ops.gateway.spec.ts` — **18 tests, all passing**:

| Area | Covers |
|---|---|
| authentication | middleware installed on init; handshakes routed through it; unauthenticated socket disconnected; authenticated socket kept |
| `ops.subscribe` | non-operator role rejected; unauthenticated rejected; operator joins global and region rooms |
| `ops.rider.location` | refuses another rider's position; broadcasts own; rejects unauthenticated; rejects malformed payload |
| coordinates | 6 cases — lat/lng above and below range, non-numeric, `NaN` |

## Verification

- `npx jest src/maps/gateways/live-ops.gateway.spec.ts` — 18/18 pass
- `npx eslint` on all four changed files — clean
- `npx tsc --noEmit` — **0 errors in changed files**. The 9 reported are pre-existing on `main`, in `blood-units/services/quarantine.service.spec.ts` and `hospitals/hospitals.module.ts`.

## Note on scope

I kept the failure paths to `Logger` warnings plus an `auth_error` to the client, rather than pulling `SecurityEventLoggerService` into `MapsModule` as `DispatchGateway` does. That keeps the module wiring minimal; happy to add audit logging for privilege violations here too if you would prefer the consistency.

`cors: { origin: '*' }` is left as-is — tightening it is a deployment-configuration decision and out of scope for this fix, but worth a separate look given what this namespace carries.
