### PR TITLE
fix: close USSD session hijack, PIN bypass, path traversal, and dispu…

### DIFF
--- a/backend/src/media-processing/media-processing.controller.ts
+++ b/backend/src/media-processing/media-processing.controller.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 import {
+  BadRequestException,
   Controller,
   Get,
   HttpCode,
@@ -26,7 +27,11 @@ import {
 } from '@nestjs/swagger';
 import { Response } from 'express';
 
-import { MediaProcessingService, MediaUploadContext } from './media-processing.service';
+import {
+  MEDIA_OWNER_TYPES,
+  MediaProcessingService,
+  MediaUploadContext,
+} from './media-processing.service';
 
 @ApiTags('Media Processing')
 @ApiBearerAuth()
@@ -54,7 +59,7 @@ export class MediaProcessingController {
       properties: {
         file: { type: 'string', format: 'binary' },
         category: { type: 'string', enum: ['profile', 'evidence', 'medical', 'signature'] },
-        ownerType: { type: 'string' },
+        ownerType: { type: 'string', enum: [...MEDIA_OWNER_TYPES] },
       },
       required: ['file', 'category'],
     },
@@ -67,9 +72,16 @@ export class MediaProcessingController {
     @Query('ownerType') ownerType: string,
     @Request() req: any,
   ) {
+    const resolvedOwnerType = ownerType ?? 'user';
+    if (!MEDIA_OWNER_TYPES.includes(resolvedOwnerType as MediaUploadContext['ownerType'])) {
+      throw new BadRequestException(
+        `Invalid ownerType. Must be one of: ${MEDIA_OWNER_TYPES.join(', ')}`,
+      );
+    }
+
     const context: MediaUploadContext = {
       ownerId: req.user?.id ?? 'anonymous',
-      ownerType: ownerType ?? 'user',
+      ownerType: resolvedOwnerType as MediaUploadContext['ownerType'],
       category: (category ?? 'profile') as MediaUploadContext['category'],
     };
     const result = await this.mediaService.ingest(file, context);

--- a/backend/src/media-processing/media-processing.service.ts
+++ b/backend/src/media-processing/media-processing.service.ts
@@ -21,9 +21,12 @@ export enum MediaProcessingState {
   REJECTED = 'rejected',
 }
 
+export const MEDIA_OWNER_TYPES = ['user', 'organization', 'blood_bank'] as const;
+export type MediaOwnerType = (typeof MEDIA_OWNER_TYPES)[number];
+
 export interface MediaUploadContext {
   ownerId: string;
-  ownerType: string;
+  ownerType: MediaOwnerType;
   category: 'profile' | 'evidence' | 'medical' | 'signature';
 }
 
@@ -363,7 +366,22 @@ export class MediaProcessingService {
   ): string {
     const ext = path.extname(originalname).toLowerCase() || '.bin';
     const base = this.configService.get<string>('MEDIA_STORAGE_PATH', '/tmp/media');
-    return path.join(base, context.ownerType, context.ownerId, `${fileId}${ext}`);
+    const resolvedBase = path.resolve(base);
+    const resolvedPath = path.resolve(
+      resolvedBase,
+      context.ownerType,
+      context.ownerId,
+      `${fileId}${ext}`,
+    );
+
+    if (
+      resolvedPath !== resolvedBase &&
+      !resolvedPath.startsWith(resolvedBase + path.sep)
+    ) {
+      throw new BadRequestException('Resolved storage path escapes storage root');
+    }
+
+    return resolvedPath;
   }
 
   private ensureDir(dir: string): void {

--- a/backend/src/migrations/1974000000000-AddUssdPinAuthToUsers.ts
+++ b/backend/src/migrations/1974000000000-AddUssdPinAuthToUsers.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUssdPinAuthToUsers1974000000000 implements MigrationInterface {
+  name = 'AddUssdPinAuthToUsers1974000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN "ussd_pin_hash" varchar,
+      ADD COLUMN "ussd_pin_failed_attempts" int NOT NULL DEFAULT 0,
+      ADD COLUMN "ussd_pin_locked_until" TIMESTAMP
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      DROP COLUMN "ussd_pin_hash",
+      DROP COLUMN "ussd_pin_failed_attempts",
+      DROP COLUMN "ussd_pin_locked_until"
+    `);
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -72,6 +72,15 @@ export class UserEntity extends BaseEntity {
   @Column({ name: 'password_history', type: 'simple-json', nullable: true })
   passwordHistory?: string[];
 
+  @Column({ name: 'ussd_pin_hash', nullable: true })
+  ussdPinHash?: string | null;
+
+  @Column({ name: 'ussd_pin_failed_attempts', type: 'int', default: 0 })
+  ussdPinFailedAttempts: number;
+
+  @Column({ name: 'ussd_pin_locked_until', type: 'timestamp', nullable: true })
+  ussdPinLockedUntil?: Date | null;
+
   @Column({ name: 'is_active', type: 'boolean', default: true })
   isActive: boolean;
 

--- a/backend/src/users/user.repository.ts
+++ b/backend/src/users/user.repository.ts
@@ -27,6 +27,12 @@ export class UserRepository extends SoftDeleteRepository<UserEntity> {
     });
   }
 
+  findByPhoneNumber(phoneNumber: string): Promise<UserEntity | null> {
+    return this.findOne({
+      where: { phoneNumber, deletedAt: null },
+    });
+  }
+
   findByOrganization(organizationId: string): Promise<UserEntity[]> {
     return this.find({ where: { organizationId, deletedAt: null } });
   }

--- a/backend/src/ussd-session/ussd-auth.service.ts
+++ b/backend/src/ussd-session/ussd-auth.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import {
+  dummyVerify,
+  verifyPassword,
+} from '../auth/utils/password.util';
+import { UserEntity } from '../users/entities/user.entity';
+import { UserRepository } from '../users/user.repository';
+
+export type UssdPinVerificationResult =
+  | { success: true; userId: string }
+  | { success: false; reason: 'not_found' | 'locked' | 'invalid_pin' };
+
+@Injectable()
+export class UssdAuthService {
+  private readonly maxFailedPinAttempts: number;
+  private readonly pinLockMinutes: number;
+
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly configService: ConfigService,
+  ) {
+    this.maxFailedPinAttempts = this.configService.get<number>(
+      'MAX_FAILED_USSD_PIN_ATTEMPTS',
+      5,
+    );
+    this.pinLockMinutes = this.configService.get<number>(
+      'USSD_PIN_LOCK_MINUTES',
+      15,
+    );
+  }
+
+  async findUserByPhoneNumber(
+    phoneNumber: string,
+  ): Promise<UserEntity | null> {
+    return this.userRepository.findByPhoneNumber(phoneNumber);
+  }
+
+  async verifyPin(
+    phoneNumber: string,
+    pin: string,
+  ): Promise<UssdPinVerificationResult> {
+    const user = await this.userRepository.findByPhoneNumber(phoneNumber);
+
+    if (!user || !user.ussdPinHash) {
+      await dummyVerify(pin);
+      return { success: false, reason: 'not_found' };
+    }
+
+    if (user.ussdPinLockedUntil) {
+      if (user.ussdPinLockedUntil.getTime() > Date.now()) {
+        return { success: false, reason: 'locked' };
+      }
+      user.ussdPinFailedAttempts = 0;
+      user.ussdPinLockedUntil = null;
+    }
+
+    const valid = await verifyPassword(pin, user.ussdPinHash);
+    if (!valid) {
+      await this.recordFailedPinAttempt(user);
+      return { success: false, reason: 'invalid_pin' };
+    }
+
+    if (user.ussdPinFailedAttempts || user.ussdPinLockedUntil) {
+      user.ussdPinFailedAttempts = 0;
+      user.ussdPinLockedUntil = null;
+      await this.userRepository.save(user);
+    }
+
+    return { success: true, userId: user.id };
+  }
+
+  private async recordFailedPinAttempt(user: UserEntity): Promise<void> {
+    user.ussdPinFailedAttempts = (user.ussdPinFailedAttempts ?? 0) + 1;
+    if (user.ussdPinFailedAttempts >= this.maxFailedPinAttempts) {
+      const lockedUntil = new Date();
+      lockedUntil.setMinutes(lockedUntil.getMinutes() + this.pinLockMinutes);
+      user.ussdPinLockedUntil = lockedUntil;
+    }
+    await this.userRepository.save(user);
+  }
+}

--- a/backend/src/ussd-session/ussd-state-machine.service.ts
+++ b/backend/src/ussd-session/ussd-state-machine.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'crypto';
 
+import { UssdAuthService } from './ussd-auth.service';
 import {
   UssdSessionStore,
   USSD_SESSION_TTL_SECONDS,
@@ -30,7 +31,10 @@ const SESSION_TTL_MS = USSD_SESSION_TTL_SECONDS * 1000;
 export class UssdStateMachine {
   private readonly logger = new Logger(UssdStateMachine.name);
 
-  constructor(private readonly sessionStore: UssdSessionStore) {}
+  constructor(
+    private readonly sessionStore: UssdSessionStore,
+    private readonly ussdAuthService: UssdAuthService,
+  ) {}
 
   async process(
     sessionId: string,
@@ -47,10 +51,12 @@ export class UssdStateMachine {
 
     if (!session) {
       session = await this.sessionStore.createInitial(sessionId, phoneNumber);
-    }
-
-    if (session.phoneNumber !== phoneNumber) {
-      session.phoneNumber = phoneNumber;
+    } else if (session.phoneNumber !== phoneNumber) {
+      this.logger.warn(
+        `Session ${sessionId} phone number mismatch: expected ${session.phoneNumber}, got ${phoneNumber}. Terminating session.`,
+      );
+      await this.sessionStore.delete(sessionId);
+      return this.end('Session mismatch detected. Please start again.');
     }
 
     if (session.expiresAt <= Date.now()) {
@@ -179,7 +185,7 @@ export class UssdStateMachine {
         'Invalid phone number.\nEnter your registered phone number:',
       );
     }
-    session.userId = phone; // placeholder – real impl would look up user by phone
+    session.pendingLoginPhone = phone;
     session.history.push(session.step);
     session.step = UssdStep.LOGIN_PIN;
     await this.sessionStore.set(session);
@@ -196,11 +202,31 @@ export class UssdStateMachine {
     if (!/^\d{4,6}$/.test(input.trim())) {
       return this.con('Invalid PIN. Enter your 4-6 digit PIN:\n(0 to go back)');
     }
-    // TODO: replace stub with real auth service call
-    const pinValid = input.trim().length >= 4; // stub
-    if (!pinValid) {
+    if (!session.pendingLoginPhone) {
+      session.step = UssdStep.LOGIN_PHONE;
+      session.history = [];
+      await this.sessionStore.set(session);
+      return this.promptForStep(session);
+    }
+
+    const result = await this.ussdAuthService.verifyPin(
+      session.pendingLoginPhone,
+      input.trim(),
+    );
+
+    if (!result.success) {
+      if (result.reason === 'locked') {
+        session.step = UssdStep.CANCELLED;
+        await this.sessionStore.set(session);
+        return this.end(
+          'Too many failed attempts. Your account is temporarily locked. Please try again later.',
+        );
+      }
       return this.con('Incorrect PIN. Try again:\n(0 to go back)');
     }
+
+    session.userId = result.userId;
+    delete session.pendingLoginPhone;
     session.history.push(session.step);
     session.step = UssdStep.SELECT_BLOOD_TYPE;
     await this.sessionStore.set(session);

--- a/backend/src/ussd-session/ussd.module.ts
+++ b/backend/src/ussd-session/ussd.module.ts
@@ -3,7 +3,9 @@ import { Module } from '@nestjs/common';
 import { OrdersModule } from '../orders/orders.module';
 import { OrdersService } from '../orders/orders.service';
 import { RedisModule } from '../redis/redis.module';
+import { UsersModule } from '../users/users.module';
 
+import { UssdAuthService } from './ussd-auth.service';
 import { UssdSessionStore } from './ussd-session.store';
 import { UssdStateMachine } from './ussd-state-machine.service';
 import { UssdController } from './ussd.controller';
@@ -40,11 +42,13 @@ class OrderServiceAdapter implements IOrderService {
   imports: [
     RedisModule,   // provides REDIS_CLIENT token for UssdSessionStore
     OrdersModule,  // provides OrdersService
+    UsersModule,   // provides UserRepository for USSD PIN authentication
   ],
   controllers: [UssdController],
   providers: [
     UssdStateMachine,
     UssdSessionStore,
+    UssdAuthService,
     {
       provide: IOrderService as unknown as string,
       useFactory: (ordersService: OrdersService) =>

--- a/backend/src/ussd-session/ussd.types.ts
+++ b/backend/src/ussd-session/ussd.types.ts
@@ -27,6 +27,7 @@ export interface UssdSession {
   sessionNonce: string;
   sequenceNumber: number;
   userId?: string;
+  pendingLoginPhone?: string;
   selectedBloodType?: string;
   selectedQuantity?: number;
   selectedBloodBankId?: string;

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -3031,6 +3031,10 @@ impl HealthChainContract {
             return Err(Error::InvalidDisputeStatus);
         }
 
+        if resolution == DisputeStatus::Open {
+            return Err(Error::InvalidDisputeStatus);
+        }
+
         let mut payments: Map<u64, Payment> = env
             .storage()
             .persistent()


### PR DESCRIPTION
…te desync

USSD session silently rebinds to a new phone number on mismatch Fixes #1191

USSD PIN authentication accepts any 4-6 digit input Fixes #1190

Path traversal via unvalidated ownerType in media upload storage path Fixes #1193

lib.rs: resolve_dispute does not validate resolution parameter, allowing dispute/payment state desync Fixes #1111